### PR TITLE
Align the MCP benchmark contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,11 @@ model has the API, the controls, the isometric axes and the traps.
 `skills/jyxzz-speedrun-tips/SKILL.md` is the original research the field manual
 came from. Edit that first, then fold anything durable into the served files.
 
-`mcp-server/` wraps the same surface over MCP for clients that speak it.
+`mcp-server/` wraps the same surface over MCP 2.x for clients that speak it.
+It loads guidance from the same `skills/` files as `/api/help`. Set
+`QUNXIA_MCP_PROFILE=benchmark` to expose only `look`, `press`,
+`press_sequence`, and `wait`; benchmark actions return metadata and `look`
+returns the native 320x200 frame. Standalone mode keeps the convenience tools.
 
 ## Session recording
 

--- a/README.md
+++ b/README.md
@@ -248,10 +248,15 @@ model has the API, the controls, the isometric axes and the traps.
 came from. Edit that first, then fold anything durable into the served files.
 
 `mcp-server/` wraps the same surface over MCP 2.x for clients that speak it.
-It loads guidance from the same `skills/` files as `/api/help`. Set
+Standalone mode loads guidance from the same `skills/` files as `/api/help`. Set
 `QUNXIA_MCP_PROFILE=benchmark` to expose only `look`, `press`,
 `press_sequence`, and `wait`; benchmark actions return metadata and `look`
 returns the native 320x200 frame. Standalone mode keeps the convenience tools.
+For benchmark mode, first create a session, then set `QUNXIA_API` to the returned
+`base_url` plus `/api`. MCP reads that session's `/api/help` at startup;
+`QUNXIA_BENCH_LANG=en|zh` selects the guide language. The client must include the
+MCP initialization `instructions` in the model's context: benchmark mode has no
+`guide` tool fallback.
 
 ## Session recording
 

--- a/mcp-server/ADAPTER.md
+++ b/mcp-server/ADAPTER.md
@@ -8,8 +8,8 @@ raw HTTP endpoints; use their MCP equivalents instead:
 
 {ACTION_BEHAVIOR}
 
-The MCP server is already connected to the game. Do not use curl, a browser,
-the host filesystem, or another transport.
+The MCP server is already connected to the game. Use the MCP tools above rather
+than the raw HTTP examples in the guide.
 
 {SESSION_BEHAVIOR}
 

--- a/mcp-server/ADAPTER.md
+++ b/mcp-server/ADAPTER.md
@@ -1,0 +1,16 @@
+You are controlling the game through MCP. The canonical guide below describes
+raw HTTP endpoints; use their MCP equivalents instead:
+
+- `GET /api/screen` -> `look`
+- `POST /api/key` -> `press`
+- `POST /api/keys` -> `press_sequence`
+- `POST /api/wait` -> `wait`
+
+{ACTION_BEHAVIOR}
+
+The MCP server is already connected to the game. Do not use curl, a browser,
+the host filesystem, or another transport.
+
+{SESSION_BEHAVIOR}
+
+--- BEGIN CANONICAL GAME GUIDE ---

--- a/mcp-server/game_knowledge.py
+++ b/mcp-server/game_knowledge.py
@@ -16,7 +16,8 @@ def guide(base, language="en"):
     return text.replace("{BASE}", base).replace("{{", "{").replace("}}", "}")
 
 
-def mcp_guide(base, language="en", benchmark=False):
+def adapt_guide(canonical, benchmark=False):
+    """Add MCP tool/session semantics to an already resolved game guide."""
     adapter = ADAPTER.read_text(encoding="utf-8")
     if benchmark:
         action = "Actions return metadata only. Call `look` when you need the next visible frame."
@@ -33,4 +34,8 @@ def mcp_guide(base, language="en", benchmark=False):
         session = "Follow the connected game's session rules in the canonical guide."
     adapter = adapter.replace("{ACTION_BEHAVIOR}", action)
     adapter = adapter.replace("{SESSION_BEHAVIOR}", session).rstrip()
-    return adapter + "\n\n" + guide(base, language)
+    return adapter + "\n\n" + canonical
+
+
+def mcp_guide(base, language="en", benchmark=False):
+    return adapt_guide(guide(base, language), benchmark)

--- a/mcp-server/game_knowledge.py
+++ b/mcp-server/game_knowledge.py
@@ -1,85 +1,36 @@
-"""Everything an agent needs to know to play 金庸群俠傳 (1996, DOS).
+"""Load MCP guidance from the same reviewed skills served by /api/help."""
 
-Kept separate from the transport so the wording can be tuned without touching
-the tool plumbing. Facts marked (verified) were measured against this build.
-"""
+import pathlib
 
