### PR TITLE
Protect core teardown and detect stalled execution

### DIFF
--- a/Sources/CoreHost/CoreHost.c
+++ b/Sources/CoreHost/CoreHost.c
@@ -2,8 +2,8 @@
 
 #include <dlfcn.h>
 #include <pthread.h>
-#include <stdatomic.h>
 #include <stdarg.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -25,13 +25,21 @@ typedef void (*fn_set_input)(retro_input_state_t);
 typedef void (*fn_set_controller)(unsigned, unsigned);
 
 static void *g_lib;
-static fn_void g_init, g_deinit, g_run, g_reset;
+static fn_void g_init, g_deinit, g_run, g_reset, g_unload;
 static fn_load g_load;
+static bool g_game_loaded;
 static fn_serialize_size g_ser_size;
 static fn_serialize g_ser;
 static fn_unserialize g_unser;
 static fn_get_av g_av;
 static fn_set_controller g_set_controller;
+
+/* Libretro entry points are not reentrant. The HTTP thread reads state while
+   the emulation thread calls retro_run; serializing concurrently can leave
+   DOSBox Pure's frame/pause handshake stuck. Keep core operations separate
+   from the framebuffer mutex: retro_run itself invokes video_cb, which takes
+   g_mu. Callbacks must not try to acquire this execution mutex. */
+static pthread_mutex_t g_exec_mu = PTHREAD_MUTEX_INITIALIZER;
 
 /* ---- video ---- */
 static pthread_mutex_t g_mu = PTHREAD_MUTEX_INITIALIZER;
@@ -41,10 +49,6 @@ static _Atomic int g_w, g_h, g_pitch;
 static _Atomic uint64_t g_serial;
 static _Atomic uint64_t g_ticks;
 static _Atomic uint64_t g_hash;
-/* libretro cores are single-threaded. The headless runner receives input on
-   asyncio's thread while retro_run lives on the emulation thread, so calls
-   into the core must never overlap. */
-static pthread_mutex_t g_core_mu = PTHREAD_MUTEX_INITIALIZER;
 
 /* ---- audio ring ---- */
 #define AUDIO_RING_FRAMES 32768
