### PR TITLE
Reset activity log after server restart

### DIFF
--- a/server/index.html
+++ b/server/index.html
@@ -513,7 +513,20 @@ function connect() {
   sock.onmessage = e => {
     if (typeof e.data === "string") {
       const m = JSON.parse(e.data);
-      if (m.t === "log") { m.e.forEach(addLog); if (m.s) setMeter(m.s); }
+      if (m.t === "log") {
+        // A process restart resets history ids and session counters. Clear the
+        // old panel before accepting the new backlog, otherwise deduplication
+        // hides every fresh entry until ids catch up.
+        if (m.s && meter) {
+          const oldUptime = meter.uptime_s + (Date.now() - meterAt) / 1000;
+          const restarted = m.s.started_at !== undefined && meter.started_at !== undefined
+            ? m.s.started_at !== meter.started_at
+            : m.s.actions < meter.actions || m.s.uptime_s + 3 < oldUptime;
+          if (restarted) clearLog();
+        }
+        m.e.forEach(addLog);
+        if (m.s) setMeter(m.s);
+      }
       else if (m.t === "key") { holdKey(m.k, m.down); noteKeyTiming(m.k, m.down); }
       else if (m.t === "clear") clearLog();
     } else {

--- a/server/server.py
+++ b/server/server.py
@@ -700,7 +700,8 @@ def note_screen():
 
 
 def session_summary():
-    return {"uptime_s": round(time.time() - session["started"], 1),
+    return {"started_at": session["started"],
+            "uptime_s": round(time.time() - session["started"], 1),
             "actions": session["actions"],
             "meaningful": beh["meaningful"],
             "oscillation": beh["oscillation"],


### PR DESCRIPTION
## Problem
When the backend process restarts, the browser reconnects without reloading. The new process starts activity IDs from zero, while the page keeps its previous `lastId`, so the reconnect backlog and new log entries are discarded as duplicates until IDs catch up.

## Fix
- Include `started_at` in `session_summary()`.
- Detect a new session in the browser before applying the log backlog and reset the activity log/deduplication state.
- Keep an actions/uptime fallback for older servers that do not send `started_at`.

This is display-only telemetry; it does not change game input, saves, recording, or benchmark scoring. The change also covers a client that missed the in-process reset broadcast.

Validated with Python syntax and JavaScript syntax checks. This branch applies the same minimal fix to `bench-automation`.