-INSTRUCTIONS = """
-You are playing 金庸群俠傳 (The Legend of Jin Yong Heroes), the original 1996
-DOS game by 河洛工作室, running under emulation. You drive it with a keyboard
-only. There is no mouse.
 
-HOW TO PLAY WITH THESE TOOLS
-Every action tool returns a PNG of the screen after the action has been applied
-and the picture has stopped changing. Look at that image before choosing the
-next action. One tool call is one action and one observation. Do not batch long
-blind sequences: read each screen.
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SKILLS = ROOT / "skills"
+ADAPTER = pathlib.Path(__file__).resolve().parent / "ADAPTER.md"
 
-The game is entirely in Traditional Chinese. Read the dialogue. It carries the
-objectives, and several screens are yes/no or menu choices where pressing the
-wrong key changes the run.
 
-CONTROLS
-- arrow up/down/left/right: walk on the map, and move the highlight in menus.
-  One press turns the character to face that way and steps one tile if the tile
-  is not blocked. Walking into a person or object is what triggers it.
-- enter (or space): confirm a menu choice, advance dialogue, and interact with
-  whatever you are facing. In the world these two keys are equivalent.
-- esc: open the main menu (醫療 heal / 解毒 cure poison / 物品 items / 狀態
-  status). Press esc again to close it.
-- y / n: answer 是/否 prompts, which the game writes as （Ｙ／Ｎ）.
-- k: light a torch inside caves. l: clear fog inside caves.
+def guide(base, language="en"):
+    name = "zh" if str(language).lower().startswith("zh") else "en"
+    play = (SKILLS / f"play.{name}.md").read_text(encoding="utf-8")
+    speedrun = (SKILLS / f"speedrun.{name}.md").read_text(encoding="utf-8")
+    text = play.rstrip() + "\n\n" + speedrun
+    return text.replace("{BASE}", base).replace("{{", "{").replace("}}", "}")
 
-THE ONE THING THAT WILL CONFUSE YOU
-While a scripted event or cutscene is playing, the game ignores movement and
-menu keys completely. Any key you send only advances the dialogue. So if arrows
-do not move the character and esc does not open the menu, you are still inside a
-cutscene: keep pressing enter and reading until it ends. Do not conclude the
-controls are broken. A reliable check for "am I free to move": press esc, and
-see whether the 醫療/解毒/物品/狀態 menu appears. (verified)
 
-ENTERING A CHINESE NAME
-Character naming uses the game's own 注音 (bopomofo) IME in the 大千 layout.
-Type the zhuyin letters, then press the digit next to the character you want.
-Layout:
-  1ㄅ 2ㄉ 3ˇ 4ˋ 5ㄓ 6ˊ 7˙ 8ㄚ 9ㄞ 0ㄢ -ㄦ
-  qㄆ wㄊ eㄍ rㄐ tㄔ yㄗ uㄧ iㄛ oㄟ pㄣ
-  aㄇ sㄋ dㄎ fㄑ gㄕ hㄘ jㄨ kㄜ lㄠ ;ㄤ
-  zㄈ xㄌ cㄏ vㄒ bㄖ nㄙ mㄩ ,ㄝ .ㄡ /ㄥ
-Tones: 1st = space, 2nd = 6, 3rd = 3, 4th = 4, neutral = 7.
-Example: 王 is ㄨㄤˊ, so type "j;6" then press "1" to pick 王. (verified)
-
-THE STORY AND YOUR GOAL
-You play 小蝦米, a modern student who buys a VR copy of this very game and wakes
-up inside the world of Jin Yong's novels. To get home you must find the twelve
-Jin Yong novels scattered across the world. Along the way you recruit famous
-characters into your party, learn their martial arts, and fight turn-based team
-battles.
-
-Opening sequence: you wake on the floor of a room. Talk to the 軟體娃娃 (the
-floating VR helmet). It tells you to leave and ask at the inn across the way
-(河洛客棧). There you find the waiter 韋小寶; tip him some silver and he points
-you to 南賢. Pick up the few items lying in the starting room before you leave.
-
-PACING
-Booting the emulator to the title screen takes about 14 seconds. From the title,
-重新開始 starts a new game, 載入進度 loads, 離開遊戲 quits. Use save_state before
-anything risky: these are emulator snapshots and restore exactly, which the
-game's own save system cannot do mid-scene.
-"""
-
-GUIDE = INSTRUCTIONS + """
-
-KEY NAMES ACCEPTED BY press / press_sequence
-  up down left right
-  enter (aliases: ok, confirm)   space
-  esc (aliases: cancel, back)
-  y n   a-z   0-9   f1-f12
-  tab backspace delete home end pageup pagedown
-  shift ctrl alt, and combos such as "alt+x"
-
-TUNING THE WAIT
-Each action waits for the screen to react and then to hold still. If a tool
-returns a half-drawn dialogue line, raise `stable`. If an action legitimately
-does nothing, the result says changed=false after the react budget expires.
-"""
+def mcp_guide(base, language="en", benchmark=False):
+    adapter = ADAPTER.read_text(encoding="utf-8")
+    if benchmark:
+        action = "Actions return metadata only. Call `look` when you need the next visible frame."
+        session = (
+            "This benchmark session is isolated, already created, and starts with a named "
+            "character in the opening room. Generic shared-session or `X-Agent` wording in "
+            "the guide does not apply. Keep playing until a tool reports `BENCHMARK ENDED`."
+        )
+    else:
+        action = (
+            "Action tools return the resulting frame when the connected API provides one. "
+            "Call `look` whenever you need a fresh visible frame."
+        )
+        session = "Follow the connected game's session rules in the canonical guide."
+    adapter = adapter.replace("{ACTION_BEHAVIOR}", action)
+    adapter = adapter.replace("{SESSION_BEHAVIOR}", session).rstrip()
+    return adapter + "\n\n" + guide(base, language)

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -25,6 +25,11 @@ BENCHMARK = PROFILE == "benchmark"
 DEFAULT_SCALE = int(os.environ.get("QUNXIA_SCALE", "1" if BENCHMARK else "2"))
 BASE = API[:-4] if API.endswith("/api") else API
 LANGUAGE = os.environ.get("QUNXIA_BENCH_LANG", "en")
+MAX_KEYS_PER_ACTION = 32
+MAX_HOLD_FRAMES = 600
+MAX_GAP_FRAMES = 600
+MAX_STABLE_FRAMES = 600
+MAX_WAIT_MS = 60000
 
 
 def _benchmark_guide():
@@ -54,6 +59,13 @@ def expose(enabled=True):
 
 class GameOffline(RuntimeError):
     pass
+
+
+def _bounded_int(name, value, minimum, maximum):
+    if (isinstance(value, bool) or not isinstance(value, int)
+            or not minimum <= value <= maximum):
+        raise ValueError(f"{name} must be an integer from {minimum} to {maximum}")
+    return value
 
 
 def _call(method, path, payload=None, timeout=240):
@@ -158,6 +170,11 @@ def press(key: str, times: int = 1, hold: int = None, stable: int = None) -> lis
 
     Remember: during a cutscene every key just advances the dialogue.
     """
+    times = _bounded_int("times", times, 1, MAX_KEYS_PER_ACTION)
+    if hold is not None:
+        hold = _bounded_int("hold", hold, 1, MAX_HOLD_FRAMES)
+    if stable is not None:
+        stable = _bounded_int("stable", stable, 1, MAX_STABLE_FRAMES)
     payload = {"hold": hold} if hold is not None else {}
     if times > 1:
         return _act("/keys", {"keys": [key] * times, **payload},
@@ -173,6 +190,11 @@ def press_sequence(keys: list[str], gap: int = 6, stable: int = None) -> list:
     single presses when you are unsure what a screen will do, because you only
     see the result of the last key here.
     """
+    if not 1 <= len(keys) <= MAX_KEYS_PER_ACTION:
+        raise ValueError(f"keys must contain from 1 to {MAX_KEYS_PER_ACTION} entries")
+    gap = _bounded_int("gap", gap, 0, MAX_GAP_FRAMES)
+    if stable is not None:
+        stable = _bounded_int("stable", stable, 1, MAX_STABLE_FRAMES)
     return _act("/keys", {"keys": keys, "gap": gap},
                 note=" ".join(keys), stable=stable)
 
@@ -187,7 +209,8 @@ def move(direction: str, steps: int = 1) -> list:
     """
     if direction not in ("up", "down", "left", "right"):
         raise ValueError("direction must be up, down, left or right")
-    return _act("/keys", {"keys": [direction] * max(1, steps), "gap": 6},
+    steps = _bounded_int("steps", steps, 1, MAX_KEYS_PER_ACTION)
+    return _act("/keys", {"keys": [direction] * steps, "gap": 6},
                 note=f"move {direction} x{steps}")
 
 
@@ -199,6 +222,7 @@ def wait(ms: int = 1000) -> list:
     world map. Benchmark mode returns metadata only; call look when you need
     the next visible frame.
     """
