### PR TITLE
Fix browser key tap timing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,24 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          package-manager-cache: false
       - run: swift build
+      - run: python3 -m unittest Scripts/test_agent_launchers.py -v
+
+  pi-adapter:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pi-version: ["0.84.3", "0.84.4"]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          package-manager-cache: false
+      - run: npm install -g "@earendil-works/pi-coding-agent@${{ matrix.pi-version }}"
+      - run: python3 -m unittest Scripts/test_pi_e2e.py -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,16 @@ on:
 jobs:
   headless-and-mcp:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mcp: ["mcp<2", "mcp>=2"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
-      - run: python -m pip install aiohttp pillow mcp
+      - run: python -m pip install aiohttp pillow "${{ matrix.mcp }}"
       - run: python -m unittest discover -s server -p 'test_*.py' -v
       - run: python -m unittest discover -s mcp-server -p 'test_*.py' -v
       - run: ./server/build.sh
@@ -20,5 +24,5 @@ jobs:
   macos-runner:
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: swift build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  headless-and-mcp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install aiohttp pillow mcp
+      - run: python -m unittest discover -s server -p 'test_*.py' -v
+      - run: python -m unittest discover -s mcp-server -p 'test_*.py' -v
+      - run: ./server/build.sh
+
+  macos-runner:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - run: swift build

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.xcodeproj
 DerivedData/
 __pycache__/
+/server/libqunxia.so
 
 # The original game. Copyrighted by its publisher and not ours to
 # redistribute, so it is kept out of the repository. Supply your own copy;

--- a/README.md
+++ b/README.md
@@ -250,8 +250,9 @@ model has the API, the controls, the isometric axes and the traps.
 `skills/jyxzz-speedrun-tips/SKILL.md` is the original research the field manual
 came from. Edit that first, then fold anything durable into the served files.
 
-`mcp-server/` wraps the same surface over MCP for clients that speak it. It uses
-the official Python SDK's `FastMCP` server:
+`mcp-server/` wraps the same surface over MCP for clients that speak it. It
+supports both the official Python SDK's current `MCPServer` API and its v1
+`FastMCP` name:
 
 ```sh
 QUNXIA_API=http://127.0.0.1:8765 uv run --with mcp mcp-server/server.py

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ ways to give it one, and both use the same game knowledge.
 OpenAI-compatible endpoint and nothing else.
 
 ```sh
-npm i -g @earendil-works/pi-coding-agent
+npm i -g @earendil-works/pi-coding-agent@latest
 
 export QUNXIA_LLM_BASE_URL=http://localhost:11434/v1
 export QUNXIA_LLM_API_KEY=sk-...
@@ -223,18 +223,21 @@ export QUNXIA_LLM_MODEL=qwen3-vl:32b
 ```
 
 It starts the game if it is not running, waits for the title screen, and drops
-into pi. Add `-p "play the opening"` to run non-interactively.
+into pi. Add `-p "play the opening"` to run non-interactively. Set
+`QUNXIA_AUTO_START=0` when the API belongs to an externally managed server.
 
 Everything the agent needs sits in `pi-agent/`, which pi uses as its
 configuration directory, so your own `~/.pi` is untouched. `SYSTEM.md` replaces
 the coding-agent prompt with the game. `extensions/qunxia/` registers eight
 `game_*` tools that apply input, wait for the screen to settle, and return the
-frame as an image. The model also keeps the pi `bash`, `read`, `write` and
-`edit` tools, and pi compacts context automatically on a long session.
+frame as an image. Shell and file tools are disabled by default so an evaluation
+cannot read the repository; set `QUNXIA_ALLOW_CODING_TOOLS=1` only when that is
+intentional. Pi compacts context automatically during a long session.
 
-Use a vision model. `QUNXIA_LLM_INPUT='"text"'` drops images for a text-only
-model, `QUNXIA_SCALE` changes screenshot size, and `QUNXIA_LLM_CONTEXT` sets the
-context window.
+Use a vision model. `QUNXIA_LLM_INPUT=text` drops images for a text-only model;
+`QUNXIA_LLM_API`, `QUNXIA_SCALE`, `QUNXIA_LLM_CONTEXT` and
+`QUNXIA_LLM_MAX_TOKENS` tune the provider. The generated `models.json` refers
+to `$QUNXIA_LLM_API_KEY` and never stores the key itself.
 
 ### Bring your own harness, take the skill
 
@@ -250,14 +253,31 @@ model has the API, the controls, the isometric axes and the traps.
 `skills/jyxzz-speedrun-tips/SKILL.md` is the original research the field manual
 came from. Edit that first, then fold anything durable into the served files.
 
-`mcp-server/` wraps the same surface over MCP for clients that speak it. It
+### Codex
+
+`mcp-server/` wraps the same surface over MCP for Codex and other clients. It
 supports both the official Python SDK's current `MCPServer` API and its v1
 `FastMCP` name:
 
 ```sh
-QUNXIA_API=http://127.0.0.1:8765 uv run --with mcp mcp-server/server.py
+QUNXIA_API=http://127.0.0.1:8765 uv run --with 'mcp>=1,<3' mcp-server/server.py
 # For the headless runner, use QUNXIA_API=http://127.0.0.1:8080/api
 ```
+
+Codex CLI/app users can register that stdio server once, using an absolute path
+and an engine-specific actor name:
+
+```sh
+QUNXIA_API=http://127.0.0.1:8765 ./Scripts/setup-codex.sh
+```
+
+The setup is idempotent and leaves an existing server of the same name alone.
+Set `QUNXIA_CODEX_REPLACE=1` only when you deliberately want to replace that
+entry with this checkout.
+
+Afterward, ask Codex to use the `qunxia` MCP tools and call `guide` before the
+first action. The same MCP action returns text plus the settled PNG, so Codex
+does not need a browser or a separate screenshot request.
 
 ## Session recording
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A long-horizon benchmark for frontier agents, built on an unmodified 1996 wuxia
 CRPG. An agent is given raw 320×200 frames, a key vocabulary, and one page of
-objectives, then left to find twelve books in an open world it has never seen.
+objectives, then left to find fourteen books in an open world it has never seen.
 
 | | |
 |---|---|
@@ -12,7 +12,7 @@ objectives, then left to find twelve books in an open world it has never seen.
 | Observation | raw VGA frames, 320×200, Traditional Chinese text |
 | Action | 16 keys, isometric movement on four diagonal axes |
 | Horizon | open world, no fixed episode length |
-| Objective | recover twelve books and return to the present |
+| Objective | recover fourteen books and return to the present |
 | Interfaces | HTTP, MCP, built-in pi harness, browser |
 | Runners | native macOS (Metal), headless Linux (browser stream) |
 
@@ -40,7 +40,7 @@ failing near the beginning of their games.
 This environment adds four properties those suites do not combine.
 
 **Long-horizon open world.** A CRPG has no level to clear. Progress comes from
-recruiting characters, learning martial arts, and locating twelve books spread
+recruiting characters, learning martial arts, and locating fourteen books spread
 across a large map, so an episode is measured in hours and the reward signal is
 whatever the agent can infer from dialogue.
 
@@ -93,10 +93,11 @@ For the browser runner, see `server/README.md`.
 
 ## Control loop
 
-Acting and looking are separate calls. A key press applies input and waits for
-the screen to settle; a screen call returns the picture. An agent acts several
-times and looks when it needs to see, which costs one settle per action and one
-encode per look.
+A key press applies input and waits for the screen to settle. The native runner
+includes that settled picture by default. The headless runner returns metadata
+by default to avoid encoding images nobody reads; add `?image=1` to capture the
+picture before the action lock is released, or call `/api/screen` separately.
+The MCP and pi tools request the atomic action image.
 
 ```mermaid
 sequenceDiagram
@@ -107,9 +108,7 @@ sequenceDiagram
     S->>E: key down, hold, key up
     E-->>S: frame hashes, 70 fps
     Note over S,E: wait for the picture to change,<br/>then to hold still
-    S-->>A: {"changed": true}
-    A->>S: GET /api/screen
-    S-->>A: PNG of the settled screen
+    S-->>A: {"changed": true, "image": "..."} when requested
 ```
 
 Waiting for the screen to change before waiting for it to settle is what makes
@@ -192,13 +191,17 @@ POST /load   {"slot":1}
 POST /reset
 ```
 
-`image` comes back as a base64 PNG data URI. `?format=png` gives raw bytes,
-`?image=0` skips the capture, and `?react`, `?stable` and `?maxsettle` tune the
-wait. `"changed": false` means the action had no visible effect. `frame` counts
+`image` is a base64 PNG data URI. Native actions include it unless `?image=0`;
+headless actions include it with `?image=1`. `?format=png` gives raw bytes on a
+screen request, and `?react`, `?stable` and `?maxsettle` tune the wait.
+`"changed": false` means the framebuffer never visibly changed; it is not a
+game-success signal. `frame` counts
 distinct video frames and stalls on a static screen, while `ticks` always rises
 while the emulator runs. Boot takes about 14 seconds.
 
-The browser runner exposes the same surface under `/api/`.
+The browser runner exposes the same key, screen, save/load and history surface
+under `/api/`. Its benchmark reset remains token-protected so a visitor cannot
+wipe a shared run.
 
 ## Letting an LLM play
 
@@ -224,7 +227,7 @@ into pi. Add `-p "play the opening"` to run non-interactively.
 
 Everything the agent needs sits in `pi-agent/`, which pi uses as its
 configuration directory, so your own `~/.pi` is untouched. `SYSTEM.md` replaces
-the coding-agent prompt with the game. `extensions/qunxia/` registers nine
+the coding-agent prompt with the game. `extensions/qunxia/` registers eight
 `game_*` tools that apply input, wait for the screen to settle, and return the
 frame as an image. The model also keeps the pi `bash`, `read`, `write` and
 `edit` tools, and pi compacts context automatically on a long session.
@@ -247,7 +250,13 @@ model has the API, the controls, the isometric axes and the traps.
 `skills/jyxzz-speedrun-tips/SKILL.md` is the original research the field manual
 came from. Edit that first, then fold anything durable into the served files.
 
-`mcp-server/` wraps the same surface over MCP for clients that speak it.
+`mcp-server/` wraps the same surface over MCP for clients that speak it. It uses
+the official Python SDK's `FastMCP` server:
+
+```sh
+QUNXIA_API=http://127.0.0.1:8765 uv run --with mcp mcp-server/server.py
+# For the headless runner, use QUNXIA_API=http://127.0.0.1:8080/api
+```
 
 ## Session recording
 

--- a/Scripts/play-agent.sh
+++ b/Scripts/play-agent.sh
@@ -7,7 +7,7 @@
 #   export QUNXIA_LLM_MODEL=gpt-5
 #   ./Scripts/play-agent.sh
 #
-# Anything after -- is passed to pi, e.g. `./Scripts/play-agent.sh -p "play"`.
+# All arguments are passed to pi, e.g. `./Scripts/play-agent.sh -p "play"`.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 ROOT="$PWD"
@@ -15,49 +15,64 @@ ROOT="$PWD"
 : "${QUNXIA_LLM_BASE_URL:?set QUNXIA_LLM_BASE_URL, e.g. http://localhost:11434/v1}"
 : "${QUNXIA_LLM_MODEL:?set QUNXIA_LLM_MODEL, e.g. gpt-5 or qwen3:32b}"
 API="${QUNXIA_API:-http://127.0.0.1:8765}"
+API="${API%/}"
 KEY="${QUNXIA_LLM_API_KEY:-local}"
-# Vision is how the agent sees the game. Set to text if your model has none.
-INPUT="${QUNXIA_LLM_INPUT:-\"text\", \"image\"}"
-CTX="${QUNXIA_LLM_CONTEXT:-128000}"
+PI_DIR="${QUNXIA_PI_DIR:-$ROOT/pi-agent}"
+AGENT="${QUNXIA_AGENT:-pi}"
 
-command -v pi >/dev/null || { echo "pi not found. Install: npm i -g @earendil-works/pi-coding-agent"; exit 1; }
-
-cat > pi-agent/models.json <<JSON
-{
-  "providers": {
-    "qunxia": {
-      "baseUrl": "${QUNXIA_LLM_BASE_URL}",
-      "api": "openai-completions",
-      "apiKey": "${KEY}",
-      "compat": { "supportsDeveloperRole": false, "supportsReasoningEffort": false },
-      "models": [
-        {
-          "id": "${QUNXIA_LLM_MODEL}",
-          "name": "${QUNXIA_LLM_MODEL}",
-          "input": [${INPUT}],
-          "contextWindow": ${CTX},
-          "maxTokens": 8192,
-          "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
-        }
-      ]
-    }
-  }
+command -v curl >/dev/null || { echo "curl not found" >&2; exit 1; }
+PI_BIN="$(command -v pi || true)"
+[[ -n "$PI_BIN" ]] || { echo "pi not found. Install: npm i -g @earendil-works/pi-coding-agent"; exit 1; }
+NODE_BIN="${QUNXIA_NODE:-$(command -v node || true)}"
+node_is_compatible() {
+  [[ -n "$1" ]] && "$1" -e \
+    'const [a,b]=process.versions.node.split(".").map(Number);process.exit(a>22||(a===22&&b>=19)?0:1)' \
+    >/dev/null 2>&1
 }
-JSON
+if ! node_is_compatible "$NODE_BIN" && node_is_compatible /opt/homebrew/bin/node; then
+  NODE_BIN=/opt/homebrew/bin/node
+fi
+node_is_compatible "$NODE_BIN" || {
+  echo "pi requires Node.js >=22.19 (set QUNXIA_NODE to a compatible node binary)" >&2
+  exit 1
+}
+[[ -f "$PI_DIR/SYSTEM.md" && -f "$PI_DIR/extensions/qunxia/index.ts" ]] || {
+  echo "Pi game config is incomplete at $PI_DIR" >&2
+  exit 1
+}
+
+# Generate valid JSON even when model ids or URLs contain punctuation. The file
+# contains an environment reference, never the API key itself.
+export QUNXIA_LLM_API_KEY="$KEY"
+"$NODE_BIN" "$ROOT/Scripts/write-pi-model.mjs" "$PI_DIR/models.json"
 
 # Bring the game up if it is not already answering.
-if ! curl -sf -m 2 "$API/state?image=0" >/dev/null 2>&1; then
+if ! curl -sf -m 2 -H "X-Agent: $AGENT" "$API/help" >/dev/null 2>&1; then
+  if [[ "${QUNXIA_AUTO_START:-1}" == "0" ]]; then
+    echo "the game is not reachable at $API (automatic start disabled)" >&2
+    exit 1
+  fi
   echo "starting the game..."
-  ./Scripts/run.sh >/tmp/qunxia-agent.log 2>&1 &
+  GAME_LOG="${QUNXIA_GAME_LOG:-${TMPDIR:-/tmp}/qunxia-agent-$$.log}"
+  ./Scripts/run.sh >"$GAME_LOG" 2>&1 &
   for i in {1..90}; do
-    curl -sf -m 2 "$API/state?image=0" >/dev/null 2>&1 && break
+    curl -sf -m 2 -H "X-Agent: $AGENT" "$API/help" >/dev/null 2>&1 && break
     sleep 1
   done
-  curl -sf -m 2 "$API/state?image=0" >/dev/null 2>&1 || {
-    echo "the game did not come up; see /tmp/qunxia-agent.log"; exit 1; }
+  curl -sf -m 2 -H "X-Agent: $AGENT" "$API/help" >/dev/null 2>&1 || {
+    echo "the game did not come up; see $GAME_LOG"; exit 1; }
   echo "waiting for the title screen..."
-  curl -sf -m 60 -X POST "$API/wait?image=0" -d '{"ms":14000}' >/dev/null || true
+  curl -sf -m 60 -X POST "$API/wait?image=0" \
+    -H 'content-type: application/json' -H "X-Agent: $AGENT" \
+    -d '{"ms":14000}' >/dev/null || true
 fi
 
-exec env PI_CODING_AGENT_DIR="$ROOT/pi-agent" QUNXIA_API="$API" \
-  pi --provider qunxia --model "$QUNXIA_LLM_MODEL" "$@"
+PI_ARGS=(--provider qunxia --model "$QUNXIA_LLM_MODEL")
+# Benchmark-safe default: expose game tools, not shell/file tools that can read
+# the repository. Set QUNXIA_ALLOW_CODING_TOOLS=1 for an unrestricted session.
+if [[ "${QUNXIA_ALLOW_CODING_TOOLS:-0}" != "1" ]]; then
+  PI_ARGS+=(--no-builtin-tools)
+fi
+
+exec env PI_CODING_AGENT_DIR="$PI_DIR" QUNXIA_API="$API" QUNXIA_AGENT="$AGENT" \
+  QUNXIA_LLM_API_KEY="$KEY" "$NODE_BIN" "$PI_BIN" "${PI_ARGS[@]}" "$@"

--- a/Scripts/play.py
+++ b/Scripts/play.py
@@ -10,18 +10,32 @@
 
 Every command writes the resulting screen to /tmp/qunxia.png unless a path is given.
 """
-import base64, json, os, subprocess, sys, urllib.request
+import base64
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
 
-API = os.environ.get("QUNXIA_API", "http://127.0.0.1:8765")
+API = os.environ.get("QUNXIA_API", "http://127.0.0.1:8765").rstrip("/")
+AGENT = os.environ.get("QUNXIA_AGENT", "play-cli")
 OUT = "/tmp/qunxia.png"
 
 
 def call(method, path, payload=None):
     data = json.dumps(payload).encode() if payload is not None else None
     req = urllib.request.Request(API + path, data=data, method=method,
-                                 headers={"Content-Type": "application/json"})
-    with urllib.request.urlopen(req, timeout=120) as r:
-        return json.loads(r.read())
+                                 headers={"Content-Type": "application/json",
+                                          "X-Agent": AGENT})
+    try:
+        with urllib.request.urlopen(req, timeout=120) as r:
+            return json.loads(r.read())
+    except urllib.error.HTTPError as exc:
+        try:
+            return json.loads(exc.read())
+        except Exception:
+            raise RuntimeError(f"game API returned HTTP {exc.code}") from exc
 
 
 def save_shot(res, path=OUT):
@@ -44,15 +58,19 @@ def main(argv):
             print(r.read().decode())
             return 0
     elif cmd == "key":
-        res = call("POST", "/key", {"key": args[0]})
+        if not args:
+            raise ValueError("key requires a key name")
+        res = call("POST", "/key?image=1", {"key": args[0]})
     elif cmd == "keys":
-        res = call("POST", "/keys", {"keys": args})
+        if not args:
+            raise ValueError("keys requires at least one key name")
+        res = call("POST", "/keys?image=1", {"keys": args})
     elif cmd == "wait":
-        res = call("POST", "/wait", {"ms": int(args[0]) if args else 1000})
+        res = call("POST", "/wait?image=1", {"ms": int(args[0]) if args else 1000})
     elif cmd in ("save", "load"):
         key = "name" if args and not args[0].isdigit() else "slot"
         val = args[0] if args else 1
-        res = call("POST", "/" + cmd, {key: int(val) if key == "slot" else val})
+        res = call("POST", f"/{cmd}?image=1", {key: int(val) if key == "slot" else val})
     elif cmd == "reset":
         res = call("POST", "/reset")
     elif cmd == "shot":
@@ -61,12 +79,27 @@ def main(argv):
         print(__doc__.strip())
         return 1
 
+    if (cmd in ("key", "keys", "wait", "save", "load", "reset")
+            and res.get("ok", True) and not res.get("image")):
+        observed = call("GET", "/screen")
+        if observed.get("image"):
+            for field in ("image", "image_width", "image_height", "width",
+                          "height", "frame"):
+                if field in observed:
+                    res[field] = observed[field]
+            res["observation"] = "follow-up (not atomic on a shared session)"
+
     path = args[0] if cmd == "shot" and args else OUT
-    print(json.dumps(save_shot(res, path), ensure_ascii=False))
+    result = save_shot(res, path)
+    print(json.dumps(result, ensure_ascii=False))
     if sys.stdout.isatty() and os.path.exists(path):
         subprocess.run(["open", path], check=False)
-    return 0
+    return 0 if result.get("ok", True) else 1
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    try:
+        sys.exit(main(sys.argv[1:]))
+    except (IndexError, ValueError, RuntimeError, urllib.error.URLError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(2)

--- a/Scripts/setup-codex.sh
+++ b/Scripts/setup-codex.sh
@@ -1,0 +1,34 @@
+#!/bin/zsh
+# Register the game MCP server with Codex CLI/app. This is intentionally a
+# separate setup step: it changes the user's Codex configuration, while merely
+# cloning or running the game should not.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+ROOT="$PWD"
+
+command -v codex >/dev/null || { echo "codex not found" >&2; exit 1; }
+command -v uv >/dev/null || { echo "uv not found (install from https://docs.astral.sh/uv/)" >&2; exit 1; }
+
+NAME="${QUNXIA_CODEX_MCP_NAME:-qunxia}"
+API="${QUNXIA_API:-http://127.0.0.1:8765}"
+API="${API%/}"
+AGENT="${QUNXIA_AGENT:-codex}"
+
+if codex mcp get "$NAME" --json >/dev/null 2>&1; then
+  if [[ "${QUNXIA_CODEX_REPLACE:-0}" == "1" ]]; then
+    codex mcp remove "$NAME"
+  else
+    echo "Codex MCP server '$NAME' already exists; leaving it unchanged."
+    echo "Set QUNXIA_CODEX_REPLACE=1 to replace it with this checkout."
+    codex mcp get "$NAME"
+    exit 0
+  fi
+fi
+
+codex mcp add "$NAME" \
+  --env "QUNXIA_API=$API" \
+  --env "QUNXIA_AGENT=$AGENT" \
+  -- uv run --with 'mcp>=1,<3' "$ROOT/mcp-server/server.py"
+
+echo "Registered the '$NAME' game tools for Codex:"
+codex mcp get "$NAME"

--- a/Scripts/test_agent_launchers.py
+++ b/Scripts/test_agent_launchers.py
@@ -1,0 +1,148 @@
+import http.server
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+import threading
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+class HealthHandler(http.server.BaseHTTPRequestHandler):
+    requests = []
+
+    def do_GET(self):
+        type(self).requests.append((self.path, self.headers.get("X-Agent")))
+        if self.path == "/help":
+            body = b"QunXia test API"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_error(404)
+
+    def log_message(self, _format, *_args):
+        pass
+
+
+def executable(path, source):
+    path.write_text(source, encoding="utf-8")
+    path.chmod(0o755)
+
+
+class PiLauncherTest(unittest.TestCase):
+    def setUp(self):
+        HealthHandler.requests = []
+        self.server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), HealthHandler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+
+    def test_existing_game_is_detected_and_key_is_not_persisted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            bin_dir = tmp_path / "bin"
+            bin_dir.mkdir()
+            executable(
+                bin_dir / "pi",
+                """#!/usr/bin/env node
+console.log(JSON.stringify({args: process.argv.slice(2), api: process.env.QUNXIA_API,
+                            agent: process.env.QUNXIA_AGENT}));
+""",
+            )
+            config_dir = tmp_path / "pi-config"
+            config_dir.mkdir()
+            (config_dir / "SYSTEM.md").write_text("game", encoding="utf-8")
+            extension_dir = config_dir / "extensions" / "qunxia"
+            extension_dir.mkdir(parents=True)
+            (extension_dir / "index.ts").write_text("export default () => {};\n",
+                                                     encoding="utf-8")
+            env = os.environ.copy()
+            env.update({
+                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                "QUNXIA_API": f"http://127.0.0.1:{self.server.server_port}/",
+                "QUNXIA_AUTO_START": "0",
+                "QUNXIA_PI_DIR": str(config_dir),
+                "QUNXIA_LLM_BASE_URL": "http://127.0.0.1:9999/v1/",
+                "QUNXIA_LLM_API_KEY": "secret-must-not-be-written",
+                "QUNXIA_LLM_MODEL": 'model"with-quote',
+            })
+            run = subprocess.run(
+                ["zsh", str(ROOT / "Scripts/play-agent.sh"), "--no-session"],
+                cwd=ROOT, env=env, text=True, capture_output=True, timeout=15,
+            )
+            self.assertEqual(run.returncode, 0, run.stderr)
+            launched = json.loads(run.stdout.strip().splitlines()[-1])
+            self.assertEqual(launched["api"], f"http://127.0.0.1:{self.server.server_port}")
+            self.assertEqual(launched["agent"], "pi")
+            self.assertIn("--no-builtin-tools", launched["args"])
+            self.assertIn("--no-session", launched["args"])
+
+            config_text = (config_dir / "models.json").read_text(encoding="utf-8")
+            config = json.loads(config_text)
+            provider = config["providers"]["qunxia"]
+            self.assertEqual(provider["apiKey"], "$QUNXIA_LLM_API_KEY")
+            self.assertNotIn("secret-must-not-be-written", config_text)
+            self.assertEqual(provider["models"][0]["id"], 'model"with-quote')
+            self.assertEqual(HealthHandler.requests, [("/help", "pi")])
+
+
+class CodexLauncherTest(unittest.TestCase):
+    def test_registration_is_absolute_and_idempotent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            bin_dir = tmp_path / "bin"
+            bin_dir.mkdir()
+            marker = tmp_path / "registered"
+            calls = tmp_path / "calls.jsonl"
+            executable(
+                bin_dir / "codex",
+                f"""#!/usr/bin/env python3
+import json, pathlib, sys
+marker = pathlib.Path({str(marker)!r})
+calls = pathlib.Path({str(calls)!r})
+with calls.open("a", encoding="utf-8") as f:
+    f.write(json.dumps(sys.argv[1:]) + "\\n")
+if sys.argv[1:3] == ["mcp", "get"] and not marker.exists():
+    raise SystemExit(1)
+if sys.argv[1:3] == ["mcp", "add"]:
+    marker.write_text("yes", encoding="utf-8")
+print("ok")
+""",
+            )
+            executable(bin_dir / "uv", "#!/bin/sh\nexit 0\n")
+            env = os.environ.copy()
+            env.update({
+                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                "QUNXIA_API": "http://127.0.0.1:9999/api/",
+                "QUNXIA_CODEX_MCP_NAME": "qunxia-test",
+            })
+            command = ["zsh", str(ROOT / "Scripts/setup-codex.sh")]
+            first = subprocess.run(command, cwd=ROOT, env=env, text=True,
+                                   capture_output=True, timeout=15)
+            self.assertEqual(first.returncode, 0, first.stderr)
+            second = subprocess.run(command, cwd=ROOT, env=env, text=True,
+                                    capture_output=True, timeout=15)
+            self.assertEqual(second.returncode, 0, second.stderr)
+
+            recorded = [json.loads(line) for line in calls.read_text().splitlines()]
+            adds = [args for args in recorded if args[:2] == ["mcp", "add"]]
+            self.assertEqual(len(adds), 1)
+            add = adds[0]
+            self.assertIn("QUNXIA_API=http://127.0.0.1:9999/api", add)
+            self.assertIn("QUNXIA_AGENT=codex", add)
+            self.assertIn("mcp>=1,<3", add)
+            self.assertIn(str((ROOT / "mcp-server/server.py").resolve()), add)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/test_pi_e2e.py
+++ b/Scripts/test_pi_e2e.py
@@ -1,0 +1,218 @@
+import base64
+import http.server
+import json
+import os
+import pathlib
+import selectors
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+IMAGE = base64.b64encode(b"synthetic-game-frame").decode()
+
+
+def sse_chunk(model, *, tool=None, tool_args=None, text=None, finish="stop"):
+    if tool:
+        delta = {
+            "role": "assistant",
+            "tool_calls": [{
+                "index": 0, "id": f"call-{tool}", "type": "function",
+                "function": {"name": tool,
+                             "arguments": json.dumps(tool_args or {})},
+            }],
+        }
+        finish = "tool_calls"
+    else:
+        delta = {"role": "assistant", "content": text}
+    chunks = [
+        {
+            "id": f"response-{model}", "object": "chat.completion.chunk",
+            "created": 0, "model": "fake", "choices": [{
+                "index": 0, "delta": delta, "finish_reason": None,
+            }],
+        },
+        {
+            "id": f"response-{model}", "object": "chat.completion.chunk",
+            "created": 0, "model": "fake", "choices": [{
+                "index": 0, "delta": {}, "finish_reason": finish,
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 3,
+                      "total_tokens": 13},
+        },
+    ]
+    return ("".join(f"data: {json.dumps(chunk)}\n\n" for chunk in chunks)
+            + "data: [DONE]\n\n").encode()
+
+
+class QuietHandler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, _format, *_args):
+        pass
+
+
+class GameHandler(QuietHandler):
+    requests = []
+
+    def do_GET(self):
+        type(self).requests.append((self.path, self.headers.get("X-Agent")))
+        if self.path == "/screen":
+            payload = json.dumps({
+                "ok": True, "width": 320, "height": 200, "frame": 7,
+                "image": f"data:image/png;base64,{IMAGE}",
+            }).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+        else:
+            payload = b"synthetic backend failure"
+            self.send_response(500)
+            self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length))
+        type(self).requests.append((self.path, self.headers.get("X-Agent"), body))
+        payload = json.dumps({
+            "ok": True, "changed": True, "width": 320, "height": 200,
+            "frame": 6,
+        }).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+class ModelHandler(QuietHandler):
+    requests = []
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        request = json.loads(self.rfile.read(length))
+        type(self).requests.append(request)
+        turn = len(type(self).requests)
+        if turn == 1:
+            payload = sse_chunk("press", tool="game_press", tool_args={"key": "enter"})
+        elif turn == 2:
+            payload = sse_chunk("saves", tool="game_saves")
+        else:
+            payload = sse_chunk("done", text="adapter ok")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+class PiAdapterEndToEndTest(unittest.TestCase):
+    def test_pi_executes_game_tool_images_and_survives_http_errors(self):
+        GameHandler.requests = []
+        ModelHandler.requests = []
+        game = http.server.ThreadingHTTPServer(("127.0.0.1", 0), GameHandler)
+        model = http.server.ThreadingHTTPServer(("127.0.0.1", 0), ModelHandler)
+        threads = []
+        for server in (game, model):
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            threads.append(thread)
+
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                config_dir = pathlib.Path(tmp)
+                shutil.copy(ROOT / "pi-agent/SYSTEM.md", config_dir / "SYSTEM.md")
+                shutil.copytree(ROOT / "pi-agent/extensions", config_dir / "extensions")
+                env = os.environ.copy()
+                env.update({
+                    "PI_CODING_AGENT_DIR": str(config_dir),
+                    "PI_OFFLINE": "1",
+                    "QUNXIA_API": f"http://127.0.0.1:{game.server_port}/",
+                    "QUNXIA_AGENT": "pi e2e!",
+                    "QUNXIA_SCALE": "not-a-number",
+                    "QUNXIA_LLM_BASE_URL": f"http://127.0.0.1:{model.server_port}/v1/",
+                    "QUNXIA_LLM_MODEL": "fake",
+                    "QUNXIA_LLM_API_KEY": "dummy",
+                })
+                subprocess.run(
+                    ["node", str(ROOT / "Scripts/write-pi-model.mjs"),
+                     str(config_dir / "models.json")],
+                    cwd=ROOT, env=env, check=True, timeout=10,
+                )
+                process = subprocess.Popen(
+                    ["pi", "--mode", "rpc", "--no-session", "--provider", "qunxia",
+                     "--model", "fake", "--no-builtin-tools", "--tools",
+                     "game_press,game_saves", "--no-skills", "--no-context-files"],
+                    cwd=ROOT, env=env, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE, text=True, bufsize=1,
+                )
+                process.stdin.write(json.dumps({
+                    "id": "prompt-1", "type": "prompt", "message": "test adapters",
+                }) + "\n")
+                process.stdin.flush()
+
+                events = []
+                selector = selectors.DefaultSelector()
+                selector.register(process.stdout, selectors.EVENT_READ)
+                deadline = time.time() + 30
+                while time.time() < deadline:
+                    if not selector.select(timeout=0.5):
+                        if process.poll() is not None:
+                            break
+                        continue
+                    line = process.stdout.readline()
+                    if not line:
+                        break
+                    event = json.loads(line)
+                    events.append(event)
+                    if event.get("type") == "agent_end":
+                        break
+                else:
+                    self.fail("Pi adapter test timed out")
+
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                stderr = process.stderr.read()
+                process.stdin.close()
+                process.stdout.close()
+                process.stderr.close()
+                self.assertEqual(stderr, "")
+
+            self.assertEqual(len(ModelHandler.requests), 3)
+            tool_names = {
+                tool["function"]["name"]
+                for tool in ModelHandler.requests[0].get("tools", [])
+            }
+            self.assertEqual(tool_names, {"game_press", "game_saves"})
+            serialized = json.dumps(ModelHandler.requests[1])
+            self.assertIn(f"data:image/png;base64,{IMAGE}", serialized)
+            self.assertTrue(GameHandler.requests[0][0].startswith("/key?"))
+            self.assertEqual(GameHandler.requests[0][1], "pie2e")
+            self.assertEqual(GameHandler.requests[1], ("/screen", "pie2e"))
+
+            tool_ends = [event for event in events
+                         if event.get("type") == "tool_execution_end"]
+            self.assertEqual(len(tool_ends), 2)
+            self.assertFalse(tool_ends[0]["isError"])
+            self.assertIn("not atomic", json.dumps(tool_ends[0]))
+            self.assertTrue(tool_ends[1]["isError"], tool_ends[1])
+            self.assertIn("non-JSON", json.dumps(tool_ends[1]))
+            self.assertTrue(any(event.get("type") == "agent_end" for event in events))
+            self.assertFalse(any(event.get("type") == "extension_error" for event in events))
+        finally:
+            for server in (game, model):
+                server.shutdown()
+                server.server_close()
+            for thread in threads:
+                thread.join(timeout=2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/write-pi-model.mjs
+++ b/Scripts/write-pi-model.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const output = process.argv[2];
+if (!output) throw new Error("usage: write-pi-model.mjs OUTPUT");
+
+function required(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function integer(name, fallback, minimum, maximum) {
+  const raw = process.env[name] ?? String(fallback);
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw new Error(`${name} must be an integer from ${minimum} to ${maximum}`);
+  }
+  return value;
+}
+
+function bool(name, fallback = false) {
+  const raw = (process.env[name] ?? String(fallback)).toLowerCase();
+  if (["1", "true", "yes"].includes(raw)) return true;
+  if (["0", "false", "no"].includes(raw)) return false;
+  throw new Error(`${name} must be true or false`);
+}
+
+const baseUrl = required("QUNXIA_LLM_BASE_URL").replace(/\/+$/, "");
+const parsedUrl = new URL(baseUrl);
+if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+  throw new Error("QUNXIA_LLM_BASE_URL must use http or https");
+}
+
+const model = required("QUNXIA_LLM_MODEL");
+const api = process.env.QUNXIA_LLM_API ?? "openai-completions";
+const supportedApis = new Set([
+  "openai-completions", "openai-responses", "anthropic-messages",
+  "google-generative-ai",
+]);
+if (!supportedApis.has(api)) throw new Error(`unsupported QUNXIA_LLM_API: ${api}`);
+
+// Accept text,image as well as the historical '"text", "image"' spelling.
+const input = [...new Set((process.env.QUNXIA_LLM_INPUT ?? "text,image")
+  .replace(/[\[\]"'\s]/g, "").split(",").filter(Boolean))];
+if (!input.includes("text") || input.some((kind) => !["text", "image"].includes(kind))) {
+  throw new Error("QUNXIA_LLM_INPUT must be text or text,image");
+}
+const contextWindow = integer("QUNXIA_LLM_CONTEXT", 128000, 1024, 10_000_000);
+const maxTokens = integer("QUNXIA_LLM_MAX_TOKENS", 8192, 256, 1_000_000);
+if (maxTokens > contextWindow) {
+  throw new Error("QUNXIA_LLM_MAX_TOKENS cannot exceed QUNXIA_LLM_CONTEXT");
+}
+
+const config = {
+  providers: {
+    qunxia: {
+      baseUrl,
+      api,
+      apiKey: "$QUNXIA_LLM_API_KEY",
+      compat: {
+        supportsDeveloperRole: bool("QUNXIA_LLM_DEVELOPER_ROLE"),
+        supportsReasoningEffort: bool("QUNXIA_LLM_REASONING_EFFORT"),
+      },
+      models: [{
+        id: model,
+        name: model,
+        reasoning: bool("QUNXIA_LLM_REASONING"),
+        input,
+        contextWindow,
+        maxTokens,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      }],
+    },
+  },
+};
+
+fs.mkdirSync(path.dirname(output), { recursive: true });
+const temporary = `${output}.tmp-${process.pid}`;
+fs.writeFileSync(temporary, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+fs.renameSync(temporary, output);

--- a/Sources/CoreHost/CoreHost.c
+++ b/Sources/CoreHost/CoreHost.c
@@ -2,6 +2,7 @@
 
 #include <dlfcn.h>
 #include <pthread.h>
+#include <stdatomic.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -36,10 +37,14 @@ static fn_set_controller g_set_controller;
 static pthread_mutex_t g_mu = PTHREAD_MUTEX_INITIALIZER;
 static uint8_t *g_fb;
 static size_t g_fb_cap;
-static int g_w, g_h, g_pitch;
-static uint64_t g_serial;
-static uint64_t g_ticks;
-static uint64_t g_hash;
+static _Atomic int g_w, g_h, g_pitch;
+static _Atomic uint64_t g_serial;
+static _Atomic uint64_t g_ticks;
+static _Atomic uint64_t g_hash;
+/* libretro cores are single-threaded. The headless runner receives input on
+   asyncio's thread while retro_run lives on the emulation thread, so calls
+   into the core must never overlap. */
+static pthread_mutex_t g_core_mu = PTHREAD_MUTEX_INITIALIZER;
 
 /* ---- audio ring ---- */
 #define AUDIO_RING_FRAMES 32768
@@ -407,48 +412,69 @@ void core_shutdown(void) {
 }
 
 void core_run_frame(void) {
+    pthread_mutex_lock(&g_core_mu);
     if (g_run) g_run();
     g_ticks++;
+    pthread_mutex_unlock(&g_core_mu);
 }
 
-void core_reset(void) {
-    core_release_all_keys();
-    core_audio_reset();
-    if (g_reset) g_reset();
-}
-
-void core_key(int retrok, bool down) {
+static void key_unlocked(int retrok, bool down) {
     if (retrok < 0 || retrok >= (int)RETROK_LAST) return;
     if (g_keys[retrok] == (down ? 1 : 0)) return;
     g_keys[retrok] = down ? 1 : 0;
     if (g_kbd_cb) g_kbd_cb(down, (unsigned)retrok, 0, 0);
 }
 
-void core_release_all_keys(void) {
+static void release_all_keys_unlocked(void) {
     for (int i = 0; i < (int)RETROK_LAST; i++) {
-        if (g_keys[i]) {
-            g_keys[i] = 0;
-            if (g_kbd_cb) g_kbd_cb(false, (unsigned)i, 0, 0);
-        }
+        if (g_keys[i]) key_unlocked(i, false);
     }
 }
 
+void core_reset(void) {
+    pthread_mutex_lock(&g_core_mu);
+    release_all_keys_unlocked();
+    core_audio_reset();
+    if (g_reset) g_reset();
+    pthread_mutex_unlock(&g_core_mu);
+}
+
+void core_key(int retrok, bool down) {
+    pthread_mutex_lock(&g_core_mu);
+    key_unlocked(retrok, down);
+    pthread_mutex_unlock(&g_core_mu);
+}
+
+void core_release_all_keys(void) {
+    pthread_mutex_lock(&g_core_mu);
+    release_all_keys_unlocked();
+    pthread_mutex_unlock(&g_core_mu);
+}
+
 void core_mouse_move(int dx, int dy) {
+    pthread_mutex_lock(&g_core_mu);
     g_mouse_dx += dx;
     g_mouse_dy += dy;
+    pthread_mutex_unlock(&g_core_mu);
 }
 
 void core_mouse_button(int button, bool down) {
+    pthread_mutex_lock(&g_core_mu);
     if (button >= 0 && button < 3) g_mouse_btn[button] = down ? 1 : 0;
+    pthread_mutex_unlock(&g_core_mu);
 }
 
 bool core_save_state(const char *path) {
     if (!g_ser_size || !g_ser) return false;
+    pthread_mutex_lock(&g_core_mu);
     size_t n = g_ser_size();
+    pthread_mutex_unlock(&g_core_mu);
     if (n == 0) { set_err("core reports zero savestate size"); return false; }
     void *buf = malloc(n);
     if (!buf) return false;
+    pthread_mutex_lock(&g_core_mu);
     bool ok = g_ser(buf, n);
+    pthread_mutex_unlock(&g_core_mu);
     if (ok) {
         FILE *f = fopen(path, "wb");
         if (!f) { free(buf); set_err("cannot open savestate for write"); return false; }
@@ -474,8 +500,10 @@ bool core_load_state(const char *path) {
     size_t got = fread(buf, 1, (size_t)n, f);
     fclose(f);
     if (got != (size_t)n) { free(buf); return false; }
-    core_release_all_keys();
+    pthread_mutex_lock(&g_core_mu);
+    release_all_keys_unlocked();
     bool ok = g_unser(buf, (size_t)n);
+    pthread_mutex_unlock(&g_core_mu);
     free(buf);
     if (ok) core_audio_reset();
     else set_err("retro_unserialize failed");

--- a/Sources/QunXia/ControlAPI.swift
+++ b/Sources/QunXia/ControlAPI.swift
@@ -10,6 +10,10 @@ final class ControlAPI {
     // keyup to be consumed in the same game-loop iteration. Ten remains well
     // below the held-key repeat delay while reliably producing one tap.
     private static let defaultTapFrames = 10
+    private static let maxHoldFrames = 1200
+    private static let maxGapFrames = 600
+    private static let maxKeysPerAction = 100
+    private static let maxActionFrames = 2800
 
     private let listener: NWListener
     private let log: ActionLog
@@ -122,8 +126,11 @@ final class ControlAPI {
             return query[key]
         }
         func int(_ key: String) -> Int? {
+            if json[key] is Bool { return nil }
             if let i = json[key] as? Int { return i }
-            if let d = json[key] as? Double { return Int(d) }
+            if let d = json[key] as? Double,
+               d.isFinite, d.rounded(.towardZero) == d,
+               d >= Double(Int.min), d <= Double(Int.max) { return Int(d) }
             if let s = query[key] { return Int(s) }
             return nil
         }
@@ -164,7 +171,10 @@ final class ControlAPI {
 
         case ("GET", "/history"):
             log.add("GET", "/history")
-            let arr = log.items.suffix(r.int("limit") ?? 100).map { rec -> [String: Any] in
+            guard let limit = bounded(r, "limit", default: 100, min: 0, max: 500) else {
+                return respond(400, "application/json", json(["ok": false, "error": "limit must be an integer from 0 to 500"]))
+            }
+            let arr = log.items.suffix(limit).map { rec -> [String: Any] in
                 ["time": Self.iso.string(from: rec.time), "verb": rec.verb,
                  "target": rec.target, "payload": rec.payload, "ok": rec.ok]
             }
@@ -188,19 +198,45 @@ final class ControlAPI {
                 log.add("KEY", r.string("key") ?? "?", ok: false)
                 return respond(400, "application/json", json(["ok": false, "error": "unknown key", "hint": "GET /keys"]))
             }
-            let hold = max(1, r.int("hold") ?? Self.defaultTapFrames)
+            guard let hold = bounded(r, "hold", default: Self.defaultTapFrames,
+                                     min: 1, max: Self.maxHoldFrames),
+                  let times = bounded(r, "times", default: 1,
+                                      min: 1, max: Self.maxKeysPerAction),
+                  let gap = bounded(r, "gap", default: 6,
+                                    min: 0, max: Self.maxGapFrames) else {
+                return respond(400, "application/json", json(["ok": false, "error": "invalid hold, times, or gap"]))
+            }
+            let total = times * (hold + 2) + max(0, times - 1) * gap
+            guard total <= Self.maxActionFrames else {
+                return respond(400, "application/json", json(["ok": false, "error": "action exceeds \(Self.maxActionFrames) frames"]))
+            }
             // Logged before the keys go in, so the pane shows an action
             // starting rather than reporting one already over.
-            log.add("KEY", name)
-            let res = emu.submitSync([.press(combo, frames: hold)], settle: settle(r), scale: scale, wantShot: r.wantsImage)
-            return reply(r, ok: res.ok, extra: ["key": name], shot: res.shot, changed: res.changed)
+            log.add("KEY", times > 1 ? "\(name) x\(times)" : name)
+            var steps: [Emulator.Step] = []
+            for i in 0..<times {
+                steps.append(.press(combo, frames: hold))
+                if i != times - 1, gap > 0 { steps.append(.wait(gap)) }
+            }
+            let res = emu.submitSync(steps, settle: settle(r), scale: scale,
+                                     wantShot: r.wantsImage, timeout: 60)
+            return reply(r, ok: res.ok, extra: ["key": name, "times": times], shot: res.shot, changed: res.changed)
 
         case ("POST", "/keys"):
-            guard let names = r.strings("keys"), !names.isEmpty else {
-                return respond(400, "application/json", json(["ok": false, "error": "keys required"]))
+            guard let names = r.strings("keys"),
+                  1...Self.maxKeysPerAction ~= names.count else {
+                return respond(400, "application/json", json(["ok": false, "error": "keys must contain 1 to \(Self.maxKeysPerAction) entries"]))
             }
-            let hold = max(1, r.int("hold") ?? Self.defaultTapFrames)
-            let gap = max(0, r.int("gap") ?? 6)
+            guard let hold = bounded(r, "hold", default: Self.defaultTapFrames,
+                                     min: 1, max: Self.maxHoldFrames),
+                  let gap = bounded(r, "gap", default: 6,
+                                    min: 0, max: Self.maxGapFrames) else {
+                return respond(400, "application/json", json(["ok": false, "error": "invalid hold or gap"]))
+            }
+            let total = names.count * (hold + 2) + max(0, names.count - 1) * gap
+            guard total <= Self.maxActionFrames else {
+                return respond(400, "application/json", json(["ok": false, "error": "action exceeds \(Self.maxActionFrames) frames"]))
+            }
             var steps: [Emulator.Step] = []
             var bad: [String] = []
             for (i, n) in names.enumerated() {
@@ -217,9 +253,20 @@ final class ControlAPI {
             return reply(r, ok: res.ok, extra: ["keys": names], shot: res.shot, changed: res.changed)
 
         case ("POST", "/wait"):
-            let frames = r.int("frames") ?? Int(Double(r.int("ms") ?? 500) * core_fps() / 1000.0)
+            let frames: Int
+            if r.value("frames") != nil {
+                guard let parsed = bounded(r, "frames", default: 0, min: 0, max: 4000) else {
+                    return respond(400, "application/json", json(["ok": false, "error": "frames must be an integer from 0 to 4000"]))
+                }
+                frames = parsed
+            } else {
+                guard let ms = bounded(r, "ms", default: 500, min: 0, max: 60000) else {
+                    return respond(400, "application/json", json(["ok": false, "error": "ms must be an integer from 0 to 60000"]))
+                }
+                frames = min(4000, Int(Double(ms) * core_fps() / 1000.0))
+            }
             log.add("WAIT", "\(frames)f")
-            let res = emu.submitSync([.wait(max(0, min(frames, 4000)))], settle: settle(r, fallbackMin: 1), scale: scale, wantShot: r.wantsImage, timeout: 120)
+            let res = emu.submitSync([.wait(frames)], settle: settle(r, fallbackMin: 1), scale: scale, wantShot: r.wantsImage, timeout: 120)
             return reply(r, ok: res.ok, extra: ["frames": frames], shot: res.shot, changed: res.changed)
 
         case ("POST", "/save"):
@@ -254,6 +301,13 @@ final class ControlAPI {
     }
 
     // MARK: - helpers
+
+    private func bounded(_ r: Request, _ key: String, default fallback: Int,
+                         min: Int, max: Int) -> Int? {
+        if r.value(key) == nil { return fallback }
+        guard let value = r.int(key), min...max ~= value else { return nil }
+        return value
+    }
 
     private func settle(_ r: Request, fallbackMin: Int? = nil) -> Emulator.Settle {
         if let fixed = r.int("settle") { return .fixed(max(0, min(fixed, 2000))) }
@@ -337,7 +391,7 @@ final class ControlAPI {
     GET  /slots                       savestates on disk
     GET  /help
 
-    POST /key    {"key":"kp3"}        one key; "hold" frames (default 10)
+    POST /key    {"key":"kp3"}        one key; optional "times", "hold", "gap"
     POST /keys   {"keys":["kp9","enter"]}   several in order; "gap" between
     POST /wait   {"ms":1000}          let the game run
     POST /save   {"slot":1} | {"name":"before-boss"}

--- a/Sources/QunXia/Emulator.swift
+++ b/Sources/QunXia/Emulator.swift
@@ -62,9 +62,14 @@ final class Emulator {
         let done: (Result) -> Void
     }
 
-    private let queue = DispatchQueue(label: "qunxia.emu")
     private let lock = NSCondition()
     private var jobs: [Job] = []
+    private var pendingNativeKeys: [(Int, Bool)] = []
+    // Native-window and API input have separate ownership. Releasing a local
+    // key must not cancel the same key while an API pulse still owns it.
+    private var nativeKeys: Set<Int> = []
+    private var actionKeys: Set<Int> = []
+    private var effectiveKeys: Set<Int> = []
     private var running = true
     private var frameBudget: Double = 1.0 / 60.0
     private(set) var lastError = ""
@@ -112,7 +117,10 @@ final class Emulator {
 
     /// Fire-and-forget, used by the native key handler in the window.
     func setKey(_ retrok: Int, down: Bool) {
-        queue.async { core_key(Int32(retrok), down) }
+        lock.lock()
+        pendingNativeKeys.append((retrok, down))
+        lock.signal()
+        lock.unlock()
     }
 
     func snapshot(scale: Int = 2) -> Shot? {
@@ -148,8 +156,38 @@ final class Emulator {
     }
 
     private func step() {
+        applyPendingNativeKeys()
         core_run_frame()
         onFrame?()
+    }
+
+    private func applyPendingNativeKeys() {
+        lock.lock()
+        let pending = pendingNativeKeys
+        pendingNativeKeys.removeAll(keepingCapacity: true)
+        lock.unlock()
+        for (key, down) in pending {
+            if down { nativeKeys.insert(key) } else { nativeKeys.remove(key) }
+            syncKey(key)
+        }
+    }
+
+    private func setActionKey(_ key: Int, down: Bool) {
+        if down { actionKeys.insert(key) } else { actionKeys.remove(key) }
+        syncKey(key)
+    }
+
+    private func syncKey(_ key: Int) {
+        let down = nativeKeys.contains(key) || actionKeys.contains(key)
+        if down == effectiveKeys.contains(key) { return }
+        if down { effectiveKeys.insert(key) } else { effectiveKeys.remove(key) }
+        core_key(Int32(key), down)
+    }
+
+    private func resyncKeysAfterCoreReset() {
+        effectiveKeys.removeAll()
+        actionKeys.removeAll()
+        for key in nativeKeys { syncKey(key) }
     }
 
     private func run(_ job: Job) {
@@ -160,9 +198,9 @@ final class Emulator {
         for s in job.steps {
             switch s {
             case .press(let combo, let frames):
-                for k in combo { core_key(Int32(k), true) }
+                for k in combo { setActionKey(k, down: true) }
                 pump(max(1, frames))
-                for k in combo.reversed() { core_key(Int32(k), false) }
+                for k in combo.reversed() { setActionKey(k, down: false) }
                 pump(2)
             case .wait(let n):
                 pump(max(0, n))
@@ -179,9 +217,11 @@ final class Emulator {
                 if !ok { detail = String(cString: core_last_error()) }
             case .load(let url):
                 ok = core_load_state(url.path)
+                if ok { resyncKeysAfterCoreReset() }
                 if !ok { detail = String(cString: core_last_error()) }
             case .reset:
                 core_reset()
+                resyncKeysAfterCoreReset()
                 pump(30)
             }
             if !ok { break }

--- a/mcp-server/game_knowledge.py
+++ b/mcp-server/game_knowledge.py
@@ -51,7 +51,7 @@ Example: 王 is ㄨㄤˊ, so type "j;6" then press "1" to pick 王. (verified)
 
 THE STORY AND YOUR GOAL
 You play 小蝦米, a modern student who buys a VR copy of this very game and wakes
-up inside the world of Jin Yong's novels. To get home you must find the twelve
+up inside the world of Jin Yong's novels. To get home you must find the fourteen
 Jin Yong novels scattered across the world. Along the way you recruit famous
 characters into your party, learn their martial arts, and fight turn-based team
 battles.

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -17,13 +17,17 @@ from typing import Optional
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from game_knowledge import GUIDE, INSTRUCTIONS
 
-from mcp.server.fastmcp import FastMCP
 from mcp.types import ImageContent, TextContent
+
+try:  # mcp 2.x
+    from mcp.server.mcpserver import MCPServer
+except ModuleNotFoundError:  # mcp 1.x
+    from mcp.server.fastmcp import FastMCP as MCPServer
 
 API = os.environ.get("QUNXIA_API", "http://127.0.0.1:8765")
 DEFAULT_SCALE = int(os.environ.get("QUNXIA_SCALE", "2"))
 
-mcp = FastMCP("qunxia", instructions=INSTRUCTIONS)
+mcp = MCPServer("qunxia", instructions=INSTRUCTIONS)
 
 DEFAULT_TAP_FRAMES = 10
 MAX_HOLD_FRAMES = 1200

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -12,17 +12,25 @@ import os
 import sys
 import urllib.error
 import urllib.request
+from typing import Optional
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from game_knowledge import GUIDE, INSTRUCTIONS
 
-from mcp.server.mcpserver import MCPServer
+from mcp.server.fastmcp import FastMCP
 from mcp.types import ImageContent, TextContent
 
 API = os.environ.get("QUNXIA_API", "http://127.0.0.1:8765")
 DEFAULT_SCALE = int(os.environ.get("QUNXIA_SCALE", "2"))
 
-mcp = MCPServer("qunxia", instructions=INSTRUCTIONS)
+mcp = FastMCP("qunxia", instructions=INSTRUCTIONS)
+
+DEFAULT_TAP_FRAMES = 10
+MAX_HOLD_FRAMES = 1200
+MAX_REPEAT = 100
+MAX_GAP_FRAMES = 600
+MAX_WAIT_MS = 60000
+MAX_ACTION_FRAMES = 2800
 
 
 class GameOffline(RuntimeError):
@@ -33,7 +41,7 @@ def _call(method, path, payload=None, timeout=240):
     data = json.dumps(payload).encode() if payload is not None else None
     req = urllib.request.Request(
         API + path, data=data, method=method,
-        headers={"Content-Type": "application/json"},
+        headers={"Content-Type": "application/json", "X-Agent": "mcp"},
     )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as r:
@@ -62,7 +70,10 @@ def _result(res, note=""):
                     "screen did NOT change (the action had no visible effect)")
     if res.get("error"):
         bits.append(str(res["error"]))
-    bits.append(f'{res.get("width")}x{res.get("height")}')
+    if res.get("image_error"):
+        bits.append(f'image unavailable: {res["image_error"]}')
+    if res.get("width") is not None and res.get("height") is not None:
+        bits.append(f'{res["width"]}x{res["height"]}')
     line = (note + " | " if note else "") + " | ".join(str(b) for b in bits)
     out.append(TextContent(type="text", text=line))
 
@@ -77,10 +88,28 @@ def _result(res, note=""):
 
 
 def _act(path, payload, note="", **params):
-    q = {"scale": DEFAULT_SCALE}
+    # Native returns an image by default; headless only encodes one when asked.
+    # Requesting it explicitly keeps action + observation atomic on either API.
+    q = {"scale": DEFAULT_SCALE, "image": 1}
     q.update({k: v for k, v in params.items() if v is not None})
     qs = "&".join(f"{k}={v}" for k, v in q.items())
     return _result(_call("POST", f"{path}?{qs}", payload), note)
+
+
+def _bounded(name, value, minimum, maximum):
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{name} must be an integer")
+    if not minimum <= value <= maximum:
+        raise ValueError(f"{name} must be between {minimum} and {maximum}")
+    return value
+
+
+def _action_length(count, hold=DEFAULT_TAP_FRAMES, gap=6):
+    total = count * (hold + 2) + max(0, count - 1) * gap
+    if total > MAX_ACTION_FRAMES:
+        raise ValueError(
+            f"action is too long ({total} frames; maximum {MAX_ACTION_FRAMES})"
+        )
 
 
 # ---------------------------------------------------------------- observation
@@ -105,20 +134,25 @@ def guide() -> str:
 # -------------------------------------------------------------------- actions
 
 @mcp.tool()
-def press(key: str, times: int = 1, hold: int = 4, stable: int = None) -> list:
+def press(key: str, times: int = 1, hold: int = DEFAULT_TAP_FRAMES,
+          stable: Optional[int] = None) -> list:
     """Press one key and return the screen it produced.
 
     key: up, down, left, right, enter (or ok), space, esc, y, n, a-z, 0-9,
          f1-f12, tab, backspace, or a combo like "alt+x".
     times: repeat the same key this many times (useful for walking or for
          advancing several dialogue lines).
-    hold: frames to hold the key down, default 4. Raise it only if a press
-         seems to be ignored.
+    hold: frames to hold the key down, default 10.
     stable: frames the picture must hold still before the screenshot is taken.
          Raise it if you get a half-written dialogue line.
 
     Remember: during a cutscene every key just advances the dialogue.
     """
+    _bounded("times", times, 1, MAX_REPEAT)
+    _bounded("hold", hold, 1, MAX_HOLD_FRAMES)
+    _action_length(times, hold)
+    if stable is not None:
+        _bounded("stable", stable, 1, 600)
     if times > 1:
         return _act("/keys", {"keys": [key] * times, "hold": hold},
                     note=f"{key} x{times}", stable=stable)
@@ -126,13 +160,20 @@ def press(key: str, times: int = 1, hold: int = 4, stable: int = None) -> list:
 
 
 @mcp.tool()
-def press_sequence(keys: list[str], gap: int = 6, stable: int = None) -> list:
+def press_sequence(keys: list[str], gap: int = 6,
+                   stable: Optional[int] = None) -> list:
     """Press several different keys in order, returning only the final screen.
 
     Use for a known menu path, e.g. ["esc", "down", "down", "enter"]. Prefer
     single presses when you are unsure what a screen will do, because you only
     see the result of the last key here.
     """
+    if not 1 <= len(keys) <= MAX_REPEAT:
+        raise ValueError(f"keys must contain between 1 and {MAX_REPEAT} entries")
+    _bounded("gap", gap, 0, MAX_GAP_FRAMES)
+    _action_length(len(keys), gap=gap)
+    if stable is not None:
+        _bounded("stable", stable, 1, 600)
     return _act("/keys", {"keys": keys, "gap": gap},
                 note=" ".join(keys), stable=stable)
 
@@ -145,9 +186,12 @@ def move(direction: str, steps: int = 1) -> list:
     not blocked, so walking into a person or object is how you talk to it. If
     nothing moves, you are either blocked or inside a cutscene.
     """
+    direction = direction.lower()
     if direction not in ("up", "down", "left", "right"):
         raise ValueError("direction must be up, down, left or right")
-    return _act("/keys", {"keys": [direction] * max(1, steps), "gap": 6},
+    _bounded("steps", steps, 1, MAX_REPEAT)
+    _action_length(steps)
+    return _act("/keys", {"keys": [direction] * steps, "gap": 6},
                 note=f"move {direction} x{steps}")
 
 
@@ -175,6 +219,7 @@ def wait(ms: int = 1000) -> list:
     Use it during boot, scene transitions, battle animations, and travel on the
     world map.
     """
+    _bounded("ms", ms, 0, MAX_WAIT_MS)
     return _act("/wait", {"ms": ms}, note=f"wait {ms}ms")
 
 

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -21,11 +21,19 @@ from mcp.types import ImageContent, TextContent
 
 try:  # mcp 2.x
     from mcp.server.mcpserver import MCPServer
+    from mcp.server.mcpserver.exceptions import ToolError
 except ModuleNotFoundError:  # mcp 1.x
     from mcp.server.fastmcp import FastMCP as MCPServer
+    from mcp.server.fastmcp.exceptions import ToolError
 
-API = os.environ.get("QUNXIA_API", "http://127.0.0.1:8765")
-DEFAULT_SCALE = int(os.environ.get("QUNXIA_SCALE", "2"))
+API = os.environ.get("QUNXIA_API", "http://127.0.0.1:8765").rstrip("/")
+try:
+    DEFAULT_SCALE = max(1, min(int(os.environ.get("QUNXIA_SCALE", "2")), 6))
+except ValueError:
+    DEFAULT_SCALE = 2
+AGENT = "".join(
+    c for c in os.environ.get("QUNXIA_AGENT", "mcp") if c.isalnum() or c in "-_."
+)[:16] or "mcp"
 
 mcp = MCPServer("qunxia", instructions=INSTRUCTIONS)
 
@@ -37,22 +45,33 @@ MAX_WAIT_MS = 60000
 MAX_ACTION_FRAMES = 2800
 
 
-class GameOffline(RuntimeError):
+class GameOffline(ToolError):
     pass
+
+
+class GameAPIError(ToolError):
+    pass
+
+
+def _decode_response(raw, path):
+    value = json.loads(raw)
+    if not isinstance(value, dict):
+        raise GameOffline(f"{path} returned a non-object JSON response")
+    return value
 
 
 def _call(method, path, payload=None, timeout=240):
     data = json.dumps(payload).encode() if payload is not None else None
     req = urllib.request.Request(
         API + path, data=data, method=method,
-        headers={"Content-Type": "application/json", "X-Agent": "mcp"},
+        headers={"Content-Type": "application/json", "X-Agent": AGENT},
     )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as r:
-            return json.loads(r.read())
+            return _decode_response(r.read(), path)
     except urllib.error.HTTPError as e:
         try:
-            return json.loads(e.read())
+            return _decode_response(e.read(), path)
         except Exception:
             raise GameOffline(f"{path} failed: HTTP {e.code}")
     except (urllib.error.URLError, ConnectionError, TimeoutError) as e:
@@ -65,6 +84,8 @@ def _call(method, path, payload=None, timeout=240):
 
 def _result(res, note=""):
     """Turn an API response into MCP content: a short status line plus the screen."""
+    if res.get("ok", True) is False:
+        raise GameAPIError(str(res.get("error") or "game API rejected the action"))
     out = []
     bits = []
     if not res.get("ok", True):
@@ -76,6 +97,8 @@ def _result(res, note=""):
         bits.append(str(res["error"]))
     if res.get("image_error"):
         bits.append(f'image unavailable: {res["image_error"]}')
+    if res.get("observation") == "follow-up":
+        bits.append("follow-up screenshot (not atomic on a shared session)")
     if res.get("width") is not None and res.get("height") is not None:
         bits.append(f'{res["width"]}x{res["height"]}')
     line = (note + " | " if note else "") + " | ".join(str(b) for b in bits)
@@ -97,7 +120,23 @@ def _act(path, payload, note="", **params):
     q = {"scale": DEFAULT_SCALE, "image": 1}
     q.update({k: v for k, v in params.items() if v is not None})
     qs = "&".join(f"{k}={v}" for k, v in q.items())
-    return _result(_call("POST", f"{path}?{qs}", payload), note)
+    res = _call("POST", f"{path}?{qs}", payload)
+    # Older headless deployments ignore image=1. Stay compatible, but label
+    # the extra GET because another controller could act between the calls.
+    if res.get("ok", True) and not res.get("image"):
+        try:
+            observed = _call("GET", "/screen")
+            if observed.get("ok", True) and observed.get("image"):
+                for key in ("image", "image_width", "image_height", "width",
+                            "height", "frame"):
+                    if key in observed:
+                        res[key] = observed[key]
+                res["observation"] = "follow-up"
+            elif observed.get("ok", True) is False:
+                res["image_error"] = str(observed.get("error") or "screen failed")
+        except GameOffline as exc:
+            res["image_error"] = str(exc)
+    return _result(res, note)
 
 
 def _bounded(name, value, minimum, maximum):
@@ -106,6 +145,12 @@ def _bounded(name, value, minimum, maximum):
     if not minimum <= value <= maximum:
         raise ValueError(f"{name} must be between {minimum} and {maximum}")
     return value
+
+
+def _state_name(name):
+    if not isinstance(name, str) or not 1 <= len(name) <= 64:
+        raise ValueError("name must be a string from 1 to 64 characters")
+    return name
 
 
 def _action_length(count, hold=DEFAULT_TAP_FRAMES, gap=6):
@@ -236,6 +281,7 @@ def save_state(name: str = "agent") -> list:
     Unlike the game's own save system this works anywhere, including mid-scene
     and mid-battle. Take one before anything you might want to undo.
     """
+    _state_name(name)
     return _act("/save", {"name": name}, note=f"save {name}")
 
 
@@ -246,13 +292,17 @@ def load_state(name: str = "agent") -> list:
     Note that a snapshot taken during a cutscene restores into that cutscene,
     so movement will be ignored until you finish reading it.
     """
+    _state_name(name)
     return _act("/load", {"name": name}, note=f"load {name}")
 
 
 @mcp.tool()
 def list_states() -> str:
     """List the snapshots on disk with their sizes and timestamps."""
-    return json.dumps(_call("GET", "/slots"), ensure_ascii=False, indent=2)
+    res = _call("GET", "/slots")
+    if res.get("ok", True) is False:
+        raise GameAPIError(str(res.get("error") or "listing states failed"))
+    return json.dumps(res, ensure_ascii=False, indent=2)
 
 
 @mcp.tool()

--- a/mcp-server/test_protocol.py
+++ b/mcp-server/test_protocol.py
@@ -1,0 +1,75 @@
+import http.server
+import json
+import os
+import pathlib
+import sys
+import threading
+import unittest
+
+from mcp.client.session import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+
+HERE = pathlib.Path(__file__).resolve().parent
+
+
+class RejectHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = json.dumps({"ok": False, "error": "synthetic rejection"}).encode()
+        self.send_response(400)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format, *_args):
+        pass
+
+
+class MCPProtocolTest(unittest.IsolatedAsyncioTestCase):
+    async def test_stdio_server_initializes_and_lists_game_tools(self):
+        env = os.environ.copy()
+        env.update({"QUNXIA_API": "http://127.0.0.1:1", "QUNXIA_AGENT": "test"})
+        parameters = StdioServerParameters(
+            command=sys.executable, args=[str(HERE / "server.py")], env=env,
+        )
+        async with stdio_client(parameters) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                initialized = await session.initialize()
+                result = await session.list_tools()
+
+        server_info = (initialized.serverInfo if hasattr(initialized, "serverInfo")
+                       else initialized.server_info)
+        self.assertEqual(server_info.name, "qunxia")
+        self.assertEqual(
+            {tool.name for tool in result.tools},
+            {"look", "guide", "press", "press_sequence", "move", "interact",
+             "open_menu", "wait", "save_state", "load_state", "list_states",
+             "reset_game"},
+        )
+
+    async def test_backend_rejection_is_an_mcp_tool_error(self):
+        backend = http.server.ThreadingHTTPServer(("127.0.0.1", 0), RejectHandler)
+        thread = threading.Thread(target=backend.serve_forever, daemon=True)
+        thread.start()
+        try:
+            env = os.environ.copy()
+            env["QUNXIA_API"] = f"http://127.0.0.1:{backend.server_port}"
+            parameters = StdioServerParameters(
+                command=sys.executable, args=[str(HERE / "server.py")], env=env,
+            )
+            async with stdio_client(parameters) as (read_stream, write_stream):
+                async with ClientSession(read_stream, write_stream) as session:
+                    await session.initialize()
+                    result = await session.call_tool("look", {})
+            dumped = result.model_dump(by_alias=True)
+            self.assertTrue(dumped["isError"])
+            self.assertIn("synthetic rejection", json.dumps(dumped))
+        finally:
+            backend.shutdown()
+            backend.server_close()
+            thread.join(timeout=2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp-server/test_server.py
+++ b/mcp-server/test_server.py
@@ -29,9 +29,25 @@ class MCPToolTest(unittest.TestCase):
             game.move("right", steps=101)
 
     def test_actions_request_atomic_image(self):
-        with mock.patch.object(game, "_call", return_value={"ok": True}) as call:
+        with mock.patch.object(
+            game, "_call", return_value={"ok": True, "image": "data:image/png;base64,cG5n"}
+        ) as call:
             game.interact()
-        self.assertIn("image=1", call.call_args.args[1])
+        self.assertIn("image=1", call.call_args_list[0].args[1])
+
+    def test_old_server_gets_labelled_follow_up_image(self):
+        with mock.patch.object(game, "_call", side_effect=[
+            {"ok": True, "changed": True},
+            {"ok": True, "width": 320, "height": 200,
+             "image": "data:image/png;base64,cG5n"},
+        ]):
+            result = game.interact()
+        self.assertIn("not atomic", result[0].text)
+        self.assertEqual(result[1].type, "image")
+
+    def test_backend_rejection_raises_a_real_tool_error(self):
+        with self.assertRaisesRegex(game.GameAPIError, "unknown key"):
+            game._result({"ok": False, "error": "unknown key"})
 
 
 if __name__ == "__main__":

--- a/mcp-server/test_server.py
+++ b/mcp-server/test_server.py
@@ -1,0 +1,38 @@
+import importlib.util
+import pathlib
+import unittest
+from unittest import mock
+
+
+HERE = pathlib.Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location("qunxia_mcp", HERE / "server.py")
+game = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(game)
+
+
+class MCPToolTest(unittest.TestCase):
+    def test_press_uses_reliable_default_hold(self):
+        with mock.patch.object(game, "_act", return_value=[]) as act:
+            game.press("right")
+        act.assert_called_once_with(
+            "/key", {"key": "right", "hold": game.DEFAULT_TAP_FRAMES},
+            note="right", stable=None,
+        )
+        self.assertEqual(game.DEFAULT_TAP_FRAMES, 10)
+
+    def test_press_rejects_non_positive_repeat(self):
+        with self.assertRaisesRegex(ValueError, "times"):
+            game.press("right", times=0)
+
+    def test_move_rejects_unbounded_batch(self):
+        with self.assertRaisesRegex(ValueError, "steps"):
+            game.move("right", steps=101)
+
+    def test_actions_request_atomic_image(self):
+        with mock.patch.object(game, "_call", return_value={"ok": True}) as call:
+            game.interact()
+        self.assertIn("image=1", call.call_args.args[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pi-agent/SYSTEM.md
+++ b/pi-agent/SYSTEM.md
@@ -1,7 +1,8 @@
 You are playing 金庸群俠傳 (The Legend of Jin Yong Heroes), the original 1996 DOS
 game by 河洛工作室, running under emulation on this machine. You drive it through
-the `game_*` tools. There is no mouse. Play it properly: read the screen, think
-about what it says, and act.
+the `game_*` tools. There is no mouse. The default launcher deliberately exposes
+no shell or file tools: the visible game frames are your only game-state source.
+Play it properly: read the screen, think about what it says, and act.
 
 ## How the loop works
 
@@ -75,11 +76,14 @@ A warning the game itself gives you: 「你們這些人都是這樣的，自以�
 - Snapshot before anything risky with `game_save`, and restore with `game_load`.
   These are emulator snapshots, so they restore exactly, including mid-battle,
   which the game's own save system cannot do.
-- You have the normal file tools as well as the game tools. Use them. Keep a
-  notes file as you play: where you are, what the map looks like, who you have
-  met, which items you hold, what you were about to try. Your context gets
-  compacted as the session grows, and those notes are what survive it. Re-read
-  them when you are unsure what you were doing.
+- Keep a compact mental ledger: current objective, evidence, important places,
+  failed routes, inventory clues, and the next test. Restate it after meaningful
+  discoveries so automatic context compaction can preserve it. If the same idea
+  fails three times without new evidence, stop repeating it and choose a new
+  test tied to the current objective.
 - When you are lost, `game_look` and read the screen again rather than pressing
   keys to see what happens.
+- `screen changed` only means some pixels changed. A blocked character can turn
+  or animate, so confirm movement from the background rather than treating that
+  status as success.
 - Boot takes about 14 seconds. If the screen is black at the start, `game_wait`.

--- a/pi-agent/SYSTEM.md
+++ b/pi-agent/SYSTEM.md
@@ -49,15 +49,16 @@ Type the zhuyin letters, then press the digit next to the character you want.
     zㄈ xㄌ cㄏ vㄒ bㄖ nㄙ mㄩ ,ㄝ .ㄡ /ㄥ
 
 Tones: 1st = space, 2nd = 6, 3rd = 3, 4th = 4, neutral = 7.
-Example: 王 is ㄨㄤˊ, so `game_type` "j;6" then press "1" to pick 王.
+Example: 王 is ㄨㄤˊ, so use `game_press_sequence` with `["j", ";", "6"]`,
+then `game_press` with `"1"` to pick 王.
 
 ## The mission
 
 You are 小蝦米, a modern student who buys a VR copy of this very game and wakes
-up inside the world of Jin Yong's novels. To get home you must find the twelve
-Jin Yong novels (十二本金庸小說) scattered across the world. Along the way you
+up inside the world of Jin Yong's novels. To get home you must find the fourteen
+Jin Yong novels (十四本金庸小說) scattered across the world. Along the way you
 recruit famous characters into your party, learn their martial arts, and fight
-turn-based team battles. Finding all twelve books and returning to the present
+turn-based team battles. Finding all fourteen books and returning to the present
 is the ultimate goal.
 
 Opening: you wake on the floor of a room. Talk to the 軟體娃娃, the floating VR

--- a/pi-agent/extensions/qunxia/index.ts
+++ b/pi-agent/extensions/qunxia/index.ts
@@ -6,42 +6,56 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 
-const API = process.env.QUNXIA_API ?? "http://127.0.0.1:8765";
-const SCALE = Number(process.env.QUNXIA_SCALE ?? "2");
+const API = (process.env.QUNXIA_API ?? "http://127.0.0.1:8765").replace(/\/+$/, "");
+const rawScale = Number(process.env.QUNXIA_SCALE ?? "2");
+const SCALE = Number.isFinite(rawScale) ? Math.min(6, Math.max(1, Math.trunc(rawScale))) : 2;
+const AGENT = (process.env.QUNXIA_AGENT ?? "pi").replace(/[^a-zA-Z0-9_.-]/g, "").slice(0, 16) || "pi";
 const MAX_ACTION_FRAMES = 2800;
 
 type Content = { type: "text"; text: string } | { type: "image"; data: string; mimeType: string };
 
+class GameApiError extends Error {}
+
 async function call(method: string, path: string, body?: unknown, signal?: AbortSignal) {
   const res = await fetch(API + path, {
     method,
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", "X-Agent": AGENT },
     body: body === undefined ? undefined : JSON.stringify(body),
     signal,
   });
-  return (await res.json()) as Record<string, any>;
+  const text = await res.text();
+  let payload: Record<string, any>;
+  try {
+    const parsed = JSON.parse(text);
+    payload = parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, any>
+      : { ok: false, error: "game API returned a non-object response" };
+  } catch {
+    payload = {
+      ok: false,
+      error: `game API returned HTTP ${res.status} with a non-JSON response`,
+    };
+  }
+  if (!res.ok) {
+    payload.ok = false;
+    payload.error ??= `game API returned HTTP ${res.status}`;
+  }
+  if (payload.ok === false) {
+    throw new GameApiError(String(payload.error ?? `game API returned HTTP ${res.status}`));
+  }
+  return payload;
 }
 
-function offline(err: unknown) {
-  return {
-    content: [{
-      type: "text" as const,
-      text:
-        `The game is not reachable at ${API} (${err}). It must be running: start it ` +
-        `with ./Scripts/run.sh from the repo and give it about 14 seconds to reach ` +
-        `the title screen.`,
-    }],
-    details: { error: String(err) },
-    isError: true,
-  };
+function toolFailure(err: unknown, signal?: AbortSignal): never {
+  if (signal?.aborted || err instanceof GameApiError) throw err;
+  throw new Error(
+    `Cannot reach the game at ${API} (${err}). Start it with ./Scripts/run.sh ` +
+    "and give it about 14 seconds to reach the title screen.",
+  );
 }
 
-function inputError(text: string) {
-  return {
-    content: [{ type: "text" as const, text }],
-    details: {},
-    isError: true,
-  };
+function inputError(text: string): never {
+  throw new Error(text);
 }
 
 function actionFits(count: number, hold = 10, gap = 6) {
@@ -57,27 +71,48 @@ function frame(res: Record<string, any>, note: string) {
   }
   if (res.error) bits.push(String(res.error));
   if (res.image_error) bits.push(`image unavailable: ${res.image_error}`);
+  if (res.observation === "follow-up") {
+    bits.push("follow-up screenshot (not atomic on a shared session)");
+  }
   if (res.width !== undefined && res.height !== undefined) {
     bits.push(`${res.width}x${res.height}`);
   }
 
   const content: Content[] = [{ type: "text", text: `${note} | ${bits.join(" | ")}` }];
-  if (typeof res.image === "string") {
-    content.push({ type: "image", data: res.image.split(",", 2)[1], mimeType: "image/png" });
+  if (typeof res.image === "string" && res.image.includes(",")) {
+    const [header, data] = res.image.split(",", 2);
+    const mimeType = header.match(/^data:([^;]+);base64$/)?.[1] ?? "image/png";
+    if (data) content.push({ type: "image", data, mimeType });
   }
   return {
     content,
     details: { ok: res.ok !== false, changed: res.changed, frame: res.frame },
-    ...(res.ok === false ? { isError: true } : {}),
   };
 }
 
 export default function (pi: ExtensionAPI) {
-  const act = async (path: string, body: unknown, note: string, signal?: AbortSignal) => {
+  const act = async (
+    path: string, body: unknown, note: string, signal?: AbortSignal, query = "",
+  ) => {
     try {
-      return frame(await call("POST", `${path}?scale=${SCALE}&image=1`, body, signal), note);
+      const res = await call("POST", `${path}?scale=${SCALE}&image=1${query}`, body, signal);
+      // Old headless deployments ignore image=1. Fall back to a separate look
+      // and say so, because a shared-session controller may act in between.
+      if (typeof res.image !== "string") {
+        try {
+          const observed = await call("GET", "/screen", undefined, signal);
+          for (const key of ["image", "image_width", "image_height", "width", "height", "frame"]) {
+            if (key in observed) res[key] = observed[key];
+          }
+          if (typeof res.image === "string") res.observation = "follow-up";
+        } catch (observationError) {
+          if (signal?.aborted) throw observationError;
+          res.image_error = String(observationError);
+        }
+      }
+      return frame(res, note);
     } catch (err) {
-      return offline(err);
+      return toolFailure(err, signal);
     }
   };
 
@@ -93,7 +128,7 @@ export default function (pi: ExtensionAPI) {
       try {
         return frame(await call("GET", "/screen", undefined, signal), "look");
       } catch (err) {
-        return offline(err);
+        return toolFailure(err, signal);
       }
     },
   });
@@ -109,7 +144,7 @@ export default function (pi: ExtensionAPI) {
       "the dialogue.",
     promptSnippet: "Press a key in the game",
     parameters: Type.Object({
-      key: Type.String({ description: "Key name, e.g. up, enter, esc, y" }),
+      key: Type.String({ minLength: 1, maxLength: 32, description: "Key name, e.g. up, enter, esc, y" }),
       times: Type.Optional(Type.Integer({ minimum: 1, maximum: 100, description: "Repeat count, default 1" })),
       hold: Type.Optional(Type.Integer({ minimum: 1, maximum: 1200, description: "Frames to hold the key, default 10" })),
       stable: Type.Optional(Type.Integer({ minimum: 1, maximum: 600,
@@ -128,11 +163,7 @@ export default function (pi: ExtensionAPI) {
         ? { keys: Array(times).fill(params.key), hold: params.hold }
         : { key: params.key, hold: params.hold };
       const path = times > 1 ? "/keys" : "/key";
-      try {
-        return frame(await call("POST", `${path}?scale=${SCALE}&image=1${q}`, body, signal), note);
-      } catch (err) {
-        return offline(err);
-      }
+      return act(path, body, note, signal, q);
     },
   });
 
@@ -146,13 +177,13 @@ export default function (pi: ExtensionAPI) {
       "the intermediate frames.",
     promptSnippet: "Press a sequence of keys in the game",
     parameters: Type.Object({
-      keys: Type.Array(Type.String(), { minItems: 1, maxItems: 100, description: "Key names in order" }),
+      keys: Type.Array(Type.String({ minLength: 1, maxLength: 32 }), { minItems: 1, maxItems: 100, description: "Key names in order" }),
       gap: Type.Optional(Type.Integer({ minimum: 0, maximum: 600, description: "Frames between keys, default 6" })),
     }),
     execute: (_id, params, signal) => {
       const gap = params.gap ?? 6;
       if (!actionFits(params.keys.length, 10, gap)) {
-        return Promise.resolve(inputError(`action exceeds ${MAX_ACTION_FRAMES} frames`));
+        inputError(`action exceeds ${MAX_ACTION_FRAMES} frames`);
       }
       return act("/keys", { keys: params.keys, gap: params.gap }, params.keys.join(" "), signal);
     },
@@ -173,11 +204,11 @@ export default function (pi: ExtensionAPI) {
     execute: (_id, params, signal) => {
       const dir = params.direction.toLowerCase();
       if (!["up", "down", "left", "right"].includes(dir)) {
-        return Promise.resolve(inputError("direction must be up, down, left or right"));
+        inputError("direction must be up, down, left or right");
       }
       const steps = Math.max(1, params.steps ?? 1);
       if (!actionFits(steps)) {
-        return Promise.resolve(inputError(`action exceeds ${MAX_ACTION_FRAMES} frames`));
+        inputError(`action exceeds ${MAX_ACTION_FRAMES} frames`);
       }
       return act("/keys", { keys: Array(steps).fill(dir), gap: 6 }, `move ${dir} x${steps}`, signal);
     },
@@ -204,7 +235,7 @@ export default function (pi: ExtensionAPI) {
       "Snapshot the whole emulator under a name. Unlike the game's own save system this " +
       "works anywhere, including mid-scene and mid-battle. Take one before anything risky.",
     promptSnippet: "Snapshot the emulator state",
-    parameters: Type.Object({ name: Type.String({ description: "Snapshot name" }) }),
+    parameters: Type.Object({ name: Type.String({ minLength: 1, maxLength: 64, description: "Snapshot name" }) }),
     execute: (_id, params, signal) => act("/save", { name: params.name }, `save ${params.name}`, signal),
   });
 
@@ -215,7 +246,7 @@ export default function (pi: ExtensionAPI) {
       "Restore a snapshot taken by game_save. A snapshot taken during a cutscene restores " +
       "into that cutscene, so movement stays ignored until you finish reading it.",
     promptSnippet: "Restore an emulator snapshot",
-    parameters: Type.Object({ name: Type.String({ description: "Snapshot name" }) }),
+    parameters: Type.Object({ name: Type.String({ minLength: 1, maxLength: 64, description: "Snapshot name" }) }),
     execute: (_id, params, signal) => act("/load", { name: params.name }, `load ${params.name}`, signal),
   });
 
@@ -228,9 +259,12 @@ export default function (pi: ExtensionAPI) {
     async execute(_id, _params, signal) {
       try {
         const res = await call("GET", "/slots", undefined, signal);
-        return { content: [{ type: "text" as const, text: JSON.stringify(res, null, 2) }], details: res };
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(res, null, 2) }],
+          details: res,
+        };
       } catch (err) {
-        return offline(err);
+        return toolFailure(err, signal);
       }
     },
   });

--- a/pi-agent/extensions/qunxia/index.ts
+++ b/pi-agent/extensions/qunxia/index.ts
@@ -8,6 +8,7 @@ import { Type } from "typebox";
 
 const API = process.env.QUNXIA_API ?? "http://127.0.0.1:8765";
 const SCALE = Number(process.env.QUNXIA_SCALE ?? "2");
+const MAX_ACTION_FRAMES = 2800;
 
 type Content = { type: "text"; text: string } | { type: "image"; data: string; mimeType: string };
 
@@ -35,6 +36,18 @@ function offline(err: unknown) {
   };
 }
 
+function inputError(text: string) {
+  return {
+    content: [{ type: "text" as const, text }],
+    details: {},
+    isError: true,
+  };
+}
+
+function actionFits(count: number, hold = 10, gap = 6) {
+  return count * (hold + 2) + Math.max(0, count - 1) * gap <= MAX_ACTION_FRAMES;
+}
+
 /** Turn an API response into a status line plus the screen. */
 function frame(res: Record<string, any>, note: string) {
   const bits: string[] = [];
@@ -43,19 +56,26 @@ function frame(res: Record<string, any>, note: string) {
     bits.push(res.changed ? "screen changed" : "screen did NOT change (no visible effect)");
   }
   if (res.error) bits.push(String(res.error));
-  bits.push(`${res.width}x${res.height}`);
+  if (res.image_error) bits.push(`image unavailable: ${res.image_error}`);
+  if (res.width !== undefined && res.height !== undefined) {
+    bits.push(`${res.width}x${res.height}`);
+  }
 
   const content: Content[] = [{ type: "text", text: `${note} | ${bits.join(" | ")}` }];
   if (typeof res.image === "string") {
     content.push({ type: "image", data: res.image.split(",", 2)[1], mimeType: "image/png" });
   }
-  return { content, details: { ok: res.ok !== false, changed: res.changed, frame: res.frame } };
+  return {
+    content,
+    details: { ok: res.ok !== false, changed: res.changed, frame: res.frame },
+    ...(res.ok === false ? { isError: true } : {}),
+  };
 }
 
 export default function (pi: ExtensionAPI) {
   const act = async (path: string, body: unknown, note: string, signal?: AbortSignal) => {
     try {
-      return frame(await call("POST", `${path}?scale=${SCALE}`, body, signal), note);
+      return frame(await call("POST", `${path}?scale=${SCALE}&image=1`, body, signal), note);
     } catch (err) {
       return offline(err);
     }
@@ -90,14 +110,18 @@ export default function (pi: ExtensionAPI) {
     promptSnippet: "Press a key in the game",
     parameters: Type.Object({
       key: Type.String({ description: "Key name, e.g. up, enter, esc, y" }),
-      times: Type.Optional(Type.Number({ description: "Repeat count, default 1" })),
-      hold: Type.Optional(Type.Number({ description: "Frames to hold the key, default 4" })),
-      stable: Type.Optional(Type.Number({
+      times: Type.Optional(Type.Integer({ minimum: 1, maximum: 100, description: "Repeat count, default 1" })),
+      hold: Type.Optional(Type.Integer({ minimum: 1, maximum: 1200, description: "Frames to hold the key, default 10" })),
+      stable: Type.Optional(Type.Integer({ minimum: 1, maximum: 600,
         description: "Frames the picture must hold still before the screenshot. Raise if you get a half-written dialogue line.",
       })),
     }),
     async execute(_id, params, signal) {
       const times = params.times ?? 1;
+      const hold = params.hold ?? 10;
+      if (!actionFits(times, hold)) {
+        return inputError(`action exceeds ${MAX_ACTION_FRAMES} frames`);
+      }
       const q = params.stable ? `&stable=${params.stable}` : "";
       const note = times > 1 ? `${params.key} x${times}` : params.key;
       const body = times > 1
@@ -105,7 +129,7 @@ export default function (pi: ExtensionAPI) {
         : { key: params.key, hold: params.hold };
       const path = times > 1 ? "/keys" : "/key";
       try {
-        return frame(await call("POST", `${path}?scale=${SCALE}${q}`, body, signal), note);
+        return frame(await call("POST", `${path}?scale=${SCALE}&image=1${q}`, body, signal), note);
       } catch (err) {
         return offline(err);
       }
@@ -122,11 +146,16 @@ export default function (pi: ExtensionAPI) {
       "the intermediate frames.",
     promptSnippet: "Press a sequence of keys in the game",
     parameters: Type.Object({
-      keys: Type.Array(Type.String(), { description: "Key names in order" }),
-      gap: Type.Optional(Type.Number({ description: "Frames between keys, default 6" })),
+      keys: Type.Array(Type.String(), { minItems: 1, maxItems: 100, description: "Key names in order" }),
+      gap: Type.Optional(Type.Integer({ minimum: 0, maximum: 600, description: "Frames between keys, default 6" })),
     }),
-    execute: (_id, params, signal) =>
-      act("/keys", { keys: params.keys, gap: params.gap }, params.keys.join(" "), signal),
+    execute: (_id, params, signal) => {
+      const gap = params.gap ?? 6;
+      if (!actionFits(params.keys.length, 10, gap)) {
+        return Promise.resolve(inputError(`action exceeds ${MAX_ACTION_FRAMES} frames`));
+      }
+      return act("/keys", { keys: params.keys, gap: params.gap }, params.keys.join(" "), signal);
+    },
   });
 
   pi.registerTool({
@@ -139,18 +168,17 @@ export default function (pi: ExtensionAPI) {
     promptSnippet: "Walk in the game world",
     parameters: Type.Object({
       direction: Type.String({ description: "up, down, left or right" }),
-      steps: Type.Optional(Type.Number({ description: "Tiles to walk, default 1" })),
+      steps: Type.Optional(Type.Integer({ minimum: 1, maximum: 100, description: "Tiles to walk, default 1" })),
     }),
     execute: (_id, params, signal) => {
       const dir = params.direction.toLowerCase();
       if (!["up", "down", "left", "right"].includes(dir)) {
-        return Promise.resolve({
-          content: [{ type: "text" as const, text: "direction must be up, down, left or right" }],
-          details: {},
-          isError: true,
-        });
+        return Promise.resolve(inputError("direction must be up, down, left or right"));
       }
       const steps = Math.max(1, params.steps ?? 1);
+      if (!actionFits(steps)) {
+        return Promise.resolve(inputError(`action exceeds ${MAX_ACTION_FRAMES} frames`));
+      }
       return act("/keys", { keys: Array(steps).fill(dir), gap: 6 }, `move ${dir} x${steps}`, signal);
     },
   });
@@ -163,7 +191,7 @@ export default function (pi: ExtensionAPI) {
       "scene transitions, battle animations and travel on the world map.",
     promptSnippet: "Let the game run for a while",
     parameters: Type.Object({
-      ms: Type.Optional(Type.Number({ description: "Milliseconds, default 1000" })),
+      ms: Type.Optional(Type.Integer({ minimum: 0, maximum: 60000, description: "Milliseconds, default 1000" })),
     }),
     execute: (_id, params, signal) =>
       act("/wait", { ms: params.ms ?? 1000 }, `wait ${params.ms ?? 1000}ms`, signal),

--- a/server/README.md
+++ b/server/README.md
@@ -12,7 +12,7 @@ Runs the game with no display and streams the VGA framebuffer to a browser.
 
 ```sh
 ./build.sh                      # -> libqunxia.so (Linux)
-python3 -m venv .venv && .venv/bin/pip install aiohttp
+python3 -m venv .venv && .venv/bin/pip install aiohttp pillow
 .venv/bin/python server.py      # PORT=8080
 ```
 
@@ -35,10 +35,14 @@ Needs `../cores/dosbox_pure_libretro.so` (libretro buildbot) and `../game/`.
   the same thing, and no scaling knob: upscaling server-side only made a bigger
   PNG out of the same pixels.
 - `/api/key`, `/api/keys`, `/api/wait` apply input and wait for
-  the screen to react and then settle, but return no picture. Acting and
-  looking are separate calls. Short taps default to ten emulated frames, and
+  the screen to react and then settle. They return metadata by default; add
+  `?image=1` to capture the settled PNG before another controller can act.
+  Short taps default to ten emulated frames, and
   their down, release and inter-tap phases are fenced by the core frame clock,
   so host scheduling cannot silently collapse repeated movement taps.
+- `GET /api/keys`, `GET /api/slots`, `POST /api/save` and `POST /api/load` mirror the native
+  control API. Save and load are paused between emulated frames so libretro is
+  never serialized concurrently with `retro_run`.
 - `POST /api/reset?token=...` hidden. Restores the start state, a character
   already created and standing in the opening room, and wipes the activity log.
   Creating a character means driving the 注音 IME, which tests input-method
@@ -58,7 +62,7 @@ Needs `../cores/dosbox_pure_libretro.so` (libretro buildbot) and `../game/`.
   that were held and encodes in the browser with MediaRecorder, so the server
   spends nothing on it. MediaRecorder captures in real time, so an export takes
   the length of the recording divided by four.
-- `/api/history` the action log. Every REST call and every key pressed in a
+- `/api/history?limit=100` the bounded action log. Every REST call and every key pressed in a
   browser is recorded and pushed to all connected pages over the same
   WebSocket, so the activity panel shows an agent and a human acting on the
   shared session side by side. Only the calls that explicitly ask to see the
@@ -66,13 +70,14 @@ Needs `../cores/dosbox_pure_libretro.so` (libretro buildbot) and `../game/`.
   (about 2 KB). Attaching one to every keypress buried the log. Only the
   newest 40 entries keep their image.
 
-PNGs are written by a ~10 line encoder over `zlib` rather than pulling in an
-image library.
+The live canvas uses the small `zlib` tile encoder. Pillow is used only for
+on-demand PNG/WebP observations and activity thumbnails.
 
 ## Several agents on one session
 
-Actions are serialised so the game stays coherent, and the queue is FIFO, so
-agents take strictly fair turns. Measured against the deployed e2-micro, each
+REST actions and browser key holds share one single-player lease, so a browser
+release cannot cancel an API press (or another browser's hold). The queue is
+FIFO. Measured against the deployed e2-micro, each
 agent pressing a key and reading the screen every third action, with a
 spectator attached throughout:
 

--- a/server/server.py
+++ b/server/server.py
@@ -12,6 +12,7 @@ import ctypes
 import hashlib
 import io
 import json
+import math
 import os
 import pathlib
 import sys
@@ -88,9 +89,13 @@ for _alias, _code in {"upright": 273, "ne": 273,      # == up    == kp9
 
 # Native resolution only, so the largest frame the core produces is 640x400.
 SNAP = ctypes.create_string_buffer(640 * 400 * 3 + 4096)
-api_lock = asyncio.Lock()     # one action at a time; the game is single-player
+# Created by the startup hook inside aiohttp's running loop. Constructing an
+# asyncio.Lock at import time binds it to a different loop on Python 3.9 as
+# soon as contention occurs.
+api_lock = None               # one action at a time; the game is single-player
 paused = threading.Event()    # held while the core is rebooted, so retro_reset
                               # is never called underneath a running retro_run
+paused_ack = threading.Event()
 
 clients: set[web.WebSocketResponse] = set()
 stats = {"frames": 0, "sent": 0, "bytes": 0, "tiles": 0, "dropped": 0,
@@ -112,10 +117,17 @@ LOCK_TIMEOUT = float(os.environ.get("QUNXIA_LOCK_TIMEOUT", "30"))
 DEFAULT_TAP_FRAMES = 10
 KEY_RELEASE_FRAMES = 2
 BETWEEN_TAPS_FRAMES = 6
+MAX_HOLD_FRAMES = 1200
+MAX_GAP_FRAMES = 600
+MAX_KEYS_PER_ACTION = 100
+MAX_ACTION_FRAMES = 2800
+MAX_WAIT_MS = 60000
+MAX_HISTORY_LIMIT = 300
 # Reset restores this rather than rebooting. It puts the agent in the opening
 # room with a character already made, because creating one means driving the
 # 注音 IME, which is a puzzle about input methods and not about the game.
 START_STATE = os.environ.get("QUNXIA_START_STATE", str(ROOT.parent / "saves" / "start.state"))
+STATE_DIR = os.environ.get("QUNXIA_STATE_DIR", str(ROOT.parent / "saves" / "states"))
 
 # Everything anyone does to this session, so the page can show who is doing
 # what. The game is shared, so this doubles as "why did the screen just move".
@@ -176,11 +188,8 @@ async def _send_one(ws, data, text):
     connection blocks forever once its window fills, so every send needs a
     deadline of its own."""
     try:
-        async with asyncio.timeout(SEND_TIMEOUT):
-            if text:
-                await ws.send_str(data)
-            else:
-                await ws.send_bytes(data)
+        send = ws.send_str(data) if text else ws.send_bytes(data)
+        await asyncio.wait_for(send, timeout=SEND_TIMEOUT)
         return ws, True
     except Exception:
         return ws, False
@@ -216,9 +225,11 @@ def emulate():
     nxt = time.perf_counter()
     while True:
         if paused.is_set():
+            paused_ack.set()
             time.sleep(0.02)
             nxt = time.perf_counter()
             continue
+        paused_ack.clear()
         LIB.core_run_frame()
         stats["frames"] += 1
         nxt += budget
@@ -369,6 +380,7 @@ async def ws_handler(request):
     # and keyup within one emulated frame, so remember when each press reached
     # the core and fence short pulses on release.
     holding: dict[int, tuple[str, int]] = {}
+    lock_held = False
     try:
         async for msg in ws:
             if msg.type != WSMsgType.TEXT:
@@ -380,24 +392,51 @@ async def ws_handler(request):
                 code = KEYS.get(name)
                 if code:
                     down = bool(d.get("down"))
-                    rec["actor"] = "web"
-                    if down and await press_web_key(name, code, holding):
-                        log_action("web", "KEY", name)
+                    if down and code not in holding:
+                        if not lock_held:
+                            lock_held = await acquire_action_lock()
+                        if not lock_held:
+                            log_action("web", "KEY", name, detail="busy", ok=False)
+                            continue
+                        try:
+                            rec["actor"] = "web"
+                            if await press_web_key(name, code, holding):
+                                log_action("web", "KEY", name)
+                        except BaseException:
+                            if not holding and lock_held:
+                                action_lock().release()
+                                lock_held = False
+                            raise
                     elif not down:
+                        rec["actor"] = "web"
                         await release_web_key(name, code, holding)
+                        if not holding and lock_held:
+                            action_lock().release()
+                            lock_held = False
             elif t == "tap":
                 name = str(d.get("k", "")).lower()
                 code = KEYS.get(name)
-                if code:
-                    rec["actor"] = "web"
-                    log_action("web", "KEY", name)
-                    await tap(code, DEFAULT_TAP_FRAMES, name)
+                if code and code not in holding:
+                    borrowed = lock_held
+                    if borrowed or await acquire_action_lock():
+                        try:
+                            rec["actor"] = "web"
+                            log_action("web", "KEY", name)
+                            await tap(code, DEFAULT_TAP_FRAMES, name)
+                        finally:
+                            if not borrowed:
+                                action_lock().release()
+                    else:
+                        log_action("web", "KEY", name, detail="busy", ok=False)
             elif t == "keyframe":
                 await send_keyframe(ws)
     finally:
         for code, (name, _) in list(holding.items()):
             LIB.core_key(code, False)
             key_event(name, False)
+        holding.clear()
+        if lock_held:
+            action_lock().release()
         clients.discard(ws)
     return ws
 
@@ -478,6 +517,42 @@ async def wait_core_frames(frames):
         await asyncio.sleep(poll)
 
 
+async def pause_emulator():
+    """Stop between emulated frames before calling reset/serialize APIs."""
+    paused.set()
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 2.0
+    while not paused_ack.is_set():
+        if loop.time() >= deadline:
+            paused.clear()
+            raise RuntimeError("emulator did not pause")
+        await asyncio.sleep(0.005)
+
+
+def resume_emulator():
+    paused.clear()
+    # Do not let a following pause observe the acknowledgement from this one.
+    paused_ack.clear()
+
+
+async def acquire_action_lock():
+    """Acquire the one-player lease shared by REST and browser input."""
+    stats["queued"] += 1
+    try:
+        await asyncio.wait_for(action_lock().acquire(), timeout=LOCK_TIMEOUT)
+        return True
+    except asyncio.TimeoutError:
+        return False
+    finally:
+        stats["queued"] -= 1
+
+
+def action_lock():
+    if api_lock is None:
+        raise RuntimeError("action lock is not initialized")
+    return api_lock
+
+
 async def press_web_key(name, code, holding):
     """Press a browser key once and remember the core tick it reached."""
     if code in holding:
@@ -544,24 +619,29 @@ def held_note(steps):
 async def run_action(request, steps, note, verb="KEY"):
     """Steps are key taps, ``("wait", seconds)`` or ``("frames", count)``.
 
-    Deliberately does not return a screenshot. Encoding a PNG for every
-    keypress cost real CPU on a shared-core box and most of those images were
-    never looked at. Ask for /api/screen when you actually want to see.
+    By default it does not return a screenshot. Encoding a PNG for every
+    keypress cost real CPU on a shared-core box and most were never read. With
+    ``?image=1`` the settled frame is captured before this action releases its
+    lease, so the observation cannot belong to another controller.
 
     One action runs at a time so the game stays coherent when several agents
     act on it, but a caller waiting behind others is told so instead of being
     left to hang.
     """
-    stats["queued"] += 1
     try:
-        await asyncio.wait_for(api_lock.acquire(), timeout=LOCK_TIMEOUT)
-    except asyncio.TimeoutError:
+        settle_args = settle_options(request)
+    except ValueError as exc:
+        return web.json_response({"ok": False, "error": str(exc)}, status=400)
+
+    if not await acquire_action_lock():
         return web.json_response(
             {"ok": False, "error": "busy", "queued": stats["queued"],
              "hint": "another agent holds the game; retry"}, status=503)
-    finally:
-        stats["queued"] -= 1
 
+    image = None
+    image_w = image_h = 0
+    image_mime = ""
+    image_error = ""
     try:
         # Logged before the keys are sent, not after: the panel should show an
         # action starting, not report it once it is already over.
@@ -576,26 +656,120 @@ async def run_action(request, steps, note, verb="KEY"):
                 await wait_core_frames(val)
             else:
                 await tap(kind, val, step[2] if len(step) > 2 else None)
-        waited, changed = await settle(baseline)
+        waited, changed = await settle(baseline, **settle_args)
+        if wants_image(request):
+            try:
+                image, image_w, image_h, image_mime = snapshot("png")
+                if not image:
+                    image_error = "no frame"
+            except Exception as exc:
+                image_error = f"{type(exc).__name__}: {exc}"
     finally:
-        api_lock.release()
+        action_lock().release()
 
-    return web.json_response({
+    result = {
         "ok": True, "action": note, "changed": changed,
         "width": LIB.core_width(), "height": LIB.core_height(),
         "frame": LIB.core_frame_serial(), "settled_frames": waited,
-    })
+    }
+    if image:
+        result.update({
+            "image_width": image_w, "image_height": image_h,
+            "image": f"data:{image_mime};base64," + base64.b64encode(image).decode(),
+        })
+    if image_error:
+        result["image_error"] = image_error
+    return web.json_response(result)
 
 
 async def body_of(request):
     try:
-        return await request.json()
+        body = await request.json()
     except Exception:
-        return {}
+        return None
+    return body if isinstance(body, dict) else None
+
+
+def bounded_int(value, name, default, minimum, maximum):
+    """Parse an integer without silently accepting fractions or booleans."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be an integer")
+    if isinstance(value, float):
+        if not math.isfinite(value) or not value.is_integer():
+            raise ValueError(f"{name} must be an integer")
+        value = int(value)
+    elif not isinstance(value, int):
+        try:
+            value = int(value)
+        except (TypeError, ValueError, OverflowError):
+            raise ValueError(f"{name} must be an integer") from None
+    if not minimum <= value <= maximum:
+        raise ValueError(f"{name} must be between {minimum} and {maximum}")
+    return value
+
+
+def settle_options(request):
+    """Validated headless equivalents of the native API settle controls."""
+    q = request.query
+    react = bounded_int(q.get("react"), "react", 30, 0, 2000)
+    stable = bounded_int(q.get("stable"), "stable", 9, 1, 600)
+    maxframes = bounded_int(q.get("maxsettle"), "maxsettle", 120, 1, 2000)
+    return {"react": react, "stable": stable, "maxframes": max(maxframes, react)}
+
+
+def wants_image(request):
+    return str(request.query.get("image", "0")).lower() in ("1", "true", "yes")
+
+
+def validate_action_frames(count, hold, gap):
+    total = count * (hold + KEY_RELEASE_FRAMES) + max(0, count - 1) * gap
+    if total > MAX_ACTION_FRAMES:
+        raise ValueError(
+            f"action is too long ({total} frames; maximum {MAX_ACTION_FRAMES})"
+        )
 
 
 def keycode(name):
     return KEYS.get(str(name).strip().lower())
+
+
+def state_path(body):
+    raw = body.get("name")
+    if raw is None:
+        slot = bounded_int(body.get("slot"), "slot", 1, 1, 99)
+        raw = f"slot{slot}"
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError("state name must be a non-empty string")
+    clean = "".join(c if c.isalnum() or c in "-_" else "_" for c in raw.strip())[:64]
+    if not clean or clean in (".", ".."):
+        raise ValueError("invalid state name")
+    return pathlib.Path(STATE_DIR) / f"{clean}.state", clean
+
+
+def attach_snapshot(result):
+    data, w, h, mime = snapshot("png")
+    if data:
+        result.update({
+            "width": LIB.core_width(), "height": LIB.core_height(),
+            "frame": LIB.core_frame_serial(),
+            "image_width": w, "image_height": h,
+            "image": f"data:{mime};base64," + base64.b64encode(data).decode(),
+        })
+    else:
+        result["image_error"] = "no frame"
+    return result
+
+
+def core_error(fallback):
+    try:
+        raw = LIB.core_last_error()
+        if raw:
+            return raw.decode(errors="replace")
+    except Exception:
+        pass
+    return fallback
 
 
 # Readable stand-in names, in the register of the game, so an agent that did
@@ -630,43 +804,73 @@ def actor(request):
 
 async def api_key(request):
     d = await body_of(request)
+    if d is None:
+        return web.json_response({"ok": False, "error": "JSON object required"}, status=400)
     code = keycode(d.get("key", ""))
     if not code:
         return web.json_response({"ok": False, "error": "unknown key"}, status=400)
-    hold = int(d.get("hold", DEFAULT_TAP_FRAMES))
-    times = max(1, min(int(d.get("times", 1)), 100))
+    try:
+        hold = bounded_int(d.get("hold"), "hold", DEFAULT_TAP_FRAMES,
+                           1, MAX_HOLD_FRAMES)
+        times = bounded_int(d.get("times"), "times", 1,
+                            1, MAX_KEYS_PER_ACTION)
+        gap = bounded_int(d.get("gap"), "gap", BETWEEN_TAPS_FRAMES,
+                          0, MAX_GAP_FRAMES)
+        validate_action_frames(times, hold, gap)
+    except ValueError as exc:
+        return web.json_response({"ok": False, "error": str(exc)}, status=400)
     name = str(d.get("key")).strip().lower()
     steps = []
     for i in range(times):
         steps.append((code, hold, name))
-        if i != times - 1:
-            steps.append(("frames", BETWEEN_TAPS_FRAMES))
+        if i != times - 1 and gap:
+            steps.append(("frames", gap))
     return await run_action(request, steps, name + (f" x{times}" if times > 1 else ""))
 
 
 async def api_keys(request):
     d = await body_of(request)
+    if d is None:
+        return web.json_response({"ok": False, "error": "JSON object required"}, status=400)
     names = d.get("keys") or []
+    if not isinstance(names, list) or not 1 <= len(names) <= MAX_KEYS_PER_ACTION:
+        return web.json_response(
+            {"ok": False,
+             "error": f"keys must contain between 1 and {MAX_KEYS_PER_ACTION} entries"},
+            status=400,
+        )
     codes = [keycode(k) for k in names]
-    if not names or any(c is None for c in codes):
+    if any(c is None for c in codes):
         return web.json_response({"ok": False, "error": "unknown key in list"}, status=400)
-    hold = int(d.get("hold", DEFAULT_TAP_FRAMES))
+    try:
+        hold = bounded_int(d.get("hold"), "hold", DEFAULT_TAP_FRAMES,
+                           1, MAX_HOLD_FRAMES)
+        gap = bounded_int(d.get("gap"), "gap", BETWEEN_TAPS_FRAMES,
+                          0, MAX_GAP_FRAMES)
+        validate_action_frames(len(names), hold, gap)
+    except ValueError as exc:
+        return web.json_response({"ok": False, "error": str(exc)}, status=400)
     steps = []
     for i, c in enumerate(codes):
         steps.append((c, hold, str(names[i]).strip().lower()))
-        if i != len(codes) - 1:
-            steps.append(("frames", BETWEEN_TAPS_FRAMES))
+        if i != len(codes) - 1 and gap:
+            steps.append(("frames", gap))
     return await run_action(request, steps, " ".join(map(str, names)), verb="KEYS")
 
 
 async def api_wait(request):
     d = await body_of(request)
-    ms = max(0, min(int(d.get("ms", 1000)), 60000))
+    if d is None:
+        return web.json_response({"ok": False, "error": "JSON object required"}, status=400)
+    try:
+        ms = bounded_int(d.get("ms"), "ms", 1000, 0, MAX_WAIT_MS)
+    except ValueError as exc:
+        return web.json_response({"ok": False, "error": str(exc)}, status=400)
     return await run_action(request, [("wait", ms / 1000)], f"{ms}ms", verb="WAIT")
 
 
 async def api_screen(request):
-    """The only way to look at the screen. JSON, or ?format=png|webp for bytes."""
+    """Look without acting. JSON, or ``?format=png|webp`` for raw bytes."""
     fmt = request.query.get("format", "")
     log_action(actor(request), "GET", "screen", thumb=True)
     data, w, h, mime = snapshot("webp" if fmt == "webp" else "png")
@@ -687,6 +891,108 @@ def base_url(request):
     return f"{scheme}://{request.host}"
 
 
+async def api_key_names(_request):
+    return web.json_response({"keys": sorted(KEYS)})
+
+
+async def api_slots(_request):
+    root = pathlib.Path(STATE_DIR)
+    slots = []
+    if root.exists():
+        for path in sorted(root.glob("*.state")):
+            try:
+                stat = path.stat()
+            except OSError:
+                continue
+            slots.append({
+                "name": path.stem, "bytes": stat.st_size,
+                "modified": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(stat.st_mtime)),
+            })
+    return web.json_response({"slots": slots})
+
+
+async def api_save(request):
+    body = await body_of(request)
+    if body is None:
+        return web.json_response({"ok": False, "error": "JSON object required"}, status=400)
+    try:
+        path, name = state_path(body)
+    except ValueError as exc:
+        return web.json_response({"ok": False, "error": str(exc)}, status=400)
+    if not await acquire_action_lock():
+        return web.json_response({"ok": False, "error": "busy"}, status=503)
+    ok = False
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        await pause_emulator()
+        try:
+            LIB.core_release_all_keys()
+            ok = bool(LIB.core_save_state(str(path).encode()))
+            result = {"ok": ok, "slot": name}
+            if not ok:
+                result["error"] = core_error("save failed")
+            if wants_image(request):
+                try:
+                    attach_snapshot(result)
+                except Exception as exc:
+                    result["image_error"] = f"{type(exc).__name__}: {exc}"
+        finally:
+            resume_emulator()
+    except Exception as exc:
+        result = {"ok": False, "slot": name, "error": str(exc)}
+    finally:
+        action_lock().release()
+    log_action(actor(request), "SAVE", name, ok=ok)
+    return web.json_response(result, status=200 if result.get("ok") else 500)
+
+
+async def api_load(request):
+    body = await body_of(request)
+    if body is None:
+        return web.json_response({"ok": False, "error": "JSON object required"}, status=400)
+    try:
+        path, name = state_path(body)
+    except ValueError as exc:
+        return web.json_response({"ok": False, "error": str(exc)}, status=400)
+    if not path.is_file():
+        return web.json_response({"ok": False, "error": "no such slot"}, status=404)
+    if not await acquire_action_lock():
+        return web.json_response({"ok": False, "error": "busy"}, status=503)
+    ok = False
+    try:
+        await pause_emulator()
+        try:
+            LIB.core_release_all_keys()
+            ok = bool(LIB.core_load_state(str(path).encode()))
+            if ok:
+                LIB.fb_reset()
+        finally:
+            resume_emulator()
+        if ok:
+            await wait_core_frames(2)
+        result = {"ok": ok, "slot": name}
+        if not ok:
+            result["error"] = core_error("load failed")
+        if wants_image(request):
+            try:
+                attach_snapshot(result)
+            except Exception as exc:
+                result["image_error"] = f"{type(exc).__name__}: {exc}"
+    except Exception as exc:
+        result = {"ok": False, "slot": name, "error": str(exc)}
+    finally:
+        action_lock().release()
+    log_action(actor(request), "LOAD", name, ok=ok)
+    if ok:
+        await fanout(json.dumps({"t": "clear"}), text=True)
+        for ws in list(clients):
+            try:
+                await asyncio.wait_for(send_keyframe(ws), timeout=SEND_TIMEOUT)
+            except Exception:
+                clients.discard(ws)
+    return web.json_response(result, status=200 if result.get("ok") else 500)
+
+
 async def api_reset(request):
     """Hidden. Reboots the emulated machine back to the title screen and wipes
     the activity log. Unlisted in /api/help and 404s unless the token matches,
@@ -697,9 +1003,8 @@ async def api_reset(request):
         raise web.HTTPNotFound()
 
     restored = False
-    async with api_lock:
-        paused.set()
-        await asyncio.sleep(0.1)          # let the in-flight frame finish
+    async with action_lock():
+        await pause_emulator()
         try:
             LIB.core_release_all_keys()
             if os.path.exists(START_STATE):
@@ -708,7 +1013,7 @@ async def api_reset(request):
                 LIB.core_reset()           # no start state, fall back to a reboot
             LIB.fb_reset()
         finally:
-            paused.clear()
+            resume_emulator()
         history.clear()
         _seq[0] = 0
         session.update(started=time.time(), actions=0, by_api=0, by_web=0)
@@ -719,8 +1024,7 @@ async def api_reset(request):
     await fanout(json.dumps({"t": "clear"}), text=True)
     for ws in list(clients):
         try:
-            async with asyncio.timeout(SEND_TIMEOUT):
-                await send_keyframe(ws)
+            await asyncio.wait_for(send_keyframe(ws), timeout=SEND_TIMEOUT)
         except Exception:
             clients.discard(ws)
     log_action("api", "RESET", "restored start state" if restored else "rebooted to title")
@@ -733,9 +1037,14 @@ async def api_snapshot(request):
     got = request.query.get("token") or request.headers.get("X-Reset-Token")
     if not want or got != want:
         raise web.HTTPNotFound()
-    async with api_lock:
-        os.makedirs(os.path.dirname(START_STATE), exist_ok=True)
-        ok = bool(LIB.core_save_state(START_STATE.encode()))
+    async with action_lock():
+        await pause_emulator()
+        try:
+            os.makedirs(os.path.dirname(START_STATE), exist_ok=True)
+            LIB.core_release_all_keys()
+            ok = bool(LIB.core_save_state(START_STATE.encode()))
+        finally:
+            resume_emulator()
     size = os.path.getsize(START_STATE) if ok and os.path.exists(START_STATE) else 0
     log_action("api", "RESET", "saved start state" if ok else "start state failed", ok=ok)
     return web.json_response({"ok": ok, "path": START_STATE, "bytes": size})
@@ -751,8 +1060,14 @@ async def api_recording(_request):
     })
 
 
-async def api_history(_request):
-    return web.json_response({"history": list(history)})
+async def api_history(request):
+    try:
+        limit = bounded_int(request.query.get("limit"), "limit", 100,
+                            0, MAX_HISTORY_LIMIT)
+    except ValueError as exc:
+        return web.json_response({"ok": False, "error": str(exc)}, status=400)
+    items = list(history)
+    return web.json_response({"history": items[-limit:] if limit else []})
 
 
 async def api_help(request):
@@ -774,6 +1089,13 @@ async def status(_request):
         "fps": round(LIB.core_fps(), 3), "frame": LIB.core_frame_serial(),
         "clients": len(clients), "session": session_summary(), **stats,
     })