@@ -366,6 +370,7 @@ bool core_init(const char *core_path, const char *game_path, const char *save_di
     g_run = (fn_void)sym("retro_run", true);
     g_reset = (fn_void)sym("retro_reset", false);
     g_load = (fn_load)sym("retro_load_game", true);
+    g_unload = (fn_void)sym("retro_unload_game", false);
     g_ser_size = (fn_serialize_size)sym("retro_serialize_size", false);
     g_ser = (fn_serialize)sym("retro_serialize", false);
     g_unser = (fn_unserialize)sym("retro_unserialize", false);
@@ -384,10 +389,12 @@ bool core_init(const char *core_path, const char *game_path, const char *save_di
     struct retro_game_info info;
     memset(&info, 0, sizeof(info));
     info.path = game_path;
+    g_game_loaded = false;
     if (!g_load(&info)) {
         set_err("retro_load_game failed");
         return false;
     }
+    g_game_loaded = true;
 
     if (g_set_controller) g_set_controller(0, RETRO_DEVICE_KEYBOARD);
 
@@ -404,77 +411,98 @@ bool core_init(const char *core_path, const char *game_path, const char *save_di
 }
 
 void core_shutdown(void) {
+    pthread_mutex_lock(&g_exec_mu);
+    /* retro_run may leave the core's own worker running the next frame.
+       Unload stops that worker; deinit alone only frees its video buffers. */
+    if (g_game_loaded && g_unload) g_unload();
+    g_game_loaded = false;
     if (g_deinit) g_deinit();
-    g_lib = NULL; /* leave dlclose out: the core spawns threads that outlive deinit */
+    g_run = g_deinit = g_reset = g_unload = NULL;
+    g_ser = NULL; g_unser = NULL; g_ser_size = NULL;
+    g_kbd_cb = NULL;
+    g_lib = NULL; /* keep the library mapped; unloading code is a separate lifecycle concern */
+    pthread_mutex_lock(&g_mu);
     free(g_fb);
     g_fb = NULL;
     g_fb_cap = 0;
+    g_w = g_h = g_pitch = 0;
+    pthread_mutex_unlock(&g_mu);
+    pthread_mutex_unlock(&g_exec_mu);
 }
 
 void core_run_frame(void) {
-    pthread_mutex_lock(&g_core_mu);
-    if (g_run) g_run();
-    g_ticks++;
-    pthread_mutex_unlock(&g_core_mu);
+    pthread_mutex_lock(&g_exec_mu);
+    if (g_run) {
+        g_run();
+        g_ticks++;
+    }
+    pthread_mutex_unlock(&g_exec_mu);
 }
 
-static void key_unlocked(int retrok, bool down) {
+static void release_all_keys_unlocked(void);
+
+void core_reset(void) {
+    pthread_mutex_lock(&g_exec_mu);
+    release_all_keys_unlocked();
+    core_audio_reset();
+    if (g_reset) g_reset();
+    pthread_mutex_unlock(&g_exec_mu);
+}
+
+void core_key(int retrok, bool down) {
     if (retrok < 0 || retrok >= (int)RETROK_LAST) return;
-    if (g_keys[retrok] == (down ? 1 : 0)) return;
-    g_keys[retrok] = down ? 1 : 0;
-    if (g_kbd_cb) g_kbd_cb(down, (unsigned)retrok, 0, 0);
+    pthread_mutex_lock(&g_exec_mu);
+    if (g_keys[retrok] != (down ? 1 : 0)) {
+        g_keys[retrok] = down ? 1 : 0;
+        if (g_kbd_cb) g_kbd_cb(down, (unsigned)retrok, 0, 0);
+    }
+    pthread_mutex_unlock(&g_exec_mu);
 }
 
 static void release_all_keys_unlocked(void) {
     for (int i = 0; i < (int)RETROK_LAST; i++) {
-        if (g_keys[i]) key_unlocked(i, false);
+        if (g_keys[i]) {
+            g_keys[i] = 0;
+            if (g_kbd_cb) g_kbd_cb(false, (unsigned)i, 0, 0);
+        }
     }
 }
 
-void core_reset(void) {
-    pthread_mutex_lock(&g_core_mu);
-    release_all_keys_unlocked();
-    core_audio_reset();
-    if (g_reset) g_reset();
-    pthread_mutex_unlock(&g_core_mu);
-}
-
-void core_key(int retrok, bool down) {
-    pthread_mutex_lock(&g_core_mu);
-    key_unlocked(retrok, down);
-    pthread_mutex_unlock(&g_core_mu);
-}
-
 void core_release_all_keys(void) {
-    pthread_mutex_lock(&g_core_mu);
+    pthread_mutex_lock(&g_exec_mu);
     release_all_keys_unlocked();
-    pthread_mutex_unlock(&g_core_mu);
+    pthread_mutex_unlock(&g_exec_mu);
 }
 
 void core_mouse_move(int dx, int dy) {
-    pthread_mutex_lock(&g_core_mu);
+    pthread_mutex_lock(&g_exec_mu);
     g_mouse_dx += dx;
     g_mouse_dy += dy;
-    pthread_mutex_unlock(&g_core_mu);
+    pthread_mutex_unlock(&g_exec_mu);
 }
 
 void core_mouse_button(int button, bool down) {
-    pthread_mutex_lock(&g_core_mu);
+    pthread_mutex_lock(&g_exec_mu);
     if (button >= 0 && button < 3) g_mouse_btn[button] = down ? 1 : 0;
-    pthread_mutex_unlock(&g_core_mu);
+    pthread_mutex_unlock(&g_exec_mu);
 }
 
 bool core_save_state(const char *path) {
-    if (!g_ser_size || !g_ser) return false;
-    pthread_mutex_lock(&g_core_mu);
+    pthread_mutex_lock(&g_exec_mu);
+    if (!g_ser_size || !g_ser) {
+        pthread_mutex_unlock(&g_exec_mu);
+        return false;
+    }
     size_t n = g_ser_size();
-    pthread_mutex_unlock(&g_core_mu);
-    if (n == 0) { set_err("core reports zero savestate size"); return false; }
+    if (n == 0) {
+        pthread_mutex_unlock(&g_exec_mu);
+        set_err("core reports zero savestate size");
+        return false;
+    }
     void *buf = malloc(n);
-    if (!buf) return false;
-    pthread_mutex_lock(&g_core_mu);
+    if (!buf) { pthread_mutex_unlock(&g_exec_mu); return false; }
     bool ok = g_ser(buf, n);
-    pthread_mutex_unlock(&g_core_mu);
+    pthread_mutex_unlock(&g_exec_mu);
     if (ok) {
         FILE *f = fopen(path, "wb");
         if (!f) { free(buf); set_err("cannot open savestate for write"); return false; }
@@ -488,7 +516,6 @@ bool core_save_state(const char *path) {
 }
 
 bool core_load_state(const char *path) {
-    if (!g_unser) return false;
     FILE *f = fopen(path, "rb");
     if (!f) return false;
     fseek(f, 0, SEEK_END);
@@ -500,13 +527,14 @@ bool core_load_state(const char *path) {
     size_t got = fread(buf, 1, (size_t)n, f);
     fclose(f);
     if (got != (size_t)n) { free(buf); return false; }
-    pthread_mutex_lock(&g_core_mu);
+    pthread_mutex_lock(&g_exec_mu);
     release_all_keys_unlocked();
-    bool ok = g_unser(buf, (size_t)n);
-    pthread_mutex_unlock(&g_core_mu);
-    free(buf);
+    /* Shutdown can complete while the state file is being read. */
+    bool ok = g_unser && g_unser(buf, (size_t)n);
     if (ok) core_audio_reset();
-    else set_err("retro_unserialize failed");
+    pthread_mutex_unlock(&g_exec_mu);
+    free(buf);
+    if (!ok) set_err("retro_unserialize failed");
     return ok;
 }
 

--- a/server/build.sh
+++ b/server/build.sh
@@ -1,9 +1,16 @@
 #!/bin/sh
-# Build the shared library the Python server loads. Linux/x86_64.
+# Build without overwriting a library that a live process has mapped.
 set -e
 cd "$(dirname "$0")"
-gcc -O2 -fPIC -shared -pthread \
+case "$(uname -s)" in
+  Darwin) SHARED="-dynamiclib"; DL_LIBS="" ;;
+  *) SHARED="-shared"; DL_LIBS="-ldl" ;;
+esac
+OUTPUT="libqunxia.so.build.$$"
+trap 'rm -f "$OUTPUT"' EXIT HUP INT TERM
+cc -std=c11 -O2 -fPIC "$SHARED" -pthread \
   -I../Sources/CoreHost/include \
   ../Sources/CoreHost/CoreHost.c tiles.c \
-  -o libqunxia.so -ldl -lpthread
+  -o "$OUTPUT" $DL_LIBS -lpthread
+mv -f "$OUTPUT" libqunxia.so
 echo "built $(pwd)/libqunxia.so"

--- a/server/health.py
+++ b/server/health.py
@@ -1,0 +1,100 @@
+"""Detect an execution stall without waiting for the core mutex or HTTP loop."""
+import json
+import os
+from pathlib import Path
+import threading
+import time
+
+
+def clock():
+    # Older Python/macOS monotonic() epochs differ between processes.
+    return time.clock_gettime(time.CLOCK_MONOTONIC) if hasattr(time, 'clock_gettime') else time.monotonic()
+
+
+def read_json(path):
+    try:
+        value = json.loads(Path(path).read_text())
+        return value if isinstance(value, dict) else None
+    except (OSError, ValueError):
+        return None
+
+
+def write_json(path, value):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + '.tmp')
+    tmp.write_text(json.dumps(value))
+    os.replace(tmp, path)
+
+
+def failure(reason):
+    return {'ok': False, 'ended': True, 'valid': False, 'error': 'environment_failure',
+            'reason': reason, 'retryable': False}
+
+
+class EnvironmentFailure(RuntimeError):
+    pass
+
+
+class Health:
+    def __init__(self, ticks, paused, directory):
+        self.ticks, self.paused = ticks, paused
+        self.directory = Path(directory)
+        self.timeout = float(os.environ.get('QUNXIA_STALL_SECONDS', '15'))
+        self.started = self.loop_at = self.tick_at = clock()
+        self.tick = int(ticks())
+        self.phase, self.phase_at = 'starting', self.started
+        self.fault = None
+        self.stop_event = threading.Event()
+
+    def pulse(self):
+        self.loop_at = clock()
+
+    def set_phase(self, phase):
+        self.phase, self.phase_at = phase, clock()
+
+    def fail(self, reason):
+        self.fault = self.fault or failure(reason)
+
+    def check(self):
+        if self.fault:
+            raise EnvironmentFailure(self.fault['reason'])
+
+    def sample(self):
+        now, tick = clock(), int(self.ticks())  # atomic C load; no execution lock
+        if tick != self.tick:
+            self.tick, self.tick_at = tick, now
+        if self.phase == 'starting':
+            if now - self.started > 30:
+                self.fail('startup_stalled')
+        elif self.phase == 'finalizing':
+            if now - self.phase_at > 300:
+                self.fail('finalization_stalled')
+        else:
+            if now - self.loop_at > self.timeout:
+                self.fail('event_loop_stalled')
+            elif not self.paused() and now - self.tick_at > self.timeout:
+                self.fail('core_stalled')
+        return {'pid': os.getpid(), 'at': now, 'phase': self.phase, 'phase_at': self.phase_at,
+                'core_ticks': tick, 'healthy': not self.fault and self.phase == 'running' and tick > 0,
+                'failure': self.fault}
+
+    def start(self):
+        self.directory.mkdir(parents=True, exist_ok=True)
+        (self.directory / 'failure.json').unlink(missing_ok=True)
+        def watch():
+            while not self.stop_event.wait(.25):
+                try:
+                    state = self.sample()
+                    write_json(self.directory / 'heartbeat.json', state)
+                    if self.fault:
+                        write_json(self.directory / 'failure.json', self.fault)
+                        os._exit(75)
+                except OSError:
+                    os._exit(75)
+        self.thread = threading.Thread(target=watch, daemon=True)
+        self.thread.start()
+
+    def stop(self):
+        self.stop_event.set()
+        self.thread.join(timeout=1)

--- a/server/peers.py
+++ b/server/peers.py
@@ -55,5 +55,3 @@ class Peer:
             if self.close_task is None:
                 self.close_task = asyncio.create_task(self.close_socket())
             await self.close_task
-
-

--- a/server/peers.py
+++ b/server/peers.py
@@ -1,0 +1,59 @@
+"""Bounded per-viewer sends; a slow socket cannot stop the shared pump."""
+import asyncio
+import contextlib
+
+
+class Peer:
+    """One bounded queue per viewer. Encoding never waits for a socket."""
+    def __init__(self, ws, timeout, on_drop):
+        self.ws, self.timeout, self.on_drop = ws, timeout, on_drop
+        self.queue = asyncio.Queue(maxsize=8)
+        self.bytes = 0
+        self.closed = False
+        self.close_task = None
+        self.task = asyncio.create_task(self.send())
+
+    def put(self, data, text=False):
+        size = len(data.encode()) if text else len(data)
+        if self.closed:
+            return
+        if self.queue.full() or self.bytes + size > 2 << 20:
+            self.drop()
+            return
+        self.bytes += size
+        self.queue.put_nowait((data, text, size))
+
+    def drop(self):
+        if not self.closed:
+            self.closed = True
+            self.on_drop(self.ws)
+            self.task.cancel()
+            self.close_task = asyncio.create_task(self.close_socket())
+
+    async def close_socket(self):
+        while not self.queue.empty():
+            self.queue.get_nowait()
+        self.bytes = 0
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(self.ws.close(code=1013, message=b"reconnect for a full frame"), 1)
+
+    async def send(self):
+        try:
+            while True:
+                data, text, size = await self.queue.get()
+                try:
+                    await asyncio.wait_for(self.ws.send_str(data) if text else self.ws.send_bytes(data),
+                                           timeout=self.timeout)
+                finally:
+                    self.bytes = max(0, self.bytes - size)
+        except (Exception, asyncio.CancelledError):
+            pass
+        finally:
+            if not self.closed:
+                self.closed = True
+                self.on_drop(self.ws)
+            if self.close_task is None:
+                self.close_task = asyncio.create_task(self.close_socket())
+            await self.close_task
+
+

--- a/server/server.py
+++ b/server/server.py
@@ -25,6 +25,8 @@ from aiohttp import WSMsgType, web
 from PIL import Image
 
 from prompt import system_prompt
+from health import Health, EnvironmentFailure
+from peers import Peer
 
 ROOT = pathlib.Path(__file__).resolve().parent
 LIB = ctypes.CDLL(str(ROOT / "libqunxia.so"))
@@ -56,6 +58,9 @@ LIB.core_save_state.restype = ctypes.c_bool
 LIB.core_load_state.argtypes = [ctypes.c_char_p]
 LIB.core_load_state.restype = ctypes.c_bool
 
+health = None
+peers = {}
+emulator_stop = threading.Event()
 BUF = ctypes.create_string_buffer(4 << 20)
 
 # Key name -> RETROK. Same vocabulary as the native runner.
@@ -183,36 +188,19 @@ def log_action(src, verb, target, detail="", ok=True, thumb=False):
     return entry
 
 
-async def _send_one(ws, data, text):
-    """One send, bounded. A peer that vanished without closing the TCP
-    connection blocks forever once its window fills, so every send needs a
-    deadline of its own."""
-    try:
-        send = ws.send_str(data) if text else ws.send_bytes(data)
-        await asyncio.wait_for(send, timeout=SEND_TIMEOUT)
-        return ws, True
-    except Exception:
-        return ws, False
+def drop_peer(ws):
+    clients.discard(ws)
+    if peers.pop(ws, None) is not None:
+        stats["dropped"] += 1
 
 
 async def fanout(data, text=False):
-    """Send to every client at once and drop the ones that fail.
-
-    Sending serially meant a single stuck client stalled the broadcast for
-    everyone, which is how streaming died while the emulator kept running.
-    """
-    targets = []
     for ws in list(clients):
-        if ws.closed:
+        peer = peers.get(ws)
+        if ws.closed or peer is None:
             clients.discard(ws)
         else:
-            targets.append(ws)
-    if not targets:
-        return
-    for ws, ok in await asyncio.gather(*(_send_one(ws, data, text) for ws in targets)):
-        if not ok:
-            clients.discard(ws)
-            stats["dropped"] += 1
+            peer.put(data, text)
 
 
 async def broadcast_log(entry):
@@ -223,7 +211,7 @@ def emulate():
     """Own thread. ctypes drops the GIL for each call, so asyncio keeps running."""
     budget = 1.0 / max(1.0, LIB.core_fps())
     nxt = time.perf_counter()
-    while True:
+    while not emulator_stop.is_set():
         if paused.is_set():
             paused_ack.set()
             time.sleep(0.02)
@@ -367,16 +355,17 @@ async def reap():
 async def send_keyframe(ws):
     n = LIB.fb_encode_delta(BUF, len(BUF), 1)
     if n > 0:
-        await ws.send_bytes(zlib.compress(BUF.raw[:n], 6))
+        peers[ws].put(zlib.compress(BUF.raw[:n], 6))
 
 
 async def ws_handler(request):
-    ws = web.WebSocketResponse(max_msg_size=0, heartbeat=30)
+    ws = web.WebSocketResponse(max_msg_size=4096, heartbeat=30, compress=False)
     await ws.prepare(request)
     clients.add(ws)
+    peers[ws] = Peer(ws, SEND_TIMEOUT, drop_peer)
     await send_keyframe(ws)
-    await ws.send_str(json.dumps({"t": "log", "e": list(history)[-80:],
-                                  "s": session_summary()}))
+    peers[ws].put(json.dumps({"t": "log", "e": list(history)[-80:],
+                                  "s": session_summary()}), text=True)
     # code -> (name, core tick at keydown). Browser automation can emit keydown
     # and keyup within one emulated frame, so remember when each press reached
     # the core and fence short pulses on release.
@@ -386,7 +375,12 @@ async def ws_handler(request):
         async for msg in ws:
             if msg.type != WSMsgType.TEXT:
                 continue
-            d = msg.json()
+            try:
+                d = msg.json()
+            except ValueError:
+                continue
+            if not isinstance(d, dict):
+                continue
             t = d.get("t")
             if t == "key":
                 name = str(d.get("k", "")).lower()
@@ -438,6 +432,9 @@ async def ws_handler(request):
         holding.clear()
         if lock_held:
             action_lock().release()
+        peer = peers.get(ws)
+        if peer:
+            peer.drop()
         clients.discard(ws)
     return ws
 
@@ -480,7 +477,7 @@ async def settle(baseline, react=30, stable=9, maxframes=120):
     last, runs, n = baseline, 0, 0
     seen: dict[int, int] = {}
     while n < maxframes:
-        await asyncio.sleep(ft)
+        await wait_core_frames(1)
         n += 1
         h = LIB.core_frame_hash()
         if not reacted:
@@ -514,7 +511,9 @@ async def wait_core_frames(frames):
     poll = min(0.01, 0.5 / fps)
     while LIB.core_ticks() < target:
         if loop.time() >= deadline:
-            raise RuntimeError("emulator frame clock stalled during input")
+            if health:
+                health.fail("core_stalled")
+            raise EnvironmentFailure("emulator frame clock stalled during input")
         await asyncio.sleep(poll)
 
 
@@ -526,7 +525,9 @@ async def pause_emulator():
     while not paused_ack.is_set():
         if loop.time() >= deadline:
             paused.clear()
-            raise RuntimeError("emulator did not pause")
+            if health:
+                health.fail("pause_stalled")
+            raise EnvironmentFailure("emulator did not pause")
         await asyncio.sleep(0.005)
 
 
@@ -1089,7 +1090,20 @@ async def status(_request):
         "width": LIB.core_width(), "height": LIB.core_height(),
         "fps": round(LIB.core_fps(), 3), "frame": LIB.core_frame_serial(),
         "clients": len(clients), "session": session_summary(), **stats,
+        **(health.sample() if health else {}),
     })
+
+
+@web.middleware
+async def json_errors(request, handler):
+    try:
+        if health:
+            health.check()
+        return await handler(request)
+    except EnvironmentFailure as exc:
+        if health:
+            health.fail(str(exc))
+        return web.json_response(health.fault, status=503)
 
 
 async def startup(app):
@@ -1097,9 +1111,34 @@ async def startup(app):
     api_lock = asyncio.Lock()
     app["pump"] = asyncio.create_task(pump())
     app["reaper"] = asyncio.create_task(reap())
+    if health:
+        app["heartbeat"] = asyncio.create_task(pulse_health())
+        health.set_phase("running")
+
+
+async def pulse_health():
+    while True:
+        health.pulse()
+        await asyncio.sleep(.25)
+
+
+async def cleanup(app):
+    for task in app.values():
+        if isinstance(task, asyncio.Task):
+            task.cancel()
+    await asyncio.gather(*(t for t in app.values() if isinstance(t, asyncio.Task)), return_exceptions=True)
+    for peer in list(peers.values()):
+        peer.drop()
+    emulator_stop.set()
+    if health:
+        LIB.core_shutdown()
+        health.stop()
 
 
 def main():
+    global health
+    health = Health(LIB.core_ticks, paused.is_set, os.environ.get("QUNXIA_HEALTH_DIR", str(pathlib.Path(SAVES) / ".health")))
+    health.start()
     os.makedirs(SAVES, exist_ok=True)
     # Measured on this class of VM: 77000 cycles leaves only 1.75x headroom over
     # the 70.09 fps the core needs, which a shared-core instance cannot hold once
@@ -1115,7 +1154,7 @@ def main():
         raise SystemExit("core_init failed: " + LIB.core_last_error().decode())
     threading.Thread(target=emulate, daemon=True).start()
 
-    app = web.Application()
+    app = web.Application(middlewares=[json_errors])
     app.add_routes([
         web.get("/", index),
         web.get("/ws", ws_handler),
@@ -1137,6 +1176,7 @@ def main():
     # Startup handlers are awaited, so the workers are detached tasks rather
     # than returned, or startup would block on loops that never end.
     app.on_startup.append(startup)
+    app.on_cleanup.append(cleanup)
     web.run_app(app, host="0.0.0.0", port=PORT, access_log=None)
 
 

--- a/server/test_core_thread_safety.py
+++ b/server/test_core_thread_safety.py
@@ -1,0 +1,232 @@
+"""Build a tiny fake core so concurrency regressions need no game assets."""
+import ctypes
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+@unittest.skipUnless(shutil.which("cc"), "C compiler required")
+class CoreThreadSafetyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.temp = tempfile.TemporaryDirectory(prefix="qunxia-thread-test-")
+        cls.addClassCleanup(cls.temp.cleanup)
+        cls.directory = pathlib.Path(cls.temp.name)
+        shared = "-dynamiclib" if sys.platform == "darwin" else "-shared"
+        common = ["cc", "-std=c11", "-O2", "-fPIC", shared, "-pthread",
+                  "-I" + str(ROOT / "Sources/CoreHost/include")]
+        cls.core_path = cls.directory / "probe-core.so"
+        host = cls.directory / "host.so"
+        subprocess.run(common + [str(ROOT / "server/test_fixtures/thread_probe_core.c"),
+                                 "-o", str(cls.core_path)], check=True)
+        subprocess.run(common + [str(ROOT / "Sources/CoreHost/CoreHost.c"),
+                                 "-o", str(host)] + ([] if sys.platform == "darwin" else ["-ldl"]), check=True)
+        cls.lib = ctypes.CDLL(str(host))
+        cls.probe = ctypes.CDLL(str(cls.core_path))
+        cls.lib.core_init.argtypes = [ctypes.c_char_p] * 3
+        cls.lib.core_init.restype = ctypes.c_bool
+        cls.has_state_access = hasattr(cls.lib, "core_state_size")
+        if cls.has_state_access:
+            cls.lib.core_state_size.restype = ctypes.c_size_t
+            cls.lib.core_state_copy.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+            cls.lib.core_state_copy.restype = ctypes.c_int
+            cls.lib.core_state_peek.argtypes = [ctypes.POINTER(ctypes.c_size_t), ctypes.c_int,
+                                              ctypes.POINTER(ctypes.c_int16)]
+        cls.lib.core_key.argtypes = [ctypes.c_int, ctypes.c_bool]
+        cls.lib.core_ticks.restype = ctypes.c_uint64
+        cls.lib.core_last_error.restype = ctypes.c_char_p
+        if cls.has_state_access:
+            cls.lib.core_mem_size.argtypes = [ctypes.c_uint]
+            cls.lib.core_mem_size.restype = ctypes.c_size_t
+            cls.lib.core_mem_read.argtypes = [ctypes.c_uint, ctypes.c_size_t, ctypes.c_void_p, ctypes.c_size_t]
+            cls.lib.core_mem_read.restype = ctypes.c_bool
+        for name in ("core_save_state", "core_load_state"):
+            getattr(cls.lib, name).argtypes = [ctypes.c_char_p]
+            getattr(cls.lib, name).restype = ctypes.c_bool
+
+    def setUp(self):
+        self.probe.probe_reset()
+        self.assertTrue(self.lib.core_init(str(self.core_path).encode(), b"unused", str(self.directory).encode()))
+        self.lib.core_release_all_keys()
+
+    def assert_serialized(self, operation):
+        runner = threading.Thread(target=self.lib.core_run_frame, daemon=True)
+        runner.start()
+        deadline = time.monotonic() + 2
+        while not self.probe.probe_running() and time.monotonic() < deadline:
+            time.sleep(.001)
+        self.assertTrue(self.probe.probe_running())
+        started, finished = threading.Event(), threading.Event()
+        result = []
+        def invoke():
+            started.set()
+            result.append(operation())
+            finished.set()
+        reader = threading.Thread(target=invoke, daemon=True)
+        reader.start()
+        try:
+            self.assertTrue(started.wait(1))
+            self.assertFalse(finished.wait(.05), "core access overlapped retro_run")
+        finally:
+            self.probe.probe_release()
+            runner.join(2)
+            reader.join(2)
+        self.assertFalse(runner.is_alive(), "video callback deadlocked on the execution lock")
+        self.assertFalse(reader.is_alive(), "core operation failed to release its lock")
+        self.assertEqual(self.probe.probe_overlaps(), 0)
+        return result[0]
+
+    def test_state_size_waits_for_frame(self):
+        if not self.has_state_access:
+            self.skipTest("benchmark-only private state access")
+        self.assertEqual(self.assert_serialized(self.lib.core_state_size), 16)
+
+    def test_state_copy_waits_for_frame_and_preserves_bytes(self):
+        if not self.has_state_access:
+            self.skipTest("benchmark-only private state access")
+        buf = ctypes.create_string_buffer(16)
+        self.assertEqual(self.assert_serialized(lambda: self.lib.core_state_copy(buf, 16)), 16)
+        self.assertEqual(buf.raw[0], 123)
+
+    def test_state_peek_waits_for_frame(self):
+        if not self.has_state_access:
+            self.skipTest("benchmark-only private state access")
+        offsets = (ctypes.c_size_t * 1)(0)
+        values = (ctypes.c_int16 * 1)()
+        self.assertEqual(self.assert_serialized(lambda: self.lib.core_state_peek(offsets, 1, values)), 0)
+        self.assertEqual(values[0], 123)
+
+    def test_save_waits_for_frame(self):
+        path = self.directory / "save.state"
+        self.assertTrue(self.assert_serialized(lambda: self.lib.core_save_state(str(path).encode())))
+        self.assertEqual(path.read_bytes()[0], 123)
+
+    def test_load_waits_for_frame(self):
+        path = self.directory / "load.state"
+        path.write_bytes(bytes(16))
+        self.assertTrue(self.assert_serialized(lambda: self.lib.core_load_state(str(path).encode())))
+
+    def test_keyboard_callback_waits_for_frame(self):
+        self.assert_serialized(lambda: self.lib.core_key(13, True))
+
+    def test_release_keys_waits_for_frame(self):
+        self.lib.core_key(13, True)
+        self.assert_serialized(self.lib.core_release_all_keys)
+
+    def test_reset_waits_for_frame_without_recursive_locking(self):
+        self.lib.core_key(13, True)
+        self.assert_serialized(self.lib.core_reset)
+
+    def test_shutdown_waits_for_frame_and_clears_callbacks(self):
+        self.assert_serialized(self.lib.core_shutdown)
+        if self.has_state_access:
+            self.assertEqual(self.lib.core_state_size(), 0)
+        self.lib.core_run_frame()  # must not call the deinitialized core
+
+    def test_load_after_shutdown_returns_failure(self):
+        path = self.directory / "shutdown-load.state"
+        path.write_bytes(bytes(16))
+        self.lib.core_shutdown()
+        self.assertFalse(self.lib.core_load_state(str(path).encode()))
+
+    def test_shutdown_unloads_game_before_deinit_and_only_once(self):
+        self.lib.core_shutdown()
+        self.assertEqual(self.probe.probe_unloads(), 1)
+        self.assertEqual(self.probe.probe_premature_deinit(), 0)
+        self.lib.core_shutdown()
+        self.assertEqual(self.probe.probe_unloads(), 1)
+
+    def test_memory_size_waits_for_frame(self):
+        if not self.has_state_access:
+            self.skipTest("benchmark-only private state access")
+        self.assertEqual(self.assert_serialized(lambda: self.lib.core_mem_size(0)), 16)
+
+    def test_memory_read_waits_for_frame(self):
+        if not self.has_state_access:
+            self.skipTest("benchmark-only private state access")
+        buf = ctypes.create_string_buffer(16)
+        self.assertTrue(self.assert_serialized(lambda: self.lib.core_mem_read(0, 0, buf, 16)))
+        self.assertEqual(buf.raw[0], 42)
+
+    def test_mouse_move_waits_for_frame(self):
+        self.assert_serialized(lambda: self.lib.core_mouse_move(1, 2))
+
+    def test_mouse_button_waits_for_frame(self):
+        self.assert_serialized(lambda: self.lib.core_mouse_button(0, True))
+
+    def test_failure_paths_release_execution_lock(self):
+        if not self.has_state_access:
+            self.skipTest("benchmark-only private state access")
+        buf = ctypes.create_string_buffer(16)
+        self.assertEqual(self.lib.core_state_copy(buf, 0), -1)
+        self.probe.probe_fail_serialize(1)
+        self.assertEqual(self.lib.core_state_copy(buf, 16), -1)
+        self.assertFalse(self.lib.core_save_state(str(self.directory / "failed.state").encode()))
+        self.probe.probe_fail_serialize(0)
+        offsets = (ctypes.c_size_t * 1)(16)
+        values = (ctypes.c_int16 * 1)()
+        self.assertEqual(self.lib.core_state_peek(offsets, 1, values), -1)
+        path = self.directory / "invalid.state"
+        path.write_bytes(b"invalid")
+        self.assertFalse(self.lib.core_load_state(str(path).encode()))
+        before = self.lib.core_ticks()
+        self.probe.probe_release()
+        runner = threading.Thread(target=self.lib.core_run_frame, daemon=True)
+        runner.start()
+        runner.join(2)
+        self.assertFalse(runner.is_alive())
+        self.assertGreater(self.lib.core_ticks(), before)
+
+    def test_zero_state_size_keeps_existing_save_diagnostic(self):
+        self.probe.probe_state_size(0)
+        self.assertFalse(self.lib.core_save_state(str(self.directory / "zero.state").encode()))
+        self.assertEqual(self.lib.core_last_error(), b"core reports zero savestate size")
+        self.probe.probe_state_size(16)
+        if self.has_state_access:
+            self.assertEqual(self.lib.core_state_size(), 16)
+
+
+    def test_shutdown_does_not_report_frames_that_never_ran(self):
+        self.lib.core_shutdown()
+        before = self.lib.core_ticks()
+        self.lib.core_run_frame()
+        self.assertEqual(self.lib.core_ticks(), before)
+
+    def test_failed_save_releases_gate_for_the_next_frame(self):
+        self.probe.probe_fail_serialize(1)
+        self.assertFalse(self.lib.core_save_state(str(self.directory / "failed.state").encode()))
+        self.probe.probe_fail_serialize(0)
+        self.probe.probe_release()
+        before = self.lib.core_ticks()
+        runner = threading.Thread(target=self.lib.core_run_frame, daemon=True)
+        runner.start()
+        runner.join(2)
+        self.assertFalse(runner.is_alive())
+        self.assertGreater(self.lib.core_ticks(), before)
+
+    def test_state_peek_rejects_overflow_and_null_arguments(self):
+        if not self.has_state_access:
+            self.skipTest("benchmark-only private state access")
+        offsets = (ctypes.c_size_t * 1)(ctypes.c_size_t(-1).value)
+        values = (ctypes.c_int16 * 1)()
+        self.assertEqual(self.lib.core_state_peek(offsets, 1, values), -1)
+        self.assertEqual(self.lib.core_state_peek(None, 1, values), -1)
+        self.assertEqual(self.lib.core_state_peek(offsets, -1, values), -1)
+
+    def test_memory_read_rejects_wrapped_range(self):
+        if not self.has_state_access:
+            self.skipTest("benchmark-only private state access")
+        data = ctypes.create_string_buffer(16)
+        self.assertFalse(self.lib.core_mem_read(0, ctypes.c_size_t(-1).value, data, 2))
+        self.assertFalse(self.lib.core_mem_read(0, 0, None, 1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/test_fixtures/thread_probe_core.c
+++ b/server/test_fixtures/thread_probe_core.c
@@ -1,0 +1,83 @@
+/* Minimal libretro fixture: keep retro_run active until the test releases it. */
+#include "libretro.h"
+#include <stdatomic.h>
+#include <string.h>
+#include <time.h>
+
+static retro_environment_t environment;
+static retro_video_refresh_t video;
+static atomic_int running, release_run, overlaps, fail_serialize, state_size;
+static atomic_int game_loaded, unloads, premature_deinit;
+static void touch_core(void) {
+    if (atomic_load(&running)) atomic_fetch_add(&overlaps, 1);
+}
+static void keyboard(bool down, unsigned key, uint32_t character, uint16_t mods) {
+    (void)down; (void)key; (void)character; (void)mods;
+    touch_core();
+}
+void probe_reset(void) {
+    atomic_store(&running, 0); atomic_store(&release_run, 0);
+    atomic_store(&overlaps, 0); atomic_store(&fail_serialize, 0);
+    atomic_store(&state_size, 16);
+    atomic_store(&game_loaded, 0); atomic_store(&unloads, 0);
+    atomic_store(&premature_deinit, 0);
+}
+int probe_running(void) { return atomic_load(&running); }
+int probe_overlaps(void) { return atomic_load(&overlaps); }
+void probe_release(void) { atomic_store(&release_run, 1); }
+void probe_fail_serialize(int value) { atomic_store(&fail_serialize, value); }
+void probe_state_size(int value) { atomic_store(&state_size, value); }
+int probe_unloads(void) { return atomic_load(&unloads); }
+int probe_premature_deinit(void) { return atomic_load(&premature_deinit); }
+void retro_set_environment(retro_environment_t cb) { environment = cb; }
+void retro_set_video_refresh(retro_video_refresh_t cb) { video = cb; }
+void retro_set_audio_sample(retro_audio_sample_t cb) { (void)cb; }
+void retro_set_audio_sample_batch(retro_audio_sample_batch_t cb) { (void)cb; }
+void retro_set_input_poll(retro_input_poll_t cb) { (void)cb; }
+void retro_set_input_state(retro_input_state_t cb) { (void)cb; }
+void retro_set_controller_port_device(unsigned port, unsigned device) { (void)port; (void)device; }
+void retro_init(void) {
+    struct retro_keyboard_callback cb = { keyboard };
+    environment(RETRO_ENVIRONMENT_SET_KEYBOARD_CALLBACK, &cb);
+}
+void retro_deinit(void) {
+    touch_core();
+    if (atomic_load(&game_loaded)) atomic_fetch_add(&premature_deinit, 1);
+}
+bool retro_load_game(const struct retro_game_info *info) {
+    (void)info; atomic_store(&game_loaded, 1); return true;
+}
+void retro_unload_game(void) {
+    touch_core(); atomic_store(&game_loaded, 0); atomic_fetch_add(&unloads, 1);
+}
+void retro_get_system_av_info(struct retro_system_av_info *av) {
+    memset(av, 0, sizeof(*av));
+    av->timing.fps = 60; av->timing.sample_rate = 48000;
+}
+void retro_run(void) {
+    atomic_store(&running, 1);
+    while (!atomic_load(&release_run)) {
+        struct timespec delay = { 0, 1000000 };
+        nanosleep(&delay, NULL);
+    }
+    uint32_t pixel = 0x00123456;
+    video(&pixel, 1, 1, sizeof(pixel));
+    atomic_store(&running, 0);
+}
+void retro_reset(void) { touch_core(); }
+size_t retro_serialize_size(void) { touch_core(); return (size_t)atomic_load(&state_size); }
+bool retro_serialize(void *data, size_t size) {
+    touch_core();
+    if (size < 16 || atomic_load(&fail_serialize)) return false;
+    memset(data, 0, size);
+    ((unsigned char *)data)[0] = 123;
+    return true;
+}
+bool retro_unserialize(const void *data, size_t size) {
+    (void)data; touch_core(); return size == 16;
+}
+size_t retro_get_memory_size(unsigned id) { (void)id; touch_core(); return 16; }
+void *retro_get_memory_data(unsigned id) {
+    static unsigned char memory[16] = { 42 };
+    (void)id; touch_core(); return memory;
+}

--- a/server/test_fixtures/thread_probe_core.c
+++ b/server/test_fixtures/thread_probe_core.c
@@ -2,6 +2,7 @@
 #include "libretro.h"
 #include <stdatomic.h>
 #include <string.h>
+#include <stdlib.h>
 #include <time.h>
 
 static retro_environment_t environment;
@@ -14,6 +15,9 @@ static void touch_core(void) {
 static void keyboard(bool down, unsigned key, uint32_t character, uint16_t mods) {
     (void)down; (void)key; (void)character; (void)mods;
     touch_core();
+    if (down && getenv("PROBE_HANG_ON_KEY")) {
+        for (;;) { struct timespec delay = {0, 1000000}; nanosleep(&delay, NULL); }
+    }
 }
 void probe_reset(void) {
     atomic_store(&running, 0); atomic_store(&release_run, 0);
@@ -37,6 +41,7 @@ void retro_set_input_poll(retro_input_poll_t cb) { (void)cb; }
 void retro_set_input_state(retro_input_state_t cb) { (void)cb; }
 void retro_set_controller_port_device(unsigned port, unsigned device) { (void)port; (void)device; }
 void retro_init(void) {
+    if (getenv("PROBE_AUTORUN")) { probe_reset(); probe_release(); }
     struct retro_keyboard_callback cb = { keyboard };
     environment(RETRO_ENVIRONMENT_SET_KEYBOARD_CALLBACK, &cb);
 }
@@ -55,6 +60,9 @@ void retro_get_system_av_info(struct retro_system_av_info *av) {
     av->timing.fps = 60; av->timing.sample_rate = 48000;
 }
 void retro_run(void) {
+    static unsigned frames;
+    const char *limit = getenv("PROBE_HANG_AFTER_FRAMES");
+    if (limit && ++frames > (unsigned)atoi(limit)) atomic_store(&release_run, 0);
     atomic_store(&running, 1);
     while (!atomic_load(&release_run)) {
         struct timespec delay = { 0, 1000000 };

--- a/server/test_worker_health.py
+++ b/server/test_worker_health.py
@@ -158,4 +158,3 @@ class WorkerIntegrationTests(unittest.TestCase):
         events=json.loads(request(self.port,'/api/recording')[1])['events']
         downs=[e['down'] for e in events if e.get('key')=='right']
         self.assertEqual(downs,[True,False])
-

--- a/server/test_worker_health.py
+++ b/server/test_worker_health.py
@@ -1,0 +1,161 @@
+"""Real worker processes and real native calls; no model/provider requests."""
+import asyncio
+import contextlib
+import ctypes
+import json
+import os
+from pathlib import Path
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError, URLError
+
+import aiohttp
+from health import read_json
+
+def stop_process(p, timeout=.5):
+    if p.poll() is None:
+        p.terminate()
+        try: p.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            p.kill(); p.wait(timeout=timeout)
+
+ROOT = Path(__file__).resolve().parent
+
+
+def free_port():
+    with socket.socket() as s:
+        s.bind(('127.0.0.1', 0))
+        return s.getsockname()[1]
+
+
+def request(port, path, body=None, timeout=5):
+    req=Request(f'http://127.0.0.1:{port}{path}', data=json.dumps(body).encode() if body is not None else None,
+                headers={'Content-Type':'application/json'})
+    try:
+        response=urlopen(req,timeout=timeout)
+    except HTTPError as e:
+        response=e
+    with response:
+        return response.status,response.read()
+
+
+def wait_for(fn, seconds=5):
+    deadline=time.monotonic()+seconds
+    last=None
+    while time.monotonic()<deadline:
+        try:
+            last=fn()
+            if last: return last
+        except (OSError, ValueError):
+            pass
+        time.sleep(.03)
+    raise AssertionError(f'timed out, last={last!r}')
+
+
+@unittest.skipUnless(shutil.which('cc'), 'C compiler required')
+class WorkerIntegrationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.build=tempfile.TemporaryDirectory(prefix='qunxia-worker-tests-')
+        cls.addClassCleanup(cls.build.cleanup)
+        cls.core=Path(cls.build.name)/'probe.so'
+        shared='-dynamiclib' if sys.platform=='darwin' else '-shared'
+        subprocess.run(['cc','-std=c11','-O2','-fPIC',shared,'-pthread',
+                        '-I'+str(ROOT.parent/'Sources/CoreHost/include'),
+                        str(ROOT/'test_fixtures/thread_probe_core.c'),'-o',str(cls.core)],check=True)
+        # The production bridge/tiles implementation is exercised in a private
+        # copy so tests never overwrite a library used by another server.
+        cls.server=Path(cls.build.name)/'server'
+        shutil.copytree(ROOT,cls.server,ignore=shutil.ignore_patterns('__pycache__','libqunxia.so*'))
+        sources=Path(cls.build.name)/'Sources'
+        shutil.copytree(ROOT.parent/'Sources/CoreHost',sources/'CoreHost')
+        subprocess.run(['sh',str(cls.server/'build.sh')],stdout=subprocess.DEVNULL,check=True)
+        # Bench warden imports its renderer from the sibling bench directory.
+        if (ROOT.parent/'bench').exists():
+            shutil.copytree(ROOT.parent/'bench',Path(cls.build.name)/'bench')
+
+    def setUp(self):
+        self.temp=tempfile.TemporaryDirectory(prefix='qunxia-test-session-')
+        self.addCleanup(self.temp.cleanup)
+        self.folder=Path(self.temp.name)
+        self.port=free_port()
+        self.procs=[]
+        self.addCleanup(lambda:[stop_process(p,timeout=.5) for p in self.procs])
+
+    def launch(self, **extra):
+        start=self.folder/'start.state'
+        start.write_bytes(b'{' + bytes(15))
+        env=dict(os.environ,PORT=str(self.port),QUNXIA_CORE=str(self.core),QUNXIA_GAME='unused',
+                 QUNXIA_SAVES=str(self.folder/'saves'),QUNXIA_STATE_DIR=str(self.folder/'slots'),
+                 QUNXIA_START_STATE=str(start),QUNXIA_RESET_TOKEN='test',
+                 QUNXIA_RECORDING_DIR=str(self.folder/'recordings'),QUNXIA_RUN_ID='test-run',
+                 QUNXIA_RUNTIME_CHILD='1',QUNXIA_STALL_SECONDS='1.5',QUNXIA_STARTUP_SECONDS='4',
+                 QUNXIA_BOOT_WAIT='0.1',QUNXIA_CHECKPOINT_SECONDS='0.3',QUNXIA_BENCH='0',
+                 QUNXIA_FINALIZATION_SECONDS='20',QUNXIA_RECOVERY_LIMIT='1',PROBE_AUTORUN='1')
+        env.pop('QUNXIA_SESSION_DIR',None)
+        env.pop('QUNXIA_RUNTIME_DIR',None)
+        env.pop('QUNXIA_PARENT_PID',None)
+        env.update(extra)
+        with (self.folder/'worker.log').open('ab') as log:
+            p=subprocess.Popen([sys.executable,str(self.server/'server.py')],env=env,cwd=self.server,
+                               stdout=log,stderr=log,start_new_session=True)
+        p.qunxia_group=True
+        self.procs.append(p)
+        return p
+
+    def healthy(self):
+        status,body=request(self.port,'/status')
+        value=json.loads(body)
+        return value if status==200 and value.get('healthy') else None
+
+
+    def test_static_pixels_still_report_execution_progress(self):
+        self.launch()
+        before=wait_for(self.healthy)
+        time.sleep(.15)
+        after=self.healthy()
+        self.assertGreater(after['core_ticks'],before['core_ticks'])
+
+    def test_native_key_deadlock_becomes_environment_failure(self):
+        p=self.launch(PROBE_HANG_ON_KEY='1')
+        wait_for(self.healthy)
+        with contextlib.suppress(OSError):
+            request(self.port,'/api/key',{'key':'enter'},timeout=4)
+        p.wait(timeout=5)
+        fault=read_json(self.folder/'saves/.health/failure.json')
+        self.assertEqual(p.returncode,75)
+        self.assertFalse(fault['valid'])
+        self.assertIn(fault['reason'],('core_stalled','event_loop_stalled'))
+
+    def test_native_run_deadlock_without_http_requests_is_detected(self):
+        p=self.launch(PROBE_HANG_AFTER_FRAMES='20')
+        wait_for(self.healthy)
+        p.wait(timeout=5)
+        fault=read_json(self.folder/'saves/.health/failure.json')
+        self.assertEqual(p.returncode,75)
+        self.assertIn(fault['reason'],('core_stalled','pause_stalled'))
+
+
+    def test_websocket_disconnect_releases_input_lease(self):
+        self.launch()
+        wait_for(self.healthy)
+        async def run():
+            async with aiohttp.ClientSession() as http:
+                async with http.ws_connect(f'http://127.0.0.1:{self.port}/ws',compress=15) as ws:
+                    self.assertEqual(ws.compress,0)
+                    await ws.send_json({'t':'key','k':'right','down':True})
+                    await asyncio.sleep(.1)
+                async with http.post(f'http://127.0.0.1:{self.port}/api/key',json={'key':'up'}) as r:
+                    self.assertEqual(r.status,200,await r.text())
+        asyncio.run(run())
+        events=json.loads(request(self.port,'/api/recording')[1])['events']
+        downs=[e['down'] for e in events if e.get('key')=='right']
+        self.assertEqual(downs,[True,False])
+


### PR DESCRIPTION
`core_shutdown()` could overlap an active emulation or state operation, and a slow WebSocket could hold up the shared frame pump. This uses the existing native execution gate for unload/deinit, preserves atomic execution counters, and gives each viewer a bounded send queue.

Input settling now waits for completed core frames. An independent watchdog detects native or request-loop stalls; it stops the affected server without automatically restarting the game. Browser key timing and disconnect cleanup are covered by regression tests.

Validation: 31 main tests passed, with 8 benchmark-only cases skipped. The tests compile isolated native fixtures and cover blocked native input/run calls, static pixels with advancing execution, and WebSocket disconnect releasing input ownership. `git diff --check` passes against main. No recording-storage or guide changes are included.
