### PR TITLE
Allowlist public benchmark session routes

### DIFF
--- a/bench/broker.py
+++ b/bench/broker.py
@@ -326,7 +326,31 @@ async def api_new(request):
     })
 
 
+PUBLIC_SESSION_ROUTES = {
+    ("GET", "api/screen"),
+    ("GET", "api/help"),
+    ("POST", "api/key"),
+    ("POST", "api/keys"),
+    ("POST", "api/wait"),
+}
+
+
+def public_session_route(method, tail, websocket=False):
+    """Whether an untrusted benchmark client may reach this game route."""
+    path = str(tail or "").strip("/")
+    if websocket:
+        return method == "GET" and path == "ws"
+    return (method, path) in PUBLIC_SESSION_ROUTES
+
+
 async def proxy(request):
+    tail = request.match_info.get("tail", "")
+    websocket = request.headers.get("Upgrade", "").lower() == "websocket"
+    if not public_session_route(request.method, tail, websocket):
+        raise web.HTTPNotFound(
+            text=json.dumps({"ok": False, "error": "route not available in benchmark sessions"}),
+            content_type="application/json")
+
     sid = request.match_info["sid"]
     sess = sessions.get(sid)
     if not sess:
@@ -341,10 +365,9 @@ async def proxy(request):
             res = await wait_published(sid, res)
         return web.json_response(ended_payload(sess, res), status=410)
 
-    tail = request.match_info.get("tail", "")
     url = f"http://127.0.0.1:{sess['port']}/{tail}"
 
-    if request.headers.get("Upgrade", "").lower() == "websocket":
+    if websocket:
         return await spectate(request, sess, url)
 
     data = await request.read()

--- a/bench/test_proxy_routes.py
+++ b/bench/test_proxy_routes.py
@@ -1,0 +1,41 @@
+import pathlib
+import sys
+import unittest
+
+
+BENCH_DIR = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(BENCH_DIR))
+
+import broker
+
+
+class PublicSessionRouteTests(unittest.TestCase):
+    def test_only_visual_benchmark_routes_are_public(self):
+        allowed = {
+            ("GET", "api/screen"),
+            ("GET", "api/help"),
+            ("POST", "api/key"),
+            ("POST", "api/keys"),
+            ("POST", "api/wait"),
+        }
+        for method, path in allowed:
+            self.assertTrue(broker.public_session_route(method, path))
+
+        for method, path in {
+            ("GET", "status"),
+            ("GET", "api/history"),
+            ("GET", "api/recording"),
+            ("POST", "api/reset"),
+            ("POST", "api/snapshot"),
+            ("GET", ""),
+        }:
+            self.assertFalse(broker.public_session_route(method, path))
+
+    def test_only_the_spectator_socket_is_public(self):
+        self.assertTrue(broker.public_session_route("GET", "ws", websocket=True))
+        self.assertFalse(broker.public_session_route("GET", "status", websocket=True))
+        self.assertFalse(broker.public_session_route("POST", "ws", websocket=True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## English

### Summary

- replace the wildcard benchmark-session proxy with an explicit public route allowlist
- permit only `GET /api/screen`, `GET /api/help`, `POST /api/key`, `POST /api/keys`, and `POST /api/wait`
- keep the read-only `/ws` spectator socket available
- block `/status`, history, recording, reset, snapshot, and every other internal route before checking whether a session exists

This makes the pure-visual boundary a server property for raw HTTP clients, rather than relying only on prompts or the Pi/MCP tool allowlists. The broker still reads `/status` internally over loopback for scoring and live publication.

### Verification

- 2 route-contract tests passed
- Python syntax and whitespace checks passed
- merges cleanly with the five existing focused PRs

## 中文

### 摘要

- 将 benchmark session 的通配代理改为明确的公开路径白名单
- 仅允许 `GET /api/screen`、`GET /api/help`、`POST /api/key`、`POST /api/keys` 与 `POST /api/wait`
- 保留只读的 `/ws` 旁观连接
- 在检查 session 是否存在之前即封锁 `/status`、历史、录像、重置、快照以及其他内部路径

这样，原始 HTTP 客户端的纯视觉边界由服务端强制，而不再只依赖提示词或 Pi/MCP 工具白名单。Broker 仍可通过本机回环地址读取 `/status`，用于私有评分与 live 发布。

### 验证

- 2 项路径契约测试通过
- Python 语法和差异格式检查通过
- 与已有五个独立 PR 干净合并