+
+
+async def startup(app):
+    global api_lock
+    api_lock = asyncio.Lock()
+    app["pump"] = asyncio.create_task(pump())
+    app["reaper"] = asyncio.create_task(reap())
 
 
 def main():
@@ -799,6 +1121,8 @@ def main():
         web.get("/status", status),
         web.get("/api/screen", api_screen),
         web.get("/api/help", api_help),
+        web.get("/api/keys", api_key_names),
+        web.get("/api/slots", api_slots),
         web.get("/api/history", api_history),
         web.get("/api/recording", api_recording),
         web.post("/api/reset", api_reset),
@@ -806,13 +1130,12 @@ def main():
         web.post("/api/key", api_key),
         web.post("/api/keys", api_keys),
         web.post("/api/wait", api_wait),
+        web.post("/api/save", api_save),
+        web.post("/api/load", api_load),
     ])
-    # on_startup handlers are awaited, so the pump has to be detached as a task
-    # rather than returned, or startup blocks on a loop that never ends.
-    async def _spawn_pump(a):
-        a["pump"] = asyncio.create_task(pump())
-        a["reaper"] = asyncio.create_task(reap())
-    app.on_startup.append(_spawn_pump)
+    # Startup handlers are awaited, so the workers are detached tasks rather
+    # than returned, or startup would block on loops that never end.
+    app.on_startup.append(startup)
     web.run_app(app, host="0.0.0.0", port=PORT, access_log=None)
 
 