+    ms = _bounded_int("ms", ms, 0, MAX_WAIT_MS)
     return _act("/wait", {"ms": ms}, note=f"wait {ms}ms")
 
 

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 """MCP server exposing 金庸群俠傳 to any LLM agent.
 
-Wraps the QunXia HTTP control API. Every action tool returns the resulting
-screen as an image, so the agent sees what its input did.
-
-Run:  uv run --with mcp mcp-server/server.py
+Run:  uv run --with 'mcp>=2,<3' mcp-server/server.py
 """
 import base64
 import json
@@ -14,15 +11,26 @@ import urllib.error
 import urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from game_knowledge import GUIDE, INSTRUCTIONS
+from game_knowledge import mcp_guide as build_guide
 
 from mcp.server.mcpserver import MCPServer
 from mcp.types import ImageContent, TextContent
 
-API = os.environ.get("QUNXIA_API", "http://127.0.0.1:8765")
-DEFAULT_SCALE = int(os.environ.get("QUNXIA_SCALE", "2"))
+API = os.environ.get("QUNXIA_API", "http://127.0.0.1:8765").rstrip("/")
+PROFILE = os.environ.get("QUNXIA_MCP_PROFILE", "standalone")
+if PROFILE not in ("standalone", "benchmark"):
+    raise ValueError("QUNXIA_MCP_PROFILE must be standalone or benchmark")
+BENCHMARK = PROFILE == "benchmark"
+DEFAULT_SCALE = int(os.environ.get("QUNXIA_SCALE", "1" if BENCHMARK else "2"))
+BASE = API[:-4] if API.endswith("/api") else API
+GUIDE = build_guide(BASE, os.environ.get("QUNXIA_BENCH_LANG", "en"), BENCHMARK)
 
-mcp = MCPServer("qunxia", instructions=INSTRUCTIONS)
+mcp = MCPServer("qunxia", instructions=GUIDE)
+
+
+def expose(enabled=True):
+    """Register convenience tools only outside scored benchmark mode."""
+    return mcp.tool() if enabled else (lambda function: function)
 
 
 class GameOffline(RuntimeError):
@@ -53,6 +61,12 @@ def _call(method, path, payload=None, timeout=240):
 
 def _result(res, note=""):
     """Turn an API response into MCP content: a short status line plus the screen."""
+    if res.get("ended"):
+        return [TextContent(type="text", text="BENCHMARK ENDED | " + json.dumps({
+            key: res.get(key) for key in (
+                "reason", "why", "actions", "played_seconds",
+                "video_url", "video_pending")
+        }, ensure_ascii=False))]
     out = []
     bits = []
     if not res.get("ok", True):
@@ -78,6 +92,8 @@ def _result(res, note=""):
 
 def _act(path, payload, note="", **params):
     q = {"scale": DEFAULT_SCALE}
+    if BENCHMARK:
+        q["image"] = 0
     q.update({k: v for k, v in params.items() if v is not None})
     qs = "&".join(f"{k}={v}" for k, v in q.items())
     return _result(_call("POST", f"{path}?{qs}", payload), note)
@@ -95,10 +111,9 @@ def look() -> list:
     return _result(_call("GET", "/screen"))
 
 
-@mcp.tool()
+@expose(not BENCHMARK)
 def guide() -> str:
-    """The full manual: controls, the 注音 name-entry layout, the story and
-    objectives, and the cutscene gotcha. Read this before your first action."""
+    """The canonical game manual plus the MCP tool-name mapping."""
     return GUIDE
 
 
@@ -106,7 +121,7 @@ def guide() -> str:
 
 @mcp.tool()
 def press(key: str, times: int = 1, hold: int = 4, stable: int = None) -> list:
-    """Press one key and return the screen it produced.
+    """Press one key. In benchmark mode, call look after acting.
 
     key: up, down, left, right, enter (or ok), space, esc, y, n, a-z, 0-9,
          f1-f12, tab, backspace, or a combo like "alt+x".
@@ -127,7 +142,7 @@ def press(key: str, times: int = 1, hold: int = 4, stable: int = None) -> list:
 
 @mcp.tool()
 def press_sequence(keys: list[str], gap: int = 6, stable: int = None) -> list:
-    """Press several different keys in order, returning only the final screen.
+    """Press several different keys in order.
 
     Use for a known menu path, e.g. ["esc", "down", "down", "enter"]. Prefer
     single presses when you are unsure what a screen will do, because you only
@@ -137,7 +152,7 @@ def press_sequence(keys: list[str], gap: int = 6, stable: int = None) -> list:
                 note=" ".join(keys), stable=stable)
 
 
-@mcp.tool()
+@expose(not BENCHMARK)
 def move(direction: str, steps: int = 1) -> list:
     """Walk. direction is up, down, left, right.
 
@@ -151,14 +166,14 @@ def move(direction: str, steps: int = 1) -> list:
                 note=f"move {direction} x{steps}")
 
 
-@mcp.tool()
+@expose(not BENCHMARK)
 def interact() -> list:
     """Interact with whatever the character is facing, confirm a menu choice,
     or advance one line of dialogue. This sends enter."""
     return _act("/key", {"key": "enter"}, note="interact")
 
 
-@mcp.tool()
+@expose(not BENCHMARK)
 def open_menu() -> list:
     """Open the in-game main menu (醫療 / 解毒 / 物品 / 狀態) by sending esc.
 
@@ -180,7 +195,7 @@ def wait(ms: int = 1000) -> list:
 
 # ----------------------------------------------------------------- savestates
 
-@mcp.tool()
+@expose(not BENCHMARK)
 def save_state(name: str = "agent") -> list:
     """Snapshot the whole emulator under this name.
 
@@ -190,7 +205,7 @@ def save_state(name: str = "agent") -> list:
     return _act("/save", {"name": name}, note=f"save {name}")
 
 
-@mcp.tool()
+@expose(not BENCHMARK)
 def load_state(name: str = "agent") -> list:
     """Restore a snapshot taken by save_state.
 
@@ -200,13 +215,13 @@ def load_state(name: str = "agent") -> list:
     return _act("/load", {"name": name}, note=f"load {name}")
 
 
-@mcp.tool()
+@expose(not BENCHMARK)
 def list_states() -> str:
     """List the snapshots on disk with their sizes and timestamps."""
     return json.dumps(_call("GET", "/slots"), ensure_ascii=False, indent=2)
 
 