--- a/server/server.py
+++ b/server/server.py
@@ -365,6 +365,10 @@ async def ws_handler(request):
     await send_keyframe(ws)
     await ws.send_str(json.dumps({"t": "log", "e": list(history)[-80:],
                                   "s": session_summary()}))
+    # code -> (name, core tick at keydown). Browser automation can emit keydown
+    # and keyup within one emulated frame, so remember when each press reached
+    # the core and fence short pulses on release.
+    holding: dict[int, tuple[str, int]] = {}
     try:
         async for msg in ws:
             if msg.type != WSMsgType.TEXT:
@@ -377,24 +381,23 @@ async def ws_handler(request):
                 if code:
                     down = bool(d.get("down"))
                     rec["actor"] = "web"
-                    LIB.core_key(code, down)
-                    key_event(name, down)
-                    if down:                      # keyup would just double every line
+                    if down and await press_web_key(name, code, holding):
                         log_action("web", "KEY", name)
+                    elif not down:
+                        await release_web_key(name, code, holding)
             elif t == "tap":
                 name = str(d.get("k", "")).lower()
                 code = KEYS.get(name)
                 if code:
                     rec["actor"] = "web"
                     log_action("web", "KEY", name)
-                    LIB.core_key(code, True)
-                    key_event(name, True)
-                    await asyncio.sleep(0.06)
-                    LIB.core_key(code, False)
-                    key_event(name, False)
+                    await tap(code, DEFAULT_TAP_FRAMES, name)
             elif t == "keyframe":
                 await send_keyframe(ws)
     finally:
+        for code, (name, _) in list(holding.items()):
+            LIB.core_key(code, False)
+            key_event(name, False)
         clients.discard(ws)
     return ws
 
@@ -473,6 +476,42 @@ async def wait_core_frames(frames):
         if loop.time() >= deadline:
             raise RuntimeError("emulator frame clock stalled during input")
         await asyncio.sleep(poll)
+
+
+async def press_web_key(name, code, holding):
+    """Press a browser key once and remember the core tick it reached."""
+    if code in holding:
+        return False
+    LIB.core_key(code, True)
+    holding[code] = (name, LIB.core_ticks())
+    key_event(name, True)
+    return True
+
+
+async def release_web_key(name, code, holding):
+    """Release a browser key after it has spanned enough emulated frames.
+
+    Human holds that already exceed the minimum stop immediately. Very short
+    taps are extended only to ``DEFAULT_TAP_FRAMES`` and followed by the normal
+    release fence, making automated browser keypresses as reliable as the REST
+    API without changing long-hold behaviour.
+    """
+    pressed = holding.get(code)
+    if pressed is None:
+        return False
+    pressed_name, pressed_at = pressed
+    elapsed = max(0, LIB.core_ticks() - pressed_at)
+    remaining = max(0, DEFAULT_TAP_FRAMES - elapsed)
+    try:
+        if remaining:
+            await wait_core_frames(remaining)
+    finally:
+        # Cancellation or a dropped socket must never strand a movement key.
+        LIB.core_key(code, False)
+        holding.pop(code, None)
+        key_event(pressed_name or name, False)
+    await wait_core_frames(KEY_RELEASE_FRAMES)
+    return True
 
 
 def key_event(name, down):