-@mcp.tool()
+@expose(not BENCHMARK)
 def reset_game() -> list:
     """Reboot the emulator back to the title screen. Discards unsaved progress."""
     return _act("/reset", {}, note="reset")

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -8,10 +8,11 @@ import json
 import os
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from game_knowledge import mcp_guide as build_guide
+from game_knowledge import adapt_guide, mcp_guide as build_guide
 
 from mcp.server.mcpserver import MCPServer
 from mcp.types import ImageContent, TextContent
@@ -23,7 +24,25 @@ if PROFILE not in ("standalone", "benchmark"):
 BENCHMARK = PROFILE == "benchmark"
 DEFAULT_SCALE = int(os.environ.get("QUNXIA_SCALE", "1" if BENCHMARK else "2"))
 BASE = API[:-4] if API.endswith("/api") else API
-GUIDE = build_guide(BASE, os.environ.get("QUNXIA_BENCH_LANG", "en"), BENCHMARK)
+LANGUAGE = os.environ.get("QUNXIA_BENCH_LANG", "en")
+
+
+def _benchmark_guide():
+    """Snapshot the guide served by the exact benchmark session we control."""
+    url = os.environ.get("QUNXIA_BENCH_HELP_URL")
+    if not url:
+        url = f"{API}/help?{urllib.parse.urlencode({'lang': LANGUAGE})}"
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:
+            canonical = response.read().decode("utf-8")
+    except (urllib.error.URLError, UnicodeError, TimeoutError) as error:
+        raise RuntimeError(f"Cannot load benchmark instructions from {url}: {error}")
+    if not canonical.strip():
+        raise RuntimeError(f"Benchmark instructions from {url} are empty")
+    return adapt_guide(canonical, benchmark=True)
+
+
+GUIDE = _benchmark_guide() if BENCHMARK else build_guide(BASE, LANGUAGE, False)
 
 mcp = MCPServer("qunxia", instructions=GUIDE)
 

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -113,7 +113,12 @@ def look() -> list:
 
 @expose(not BENCHMARK)
 def guide() -> str:
-    """The canonical game manual plus the MCP tool-name mapping."""
+    """Re-read the canonical game manual and MCP tool-name mapping.
+
+    The MCP server also sends this text as server instructions at connection
+    time. This tool is a compatibility fallback for clients that do not place
+    those optional instructions into the model context.
+    """
     return GUIDE
 
 
@@ -165,23 +170,6 @@ def move(direction: str, steps: int = 1) -> list:
         raise ValueError("direction must be up, down, left or right")
     return _act("/keys", {"keys": [direction] * max(1, steps), "gap": 6},
                 note=f"move {direction} x{steps}")
-
-
-@expose(not BENCHMARK)
-def interact() -> list:
-    """Interact with whatever the character is facing, confirm a menu choice,
-    or advance one line of dialogue. This sends enter."""
-    return _act("/key", {"key": "enter"}, note="interact")
-
-
-@expose(not BENCHMARK)
-def open_menu() -> list:
-    """Open the in-game main menu (醫療 / 解毒 / 物品 / 狀態) by sending esc.
-
-    Also the reliable test for whether a cutscene is still running: if the menu
-    does not appear, you are not free to act yet.
-    """
-    return _act("/key", {"key": "esc"}, note="esc")
 
 
 @mcp.tool()

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -25,15 +25,11 @@ BENCHMARK = PROFILE == "benchmark"
 DEFAULT_SCALE = int(os.environ.get("QUNXIA_SCALE", "1" if BENCHMARK else "2"))
 BASE = API[:-4] if API.endswith("/api") else API
 LANGUAGE = os.environ.get("QUNXIA_BENCH_LANG", "en")
-MAX_KEYS_PER_ACTION = 32
-MAX_HOLD_FRAMES = 600
-MAX_GAP_FRAMES = 600
-MAX_STABLE_FRAMES = 600
-MAX_WAIT_MS = 60000
+MAX_ARRAY_REPEAT = 100
 
 
 def _benchmark_guide():
-    """Snapshot the guide served by the exact benchmark session we control."""
+    """Snapshot benchmark guidance, defaulting to the connected session."""
     url = os.environ.get("QUNXIA_BENCH_HELP_URL")
     if not url:
         url = f"{API}/help?{urllib.parse.urlencode({'lang': LANGUAGE})}"
@@ -83,21 +79,18 @@ def _call(method, path, payload=None, timeout=240):
         except Exception:
             raise GameOffline(f"{path} failed: HTTP {e.code}")
     except (urllib.error.URLError, ConnectionError, TimeoutError) as e:
-        raise GameOffline(
-            f"Cannot reach the game at {API} ({e}). Start it with "
-            "'./Scripts/run.sh' in the repo, wait about 14 seconds for the "
-            "title screen, then retry."
-        )
+        raise GameOffline(f"Cannot reach the game at {API} ({e}). Check "
+                          "QUNXIA_API and the selected game or benchmark session.")
 
 
 def _result(res, note=""):
     """Turn an API response into MCP content: a short status line plus the screen."""
     if res.get("ended"):
-        return [TextContent(type="text", text="BENCHMARK ENDED | " + json.dumps({
-            key: res.get(key) for key in (
-                "reason", "why", "actions", "played_seconds",
-                "video_url", "video_pending")
-        }, ensure_ascii=False))]
+        summary = {key: res.get(key) for key in
+                   ("reason", "why", "actions", "video_url", "video_pending")}
+        summary["played_seconds"] = res.get("played_seconds", res.get("played"))
+        return [TextContent(type="text", text="BENCHMARK ENDED | "
+                            + json.dumps(summary, ensure_ascii=False))]
     out = []
     bits = []
     if not res.get("ok", True):
@@ -170,11 +163,7 @@ def press(key: str, times: int = 1, hold: int = None, stable: int = None) -> lis
 
     Remember: during a cutscene every key just advances the dialogue.
     """
-    times = _bounded_int("times", times, 1, MAX_KEYS_PER_ACTION)
-    if hold is not None:
-        hold = _bounded_int("hold", hold, 1, MAX_HOLD_FRAMES)
-    if stable is not None:
-        stable = _bounded_int("stable", stable, 1, MAX_STABLE_FRAMES)
+    times = _bounded_int("times", times, 1, MAX_ARRAY_REPEAT)
     payload = {"hold": hold} if hold is not None else {}
     if times > 1:
         return _act("/keys", {"keys": [key] * times, **payload},
@@ -190,11 +179,6 @@ def press_sequence(keys: list[str], gap: int = 6, stable: int = None) -> list:
     single presses when you are unsure what a screen will do, because you only
     see the result of the last key here.
     """