--- a/server/test_api.py
+++ b/server/test_api.py
@@ -1,0 +1,172 @@
+import asyncio
+import base64
+import json
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+
+with mock.patch("ctypes.CDLL", return_value=mock.MagicMock()):
+    import server
+
+
+class FakeRequest:
+    def __init__(self, body=None, query=None):
+        self._body = {} if body is None else body
+        self.query = {} if query is None else query
+        self.headers = {}
+        self.remote = "127.0.0.1"
+
+    async def json(self):
+        if isinstance(self._body, Exception):
+            raise self._body
+        return self._body
+
+
+def response_json(response):
+    return json.loads(response.body)
+
+
+class InputValidationTest(unittest.IsolatedAsyncioTestCase):
+    async def test_key_rejects_fractional_hold(self):
+        response = await server.api_key(FakeRequest({"key": "right", "hold": 1.5}))
+        self.assertEqual(response.status, 400)
+        self.assertIn("integer", response_json(response)["error"])
+
+    async def test_keys_honours_requested_gap(self):
+        captured = {}
+
+        async def fake_run(_request, steps, note, verb="KEY"):
+            captured.update(steps=steps, note=note, verb=verb)
+            return object()
+
+        with mock.patch.object(server, "run_action", fake_run):
+            marker = await server.api_keys(
+                FakeRequest({"keys": ["up", "enter"], "hold": 10, "gap": 17})
+            )
+
+        self.assertIsNotNone(marker)
+        self.assertEqual(
+            captured["steps"],
+            [(server.KEYS["up"], 10, "up"), ("frames", 17),
+             (server.KEYS["enter"], 10, "enter")],
+        )
+
+    async def test_oversized_action_is_rejected(self):
+        response = await server.api_key(
+            FakeRequest({"key": "right", "times": 100, "hold": 100})
+        )
+        self.assertEqual(response.status, 400)
+        self.assertIn("too long", response_json(response)["error"])
+
+    async def test_zero_gap_does_not_insert_a_frame(self):
+        captured = {}
+
+        async def fake_run(_request, steps, _note, verb="KEY"):
+            captured["steps"] = steps
+            return object()
+
+        with mock.patch.object(server, "run_action", fake_run):
+            await server.api_keys(
+                FakeRequest({"keys": ["up", "enter"], "gap": 0})
+            )
+        self.assertEqual(len(captured["steps"]), 2)
+
+    async def test_non_object_json_is_rejected(self):
+        response = await server.api_wait(FakeRequest([1000]))
+        self.assertEqual(response.status, 400)
+
+
+class HistoryTest(unittest.IsolatedAsyncioTestCase):
+    async def test_history_limit_returns_only_newest_entries(self):
+        old = server.history
+        server.history = server.collections.deque(
+            ({"id": i} for i in range(8)), maxlen=server.MAX_HISTORY_LIMIT
+        )
+        try:
+            response = await server.api_history(FakeRequest(query={"limit": "3"}))
+        finally:
+            server.history = old
+        self.assertEqual([item["id"] for item in response_json(response)["history"]], [5, 6, 7])
+
+    async def test_history_rejects_invalid_limit(self):
+        response = await server.api_history(FakeRequest(query={"limit": "all"}))
+        self.assertEqual(response.status, 400)
+
+
+class StatePathTest(unittest.TestCase):
+    def test_state_name_cannot_escape_state_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.object(server, "STATE_DIR", tmp):
+                path, name = server.state_path({"name": "../../checkpoint"})
+            self.assertEqual(path.parent, pathlib.Path(tmp))
+            self.assertEqual(path.name, f"{name}.state")
+            self.assertNotIn("..", path.name)
+
+
+class AtomicObservationTest(unittest.IsolatedAsyncioTestCase):
+    async def test_action_lock_is_created_on_the_serving_event_loop(self):
+        app = {}
+        old_lock = server.api_lock
+        await server.startup(app)
+        waiter = None
+        try:
+            lock = server.action_lock()
+            await lock.acquire()
+            waiter = asyncio.create_task(server.acquire_action_lock())
+            await asyncio.sleep(0)
+            self.assertFalse(waiter.done())
+            lock.release()
+            self.assertTrue(await waiter)
+            lock.release()
+        finally:
+            if waiter and not waiter.done():
+                waiter.cancel()
+            for task in app.values():
+                task.cancel()
+            await asyncio.gather(*app.values(), return_exceptions=True)
+            server.api_lock = old_lock
+
+    async def test_requested_image_is_captured_before_action_lock_releases(self):
+        fake_lib = mock.MagicMock()
+        fake_lib.core_frame_hash.return_value = 1
+        fake_lib.core_width.return_value = 320
+        fake_lib.core_height.return_value = 200
+        fake_lib.core_frame_serial.return_value = 42
+        fake_lib.core_fps.return_value = 70.0
+
+        async def fake_tap(*_args):
+            return None
+
+        async def fake_settle(*_args, **_kwargs):
+            return 9, True
+
+        def fake_snapshot(_format):
+            self.assertTrue(server.api_lock.locked())
+            return b"png", 320, 200, "image/png"
+
+        old_lock = server.api_lock
+        test_lock = asyncio.Lock()
+        server.api_lock = test_lock
+        try:
+            with mock.patch.object(server, "LIB", fake_lib), \
+                 mock.patch.object(server, "tap", fake_tap), \
+                 mock.patch.object(server, "settle", fake_settle), \
+                 mock.patch.object(server, "snapshot", fake_snapshot), \
+                 mock.patch.object(server, "log_action", lambda *_a, **_k: None):
+                response = await server.run_action(
+                    FakeRequest(query={"image": "1"}),
+                    [(server.KEYS["right"], 10, "right")],
+                    "right",
+                )
+        finally:
+            server.api_lock = old_lock
+
+        result = response_json(response)
+        self.assertFalse(test_lock.locked())
+        self.assertEqual(base64.b64decode(result["image"].split(",", 1)[1]), b"png")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/test_input_timing.py
+++ b/server/test_input_timing.py
@@ -1,0 +1,101 @@
+import asyncio
+import unittest
+from unittest import mock
+
+
+# server.py binds the native core at import time. These tests exercise only the
+# input scheduler, so use a placeholder library and replace it per test.
+with mock.patch("ctypes.CDLL", return_value=mock.MagicMock()):
+    import server
+
+
+class FakeLib:
+    def __init__(self):
+        self.tick = 0
+        self.events = []
+
+    def core_ticks(self):
+        return self.tick
+
+    def core_key(self, code, down):
+        self.events.append((self.tick, code, down))
+
+
+class BrowserInputTimingTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.lib = FakeLib()
+        self.waits = []
+        self.key_events = []
+
+        async def wait_frames(frames):
+            self.waits.append(frames)
+            self.lib.tick += frames
+
+        self.patches = [
+            mock.patch.object(server, "LIB", self.lib),
+            mock.patch.object(server, "wait_core_frames", wait_frames),
+            mock.patch.object(
+                server, "key_event",
+                lambda name, down: self.key_events.append((name, down)),
+            ),
+        ]
+        for patch in self.patches:
+            patch.start()
+
+    async def asyncTearDown(self):
+        for patch in reversed(self.patches):
+            patch.stop()
+
+    async def test_short_tap_is_held_for_minimum_core_frames(self):
+        holding = {}
+        self.assertTrue(await server.press_web_key("right", 275, holding))
+        self.lib.tick = 1
+
+        self.assertTrue(await server.release_web_key("right", 275, holding))
+
+        self.assertEqual(self.lib.events, [(0, 275, True), (10, 275, False)])
+        self.assertEqual(self.waits, [9, server.KEY_RELEASE_FRAMES])
+        self.assertEqual(self.key_events, [("right", True), ("right", False)])
+        self.assertEqual(holding, {})
+
+    async def test_long_human_hold_releases_without_added_hold_delay(self):
+        holding = {}
+        await server.press_web_key("up", 273, holding)
+        self.lib.tick = server.DEFAULT_TAP_FRAMES + 5
+
+        await server.release_web_key("up", 273, holding)
+
+        self.assertEqual(
+            self.lib.events,
+            [(0, 273, True), (server.DEFAULT_TAP_FRAMES + 5, 273, False)],
+        )
+        self.assertEqual(self.waits, [server.KEY_RELEASE_FRAMES])
+
+    async def test_duplicate_keydown_does_not_restart_the_hold_window(self):
+        holding = {}
+        self.assertTrue(await server.press_web_key("left", 276, holding))
+        self.lib.tick = 4
+        self.assertFalse(await server.press_web_key("left", 276, holding))
+
+        await server.release_web_key("left", 276, holding)
+
+        self.assertEqual(self.lib.events, [(0, 276, True), (10, 276, False)])
+        self.assertEqual(self.key_events, [("left", True), ("left", False)])
+
+    async def test_cancelled_wait_still_releases_the_key(self):
+        holding = {}
+        await server.press_web_key("down", 274, holding)
+
+        async def cancel_wait(_frames):
+            raise asyncio.CancelledError
+
+        with mock.patch.object(server, "wait_core_frames", cancel_wait):
+            with self.assertRaises(asyncio.CancelledError):
+                await server.release_web_key("down", 274, holding)
+
+        self.assertEqual(self.lib.events, [(0, 274, True), (0, 274, False)])
+        self.assertEqual(holding, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/play.en.md
+++ b/skills/play.en.md
@@ -6,9 +6,10 @@ how you play it is up to you.
 
 ## The loop
 
-Acting and looking are separate calls. A key press applies your input and waits
-for the screen to settle, but returns no picture; `GET /api/screen` returns one.
-Act, then look when you need to see. Sending a few keys and looking once is fine.
+By default, acting and looking are separate calls. A key press waits for the
+screen to settle and returns metadata; `GET /api/screen` returns the picture.
+Add `?image=1` to an action URL when you need the resulting picture atomically,
+before another player can act. Sending a few keys and looking once is also fine.
 
 The game is entirely in Traditional Chinese, and the text is where everything
 happens: objectives, choices, and prompts that expect a specific key.
@@ -19,11 +20,14 @@ happens: objectives, choices, and prompts that expect a specific key.
     POST {BASE}/api/key   {{"key":"kp3"}}           one key; +"times", +"hold"
     POST {BASE}/api/keys  {{"keys":["kp9","enter"]}} several, in order
     POST {BASE}/api/wait  {{"ms":1000}}             let the game run
+    GET  {BASE}/api/slots                         list emulator snapshots
+    POST {BASE}/api/save  {{"name":"checkpoint"}}   save a snapshot
+    POST {BASE}/api/load  {{"name":"checkpoint"}}   restore a snapshot
     GET  {BASE}/api/help                          this skill
 
-Only `/api/screen` returns a picture: JSON with `image`, a base64 PNG data URI
-(`?format=png` or `?format=webp` for raw bytes). Action calls return `changed`
-and `frame` only.
+`/api/screen` returns JSON with `image`, a base64 PNG data URI (`?format=png` or
+`?format=webp` for raw bytes). Action calls return `changed` and `frame`, and
+also return the same `image` when called with `?image=1`.
 
     curl -s -X POST {BASE}/api/key -H 'content-type: application/json' \
          -d '{{"key":"enter"}}'
@@ -129,7 +133,7 @@ differ, trust your own compass): 主角居 (357,235), 河洛客棧 (359,229),
 
 You are 小蝦米, a modern student who buys a VR copy of this very game and wakes
 inside the world of Jin Yong's wuxia novels. Getting home means finding the