-    if not 1 <= len(keys) <= MAX_KEYS_PER_ACTION:
-        raise ValueError(f"keys must contain from 1 to {MAX_KEYS_PER_ACTION} entries")
-    gap = _bounded_int("gap", gap, 0, MAX_GAP_FRAMES)
-    if stable is not None:
-        stable = _bounded_int("stable", stable, 1, MAX_STABLE_FRAMES)
     return _act("/keys", {"keys": keys, "gap": gap},
                 note=" ".join(keys), stable=stable)
 
@@ -209,7 +193,7 @@ def move(direction: str, steps: int = 1) -> list:
     """
     if direction not in ("up", "down", "left", "right"):
         raise ValueError("direction must be up, down, left or right")
-    steps = _bounded_int("steps", steps, 1, MAX_KEYS_PER_ACTION)
+    steps = _bounded_int("steps", steps, 1, MAX_ARRAY_REPEAT)
     return _act("/keys", {"keys": [direction] * steps, "gap": 6},
                 note=f"move {direction} x{steps}")
 
@@ -222,7 +206,6 @@ def wait(ms: int = 1000) -> list:
     world map. Benchmark mode returns metadata only; call look when you need
     the next visible frame.
     """
-    ms = _bounded_int("ms", ms, 0, MAX_WAIT_MS)
     return _act("/wait", {"ms": ms}, note=f"wait {ms}ms")
 
 

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -149,12 +149,13 @@ def guide() -> str:
 # -------------------------------------------------------------------- actions
 
 @mcp.tool()
-def press(key: str, times: int = 1, hold: int = None, stable: int = None) -> list:
+def press(key: str, times: int = 1, hold: int | None = None,
+          stable: int | None = None) -> list:
     """Press one key. In benchmark mode, call look after acting.
 
     key: kp1, kp3, kp7, kp9 (preferred movement keys), up, down, left, right,
          enter (or ok), space, esc, y, n, a-z, 0-9, f1-f12, tab,
-         backspace, or a combo like "alt+x".
+         backspace. The native runner also accepts combos like "alt+x".
     times: repeat the same key this many times (useful for walking or for
          advancing several dialogue lines).
     hold: frames to hold the key down. Omit it to use the game server's safe
@@ -172,7 +173,8 @@ def press(key: str, times: int = 1, hold: int = None, stable: int = None) -> lis
 
 
 @mcp.tool()
-def press_sequence(keys: list[str], gap: int = 6, stable: int = None) -> list:
+def press_sequence(keys: list[str], gap: int = 6,
+                   stable: int | None = None) -> list:
     """Press several different keys in order.
 
     Use for a known menu path, e.g. ["esc", "down", "down", "enter"]. Prefer

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -120,24 +120,25 @@ def guide() -> str:
 # -------------------------------------------------------------------- actions
 
 @mcp.tool()
-def press(key: str, times: int = 1, hold: int = 4, stable: int = None) -> list:
+def press(key: str, times: int = 1, hold: int = None, stable: int = None) -> list:
     """Press one key. In benchmark mode, call look after acting.
 
-    key: up, down, left, right, enter (or ok), space, esc, y, n, a-z, 0-9,
-         f1-f12, tab, backspace, or a combo like "alt+x".
+    key: kp1, kp3, kp7, kp9 (preferred movement keys), up, down, left, right,
+         enter (or ok), space, esc, y, n, a-z, 0-9, f1-f12, tab,
+         backspace, or a combo like "alt+x".
     times: repeat the same key this many times (useful for walking or for
          advancing several dialogue lines).
-    hold: frames to hold the key down, default 4. Raise it only if a press
-         seems to be ignored.
-    stable: frames the picture must hold still before the screenshot is taken.
-         Raise it if you get a half-written dialogue line.
+    hold: frames to hold the key down. Omit it to use the game server's safe
+         tap default; override it only for an intentional longer press.
+    stable: frames the picture must hold still before the action settles.
 
     Remember: during a cutscene every key just advances the dialogue.
     """
+    payload = {"hold": hold} if hold is not None else {}
     if times > 1:
-        return _act("/keys", {"keys": [key] * times, "hold": hold},
+        return _act("/keys", {"keys": [key] * times, **payload},
                     note=f"{key} x{times}", stable=stable)
-    return _act("/key", {"key": key, "hold": hold}, note=key, stable=stable)
+    return _act("/key", {"key": key, **payload}, note=key, stable=stable)
 
 
 @mcp.tool()
@@ -185,10 +186,11 @@ def open_menu() -> list:
 
 @mcp.tool()
 def wait(ms: int = 1000) -> list:
-    """Let the game run without pressing anything, then return the screen.
+    """Let the game run without pressing anything.
 
     Use it during boot, scene transitions, battle animations, and travel on the
-    world map.
+    world map. Benchmark mode returns metadata only; call look when you need
+    the next visible frame.
     """
     return _act("/wait", {"ms": ms}, note=f"wait {ms}ms")
 

--- a/mcp-server/test_game_knowledge.py
+++ b/mcp-server/test_game_knowledge.py
@@ -7,7 +7,7 @@ ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "mcp-server"))
 sys.path.insert(0, str(ROOT / "server"))
 
-from game_knowledge import guide, mcp_guide
+from game_knowledge import adapt_guide, guide, mcp_guide
 from prompt import system_prompt
 
 
@@ -26,6 +26,12 @@ class GameKnowledgeTests(unittest.TestCase):
         self.assertIn("Actions return metadata only", prompt)
         self.assertIn("benchmark session is isolated", prompt)
         self.assertIn("BENCHMARK ENDED", prompt)
+
+    def test_adapter_accepts_a_session_resolved_guide(self):
+        canonical = "session-specific guide at https://session.invalid/api"
+        prompt = adapt_guide(canonical, benchmark=True)
+        self.assertTrue(prompt.endswith(canonical))
+        self.assertIn("Actions return metadata only", prompt)
 
 
 if __name__ == "__main__":

--- a/mcp-server/test_game_knowledge.py
+++ b/mcp-server/test_game_knowledge.py
@@ -1,0 +1,32 @@
+import pathlib
+import sys
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "mcp-server"))
+sys.path.insert(0, str(ROOT / "server"))
+
+from game_knowledge import guide, mcp_guide
+from prompt import system_prompt
+
+
+class GameKnowledgeTests(unittest.TestCase):
+    def test_mcp_and_http_help_share_the_same_source(self):
+        for language in ("en", "zh"):
+            canonical = system_prompt("http://session.invalid", language)
+            self.assertEqual(guide("http://session.invalid", language), canonical)
+            for benchmark in (False, True):
+                prompt = mcp_guide("http://session.invalid", language, benchmark)
+                self.assertTrue(prompt.endswith(canonical))
+                self.assertIn("`GET /api/screen` -> `look`", prompt)
+
+    def test_benchmark_adapter_states_the_isolation_contract(self):
+        prompt = mcp_guide("http://session.invalid", "en", True)
+        self.assertIn("Actions return metadata only", prompt)
+        self.assertIn("benchmark session is isolated", prompt)
+        self.assertIn("BENCHMARK ENDED", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp-server/test_server.py
+++ b/mcp-server/test_server.py
@@ -1,0 +1,40 @@
+import importlib.util
+import pathlib
+import unittest
+from unittest.mock import patch
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("server.py")
+SPEC = importlib.util.spec_from_file_location("qunxia_mcp_server", MODULE_PATH)
+SERVER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(SERVER)
+
+
+class PressContractTests(unittest.TestCase):
+    def test_omitted_hold_uses_http_server_default(self):
+        with patch.object(SERVER, "_act", return_value=[]) as act:
+            SERVER.press("esc")
+        act.assert_called_once_with(
+            "/key", {"key": "esc"}, note="esc", stable=None,
+        )
+
+    def test_explicit_hold_is_forwarded(self):
+        with patch.object(SERVER, "_act", return_value=[]) as act:
+            SERVER.press("kp3", times=2, hold=14, stable=8)
+        act.assert_called_once_with(
+            "/keys", {"keys": ["kp3", "kp3"], "hold": 14},
+            note="kp3 x2", stable=8,
+        )
+
+    def test_benchmark_actions_suppress_images(self):
+        with (
+            patch.object(SERVER, "BENCHMARK", True),
+            patch.object(SERVER, "_call", return_value={"ok": True}) as call,
+        ):
+            SERVER._act("/key", {"key": "esc"})
+        path = call.call_args.args[1]
+        self.assertIn("image=0", path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp-server/test_server.py
+++ b/mcp-server/test_server.py
@@ -42,6 +42,28 @@ class PressContractTests(unittest.TestCase):
             note="kp3 x2", stable=8,
         )
 
+    def test_action_batches_match_the_game_server_limit(self):
+        with self.assertRaisesRegex(
+                ValueError, "times must be an integer from 1 to 32"):
+            SERVER.press("kp3", times=33)
+        with self.assertRaisesRegex(
+                ValueError, "keys must contain from 1 to 32"):
+            SERVER.press_sequence(["kp3"] * 33)
+        with self.assertRaisesRegex(
+                ValueError, "steps must be an integer from 1 to 32"):
+            SERVER.move("right", steps=33)
+
+    def test_action_timing_parameters_are_bounded(self):
+        with self.assertRaisesRegex(
+                ValueError, "hold must be an integer from 1 to 600"):
+            SERVER.press("kp3", hold=0)
+        with self.assertRaisesRegex(
+                ValueError, "stable must be an integer from 1 to 600"):
+            SERVER.press("kp3", stable=601)
+        with self.assertRaisesRegex(
+                ValueError, "gap must be an integer from 0 to 600"):
+            SERVER.press_sequence(["kp3", "enter"], gap=-1)
+
     def test_benchmark_actions_suppress_images(self):
         benchmark = load_server("benchmark")
         with patch.object(benchmark, "_call", return_value={"ok": True}) as call:

--- a/mcp-server/test_server.py
+++ b/mcp-server/test_server.py
@@ -1,7 +1,12 @@
 import asyncio
+import base64
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import importlib.util
+import json
 import os
 import pathlib
+import threading
 import unittest
 import urllib.parse
 from unittest.mock import patch
@@ -12,10 +17,10 @@ SESSION_GUIDE = "# guide served by the active benchmark session"
 SESSION_GUIDE_URL = "data:text/plain," + urllib.parse.quote(SESSION_GUIDE)
 
 
-def load_server(profile):
-    environment = {"QUNXIA_MCP_PROFILE": profile}
+def load_server(profile, **overrides):
+    environment = {"QUNXIA_MCP_PROFILE": profile, **overrides}
     if profile == "benchmark":
-        environment["QUNXIA_BENCH_HELP_URL"] = SESSION_GUIDE_URL
+        environment.setdefault("QUNXIA_BENCH_HELP_URL", SESSION_GUIDE_URL)
     environment = {
         **{key: value for key, value in os.environ.items()
            if not key.startswith("QUNXIA_")},
@@ -34,6 +39,41 @@ SERVER = load_server("standalone")
 
 def tool_names(server):
     return {tool.name for tool in asyncio.run(server.mcp.list_tools())}
+
+
+@contextmanager
+def http_fixture(responses):
+    requests = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.respond()
+
+        def do_POST(self):
+            self.respond()
+
+        def respond(self):
+            body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+            requests.append((self.command, self.path, json.loads(body) if body else None))
+            status, content_type, payload = responses[len(requests) - 1]
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *_args):
+            pass
+
+    http = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=http.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{http.server_port}", requests
+    finally:
+        http.shutdown()
+        thread.join()
+        http.server_close()
 
 
 class PressContractTests(unittest.TestCase):
@@ -92,6 +132,81 @@ class PressContractTests(unittest.TestCase):
     def test_benchmark_uses_the_connected_session_guide(self):
         benchmark = load_server("benchmark")
         self.assertTrue(benchmark.GUIDE.endswith(SESSION_GUIDE))
+
+
+class MCPHTTPContractTests(unittest.TestCase):
+    # A tiny synthetic PNG checks transport without requiring a running game.
+    PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII="
+
+    def call_tool(self, server, name, arguments):
+        return asyncio.run(server.mcp.call_tool(name, arguments))
+
+    def test_null_optional_timing_arguments_use_the_server_defaults(self):
+        for profile in ("standalone", "benchmark"):
+            server = load_server(profile)
+            for name, arguments, expected_body in (
+                ("press", {"key": "esc", "hold": None, "stable": None}, {"key": "esc"}),
+                ("press_sequence", {"keys": ["esc"], "stable": None},
+                 {"keys": ["esc"], "gap": 6}),
+            ):
+                with self.subTest(profile=profile, tool=name), patch.object(
+                        server, "_call", return_value={"ok": True}) as call:
+                    self.call_tool(server, name, arguments)
+                    self.assertEqual(call.call_args.args[2], expected_body)
+                    self.assertNotIn("stable=", call.call_args.args[1])
+
+    def test_standalone_action_preserves_png_image_content(self):
+        response = json.dumps({
+            "ok": True, "changed": True, "width": 320, "height": 200,
+            "image_width": 640, "image_height": 400,
+            "image": "data:image/png;base64," + self.PNG,
+        }).encode()
+        with http_fixture([(200, "application/json", response)]) as (origin, requests):
+            server = load_server("standalone", QUNXIA_API=origin)
+            result = self.call_tool(server, "press", {"key": "esc"})
+        self.assertEqual(requests, [("POST", "/key?scale=2", {"key": "esc"})])
+        self.assertEqual([part.type for part in result.content], ["text", "image"])
+        self.assertEqual(result.content[1].data, self.PNG)
+        self.assertEqual(result.content[1].model_dump(by_alias=True)["mimeType"], "image/png")
+        self.assertTrue(base64.b64decode(result.content[1].data).startswith(b"\x89PNG\r\n\x1a\n"))
+
+    def test_benchmark_uses_session_help_and_separate_json_observation(self):
+        metadata = {"ok": True, "changed": True, "width": 320, "height": 200, "frame": 7}
+        screen = {"ok": True, "width": 320, "height": 200,
+                  "image": "data:image/png;base64," + self.PNG}
+        responses = [(200, "text/plain", SESSION_GUIDE.encode()),
+                     (200, "application/json", json.dumps(metadata).encode()),
+                     (200, "application/json", json.dumps(screen).encode())]
+        with http_fixture(responses) as (origin, requests):
+            server = load_server("benchmark", QUNXIA_API=origin + "/s/test/api/",
+                                 QUNXIA_BENCH_HELP_URL="", QUNXIA_BENCH_LANG="zh")
+            action = self.call_tool(server, "press", {"key": "kp3", "hold": 14})
+            look = self.call_tool(server, "look", {})
+        self.assertEqual(requests, [
+            ("GET", "/s/test/api/help?lang=zh", None),
+            ("POST", "/s/test/api/key?scale=1&image=0", {"key": "kp3", "hold": 14}),
+            ("GET", "/s/test/api/screen", None),
+        ])
+        self.assertTrue(server.GUIDE.endswith(SESSION_GUIDE))
+        self.assertEqual([part.type for part in action.content], ["text"])
+        self.assertEqual([part.type for part in look.content], ["text", "image"])
+        self.assertEqual(look.content[1].data, self.PNG)
+
+    def test_http_410_retains_broker_and_warden_timing(self):
+        for timing in ({"played": 42}, {"played_seconds": 42}):
+            ended = {"ok": True, "ended": True, "reason": "budget",
+                     "actions": 7, "video_url": "https://example.invalid/run.mp4", **timing}
+            with self.subTest(timing=timing), http_fixture([
+                    (410, "application/json", json.dumps(ended).encode())]) as (origin, _requests):
+                server = load_server("benchmark", QUNXIA_API=origin + "/api")
+                result = self.call_tool(server, "wait", {"ms": 1500})
+            self.assertEqual(len(result.content), 1)
+            prefix, summary = result.content[0].text.split(" | ", 1)
+            self.assertEqual(prefix, "BENCHMARK ENDED")
+            summary = json.loads(summary)
+            self.assertEqual(summary["played_seconds"], 42)
+            self.assertEqual(summary["actions"], 7)
+            self.assertEqual(summary["video_url"], ended["video_url"])
 
 
 if __name__ == "__main__":

--- a/mcp-server/test_server.py
+++ b/mcp-server/test_server.py
@@ -1,13 +1,23 @@
 import importlib.util
+import os
 import pathlib
 import unittest
 from unittest.mock import patch
 
 
 MODULE_PATH = pathlib.Path(__file__).with_name("server.py")
-SPEC = importlib.util.spec_from_file_location("qunxia_mcp_server", MODULE_PATH)
-SERVER = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(SERVER)
+
+
+def load_server(profile):
+    with patch.dict(os.environ, {"QUNXIA_MCP_PROFILE": profile}):
+        spec = importlib.util.spec_from_file_location(
+            f"qunxia_mcp_server_{profile}", MODULE_PATH)
+        server = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(server)
+        return server
+
+
+SERVER = load_server("standalone")
 
 
 class PressContractTests(unittest.TestCase):
@@ -27,13 +37,24 @@ class PressContractTests(unittest.TestCase):
         )
 
     def test_benchmark_actions_suppress_images(self):
-        with (
-            patch.object(SERVER, "BENCHMARK", True),
-            patch.object(SERVER, "_call", return_value={"ok": True}) as call,
-        ):
-            SERVER._act("/key", {"key": "esc"})
+        benchmark = load_server("benchmark")
+        with patch.object(benchmark, "_call", return_value={"ok": True}) as call:
+            benchmark._act("/key", {"key": "esc"})
         path = call.call_args.args[1]
+        self.assertIn("scale=1", path)
         self.assertIn("image=0", path)
+
+    def test_profiles_register_the_expected_tools(self):
+        standalone = set(SERVER.mcp._tool_manager._tools)
+        benchmark = load_server("benchmark")
+        self.assertEqual(
+            set(benchmark.mcp._tool_manager._tools),
+            {"look", "press", "press_sequence", "wait"},
+        )
+        self.assertTrue(
+            {"guide", "move", "save_state", "load_state", "reset_game"}
+            < standalone,
+        )
 
 
 if __name__ == "__main__":

--- a/mcp-server/test_server.py
+++ b/mcp-server/test_server.py
@@ -48,13 +48,18 @@ class PressContractTests(unittest.TestCase):
         standalone = set(SERVER.mcp._tool_manager._tools)
         benchmark = load_server("benchmark")
         self.assertEqual(
+            standalone,
+            {
+                "guide", "look", "press", "press_sequence", "move", "wait",
+                "save_state", "load_state", "list_states", "reset_game",
+            },
+        )
+        self.assertEqual(
             set(benchmark.mcp._tool_manager._tools),
             {"look", "press", "press_sequence", "wait"},
         )
-        self.assertTrue(
-            {"guide", "move", "save_state", "load_state", "reset_game"}
-            < standalone,
-        )
+        self.assertNotIn("interact", standalone)
+        self.assertNotIn("open_menu", standalone)
 
 
 if __name__ == "__main__":

--- a/mcp-server/test_server.py
+++ b/mcp-server/test_server.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib.util
 import os
 import pathlib
@@ -15,7 +16,12 @@ def load_server(profile):
     environment = {"QUNXIA_MCP_PROFILE": profile}
     if profile == "benchmark":
         environment["QUNXIA_BENCH_HELP_URL"] = SESSION_GUIDE_URL
-    with patch.dict(os.environ, environment):
+    environment = {
+        **{key: value for key, value in os.environ.items()
+           if not key.startswith("QUNXIA_")},
+        **environment,
+    }
+    with patch.dict(os.environ, environment, clear=True):
         spec = importlib.util.spec_from_file_location(
             f"qunxia_mcp_server_{profile}", MODULE_PATH)
         server = importlib.util.module_from_spec(spec)
@@ -24,6 +30,10 @@ def load_server(profile):
 
 
 SERVER = load_server("standalone")
+
+
+def tool_names(server):
+    return {tool.name for tool in asyncio.run(server.mcp.list_tools())}
 
 
 class PressContractTests(unittest.TestCase):
@@ -42,27 +52,17 @@ class PressContractTests(unittest.TestCase):
             note="kp3 x2", stable=8,
         )
 
-    def test_action_batches_match_the_game_server_limit(self):
+    def test_locally_expanded_action_batches_are_bounded(self):
         with self.assertRaisesRegex(
-                ValueError, "times must be an integer from 1 to 32"):
-            SERVER.press("kp3", times=33)
+                ValueError, "times must be an integer from 1 to 100"):
+            SERVER.press("kp3", times=101)
         with self.assertRaisesRegex(
-                ValueError, "keys must contain from 1 to 32"):
-            SERVER.press_sequence(["kp3"] * 33)
-        with self.assertRaisesRegex(
-                ValueError, "steps must be an integer from 1 to 32"):
-            SERVER.move("right", steps=33)
+                ValueError, "steps must be an integer from 1 to 100"):
+            SERVER.move("right", steps=101)
 
-    def test_action_timing_parameters_are_bounded(self):
-        with self.assertRaisesRegex(
-                ValueError, "hold must be an integer from 1 to 600"):
-            SERVER.press("kp3", hold=0)
-        with self.assertRaisesRegex(
-                ValueError, "stable must be an integer from 1 to 600"):
-            SERVER.press("kp3", stable=601)
-        with self.assertRaisesRegex(
-                ValueError, "gap must be an integer from 0 to 600"):
-            SERVER.press_sequence(["kp3", "enter"], gap=-1)
+    def test_broker_end_payload_keeps_played_seconds(self):
+        result = SERVER._result({"ended": True, "played": 42})
+        self.assertIn('"played_seconds": 42', result[0].text)
 
     def test_benchmark_actions_suppress_images(self):
         benchmark = load_server("benchmark")
@@ -73,7 +73,7 @@ class PressContractTests(unittest.TestCase):
         self.assertIn("image=0", path)
 
     def test_profiles_register_the_expected_tools(self):
-        standalone = set(SERVER.mcp._tool_manager._tools)
+        standalone = tool_names(SERVER)
         benchmark = load_server("benchmark")
         self.assertEqual(
             standalone,
@@ -83,7 +83,7 @@ class PressContractTests(unittest.TestCase):
             },
         )
         self.assertEqual(
-            set(benchmark.mcp._tool_manager._tools),
+            tool_names(benchmark),
             {"look", "press", "press_sequence", "wait"},
         )
         self.assertNotIn("interact", standalone)

--- a/mcp-server/test_server.py
+++ b/mcp-server/test_server.py
@@ -2,14 +2,20 @@ import importlib.util
 import os
 import pathlib
 import unittest
+import urllib.parse
 from unittest.mock import patch
 
 
 MODULE_PATH = pathlib.Path(__file__).with_name("server.py")
+SESSION_GUIDE = "# guide served by the active benchmark session"
+SESSION_GUIDE_URL = "data:text/plain," + urllib.parse.quote(SESSION_GUIDE)
 
 
 def load_server(profile):
-    with patch.dict(os.environ, {"QUNXIA_MCP_PROFILE": profile}):
+    environment = {"QUNXIA_MCP_PROFILE": profile}
+    if profile == "benchmark":
+        environment["QUNXIA_BENCH_HELP_URL"] = SESSION_GUIDE_URL
+    with patch.dict(os.environ, environment):
         spec = importlib.util.spec_from_file_location(
             f"qunxia_mcp_server_{profile}", MODULE_PATH)
         server = importlib.util.module_from_spec(spec)
@@ -60,6 +66,10 @@ class PressContractTests(unittest.TestCase):
         )
         self.assertNotIn("interact", standalone)
         self.assertNotIn("open_menu", standalone)
+
+    def test_benchmark_uses_the_connected_session_guide(self):
+        benchmark = load_server("benchmark")
+        self.assertTrue(benchmark.GUIDE.endswith(SESSION_GUIDE))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## English

### Purpose and changes

- Align MCP with the benchmark action/observation contract: benchmark mode exposes only `look`, `press`, `press_sequence`, and `wait`; actions return metadata and `look` returns a native-size screenshot.
- Fetch benchmark instructions from the connected session's `/api/help` at startup, rather than using another checkout's game guide. Standalone mode reads the repository's shared skills and retains convenience tools.
- Remove redundant action aliases and leave safe default tap timing to the server. Bound array repeat counts; optional `hold`/`stable` accept both omission and explicit null through the MCP SDK.
- Preserve useful timing and reason fields on ended-session responses.
- Document the session `base_url + /api` setup. The client must include MCP initialization `instructions` in model context; benchmark mode intentionally has no fifth guide tool.

### Verification and integration

14 tests passed with MCP 2.1.1. Tests cover registered tools, guidance, real SDK calls over a local HTTP fixture, image content, action/observation separation, explicit nulls, and both forms of HTTP 410 timing. They use synthetic images and do not run a real game.

PR #8 supplies Linux support for requested settle/gap options. PR #10 corrects the book count in the old embedded MCP guide; this PR replaces that entire guide with the shared loader. When combining #9 and #10, retain this PR's loader and #10's shared skill correction. The integration result was tested locally; the two independent branches have a small overlapping-text merge conflict. No endpoint-blocking security layer is added.

## 中文

### 目的与改动

- MCP 对齐 benchmark 的动作／观察协议：正式模式仅开放 `look`、`press`、`press_sequence`、`wait`，动作返回元信息，看图返回原生尺寸截图。
- benchmark 启动时读取实际连接 session 的 `/api/help`，不再从另一版本 checkout 获取游戏说明。独立模式读取仓库共享技能，保留便捷工具。
- 删除重复动作别名，安全的默认短按时长交给服务端。限制数组重复次数；可选 `hold`／`stable` 在 MCP SDK 中同时支持省略和显式 null。
- 会话结束时保留有效的时长与原因字段。
- 说明如何配置 session 的 `base_url + /api`；客户端必须把 MCP 初始化的 `instructions` 放入模型上下文，benchmark 不额外增加第五个 guide 工具。

### 验证与集成

MCP 2.1.1 下 14 项测试通过，覆盖工具注册、说明文本、本地 HTTP 夹具上的真实 SDK 调用、图片内容、动作／观察分离、显式 null 和两种 HTTP 410 时长字段。使用合成图片，没有运行真实游戏。

PR #8 提供 Linux 的稳定帧数和按键间隔支持。PR #10 修正旧内嵌 MCP 说明的书数，而本 PR 用共享加载器替代该整段说明；合并两者时保留本 PR 的加载器及 #10 的共享技能修正。已测试组合结果，但两个独立分支在这段文字上有一个小合并冲突。不增加接口封锁安全层。