-twelve Jin Yong novels scattered across the land. Characters from those novels
+fourteen Jin Yong novels scattered across the land. Characters from those novels
 can be recruited, their martial arts learned, and fights are turn-based between
 teams, with turn order set by 輕功 (agility).
 

--- a/skills/play.zh.md
+++ b/skills/play.zh.md
@@ -5,8 +5,9 @@
 
 ## 運作方式
 
-「動作」和「看畫面」是分開的呼叫。送按鍵會等畫面穩定，但不回傳圖片；要看畫面
-請用 `GET /api/screen`。先動作，需要時再看。連送幾個鍵、最後看一次也可以。
+預設把「動作」和「看畫面」分成兩次呼叫。送按鍵會等畫面穩定並回傳狀態；要看畫面
+請用 `GET /api/screen`。若需要保證看到的就是自己剛才動作的結果，可在動作 URL 加
+`?image=1`，伺服器會在讓下一位操作者行動前一併截圖。連送幾個鍵、最後看一次也可以。
 
 遊戲全是繁體中文，而所有事情都發生在文字裡：目標、選擇，以及等待特定按鍵的提問。
 
@@ -16,11 +17,14 @@
     POST {BASE}/api/key   {{"key":"kp3"}}           單鍵；可加 "times"、"hold"
     POST {BASE}/api/keys  {{"keys":["kp9","enter"]}} 依序送出多鍵
     POST {BASE}/api/wait  {{"ms":1000}}             讓遊戲自己跑一段時間
+    GET  {BASE}/api/slots                         列出模擬器快照
+    POST {BASE}/api/save  {{"name":"checkpoint"}}   儲存快照
+    POST {BASE}/api/load  {{"name":"checkpoint"}}   還原快照
     GET  {BASE}/api/help                          本技能說明
 
-只有 `/api/screen` 會回傳畫面：JSON 含 `image`，是 base64 的 PNG data URI
-（加 `?format=png` 或 `?format=webp` 可直接取得位元組）。動作類呼叫只回傳
-`changed` 與 `frame`。
+`/api/screen` 會回傳畫面：JSON 含 `image`，是 base64 的 PNG data URI（加
+`?format=png` 或 `?format=webp` 可直接取得位元組）。動作類呼叫預設回傳
+`changed` 與 `frame`；加 `?image=1` 也會回傳同樣的 `image`。
 
     curl -s -X POST {BASE}/api/key -H 'content-type: application/json' \
          -d '{{"key":"enter"}}'
@@ -111,7 +115,7 @@ f1-f12、tab、backspace。
 ## 這個世界
 
 你是小蝦米，一個買了本遊戲 VR 版的現代學生，醒來後發現自己身處金庸武俠小說的
-世界。想回到現代，就得找齊散落各地的十二本金庸小說。小說中的人物可以招募入隊、
+世界。想回到現代，就得找齊散落各地的十四本金庸小說。小說中的人物可以招募入隊、
 可以習得他們的武功；戰鬥是團隊回合制，出手順序由**輕功**高低決定。
 
 只有主角死亡才會結束遊戲，隊友戰敗只是重傷退場，之後還能再上。看到任何像是「被


### PR DESCRIPTION
## Summary

- frame-fence browser WebSocket key releases so very short automated keypresses reach the DOS core
- preserve immediate release for genuine long holds and release held keys on cancellation or disconnect
- route WebSocket tap messages through the existing core-frame scheduler
- add regression coverage for short taps, long holds, duplicate keydown events, and cancelled waits

## Why

The browser sends keydown and keyup as separate WebSocket messages. Unlike the REST key endpoint, the WebSocket handler previously toggled the core key state immediately, so fast automated keypresses could press and release within one emulated frame. The game would never sample the pressed state, making movement intermittent.

Short browser taps now span the same 10 emulated frames used by the REST API. Human holds that already exceed that minimum still stop immediately on keyup.

## Validation

- `cd server && python -m unittest -v test_input_timing.py`
- `python -m py_compile server.py test_input_timing.py`
- live browser validation: rapid directional taps, Enter, Space, and Escape all produced reliable responses
- long-hold validation: a 0.45 s movement hold stopped immediately after release and remained stationary while idle
