### PR TITLE
[Stacked on #16] Store full recordings on disk

### DIFF
--- a/Sources/CoreHost/CoreHost.c
+++ b/Sources/CoreHost/CoreHost.c
@@ -2,8 +2,8 @@
 
 #include <dlfcn.h>
 #include <pthread.h>
-#include <stdatomic.h>
 #include <stdarg.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -25,13 +25,21 @@ typedef void (*fn_set_input)(retro_input_state_t);
 typedef void (*fn_set_controller)(unsigned, unsigned);
 
 static void *g_lib;
-static fn_void g_init, g_deinit, g_run, g_reset;
+static fn_void g_init, g_deinit, g_run, g_reset, g_unload;
 static fn_load g_load;
+static bool g_game_loaded;
 static fn_serialize_size g_ser_size;
 static fn_serialize g_ser;
 static fn_unserialize g_unser;
 static fn_get_av g_av;
 static fn_set_controller g_set_controller;
+
+/* Libretro entry points are not reentrant. The HTTP thread reads state while
+   the emulation thread calls retro_run; serializing concurrently can leave
+   DOSBox Pure's frame/pause handshake stuck. Keep core operations separate
+   from the framebuffer mutex: retro_run itself invokes video_cb, which takes
+   g_mu. Callbacks must not try to acquire this execution mutex. */
+static pthread_mutex_t g_exec_mu = PTHREAD_MUTEX_INITIALIZER;
 
 /* ---- video ---- */
 static pthread_mutex_t g_mu = PTHREAD_MUTEX_INITIALIZER;
@@ -41,10 +49,6 @@ static _Atomic int g_w, g_h, g_pitch;
 static _Atomic uint64_t g_serial;
 static _Atomic uint64_t g_ticks;
 static _Atomic uint64_t g_hash;
-/* libretro cores are single-threaded. The headless runner receives input on
-   asyncio's thread while retro_run lives on the emulation thread, so calls
-   into the core must never overlap. */
-static pthread_mutex_t g_core_mu = PTHREAD_MUTEX_INITIALIZER;
 
 /* ---- audio ring ---- */
 #define AUDIO_RING_FRAMES 32768
@@ -366,6 +370,7 @@ bool core_init(const char *core_path, const char *game_path, const char *save_di
     g_run = (fn_void)sym("retro_run", true);
     g_reset = (fn_void)sym("retro_reset", false);
     g_load = (fn_load)sym("retro_load_game", true);
+    g_unload = (fn_void)sym("retro_unload_game", false);
     g_ser_size = (fn_serialize_size)sym("retro_serialize_size", false);
     g_ser = (fn_serialize)sym("retro_serialize", false);
     g_unser = (fn_unserialize)sym("retro_unserialize", false);
@@ -384,10 +389,12 @@ bool core_init(const char *core_path, const char *game_path, const char *save_di
     struct retro_game_info info;
     memset(&info, 0, sizeof(info));
     info.path = game_path;
+    g_game_loaded = false;
     if (!g_load(&info)) {
         set_err("retro_load_game failed");
         return false;
     }
+    g_game_loaded = true;
 
     if (g_set_controller) g_set_controller(0, RETRO_DEVICE_KEYBOARD);
 
@@ -404,77 +411,98 @@ bool core_init(const char *core_path, const char *game_path, const char *save_di
 }
 
 void core_shutdown(void) {
+    pthread_mutex_lock(&g_exec_mu);
+    /* retro_run may leave the core's own worker running the next frame.
+       Unload stops that worker; deinit alone only frees its video buffers. */
+    if (g_game_loaded && g_unload) g_unload();
+    g_game_loaded = false;
     if (g_deinit) g_deinit();
-    g_lib = NULL; /* leave dlclose out: the core spawns threads that outlive deinit */
+    g_run = g_deinit = g_reset = g_unload = NULL;
+    g_ser = NULL; g_unser = NULL; g_ser_size = NULL;
+    g_kbd_cb = NULL;
+    g_lib = NULL; /* keep the library mapped; unloading code is a separate lifecycle concern */
+    pthread_mutex_lock(&g_mu);
     free(g_fb);
     g_fb = NULL;
     g_fb_cap = 0;
+    g_w = g_h = g_pitch = 0;
+    pthread_mutex_unlock(&g_mu);
+    pthread_mutex_unlock(&g_exec_mu);
 }
 
 void core_run_frame(void) {
-    pthread_mutex_lock(&g_core_mu);
-    if (g_run) g_run();
-    g_ticks++;
-    pthread_mutex_unlock(&g_core_mu);
+    pthread_mutex_lock(&g_exec_mu);
+    if (g_run) {
+        g_run();
+        g_ticks++;
+    }
+    pthread_mutex_unlock(&g_exec_mu);
 }
 
-static void key_unlocked(int retrok, bool down) {
+static void release_all_keys_unlocked(void);
+
+void core_reset(void) {
+    pthread_mutex_lock(&g_exec_mu);
+    release_all_keys_unlocked();
+    core_audio_reset();
+    if (g_reset) g_reset();
+    pthread_mutex_unlock(&g_exec_mu);
+}
+
+void core_key(int retrok, bool down) {
     if (retrok < 0 || retrok >= (int)RETROK_LAST) return;
-    if (g_keys[retrok] == (down ? 1 : 0)) return;
-    g_keys[retrok] = down ? 1 : 0;
-    if (g_kbd_cb) g_kbd_cb(down, (unsigned)retrok, 0, 0);
+    pthread_mutex_lock(&g_exec_mu);
+    if (g_keys[retrok] != (down ? 1 : 0)) {
+        g_keys[retrok] = down ? 1 : 0;
+        if (g_kbd_cb) g_kbd_cb(down, (unsigned)retrok, 0, 0);
+    }
+    pthread_mutex_unlock(&g_exec_mu);
 }
 
 static void release_all_keys_unlocked(void) {
     for (int i = 0; i < (int)RETROK_LAST; i++) {
-        if (g_keys[i]) key_unlocked(i, false);
+        if (g_keys[i]) {
+            g_keys[i] = 0;
+            if (g_kbd_cb) g_kbd_cb(false, (unsigned)i, 0, 0);
+        }
     }
 }
 
-void core_reset(void) {
-    pthread_mutex_lock(&g_core_mu);
-    release_all_keys_unlocked();
-    core_audio_reset();
-    if (g_reset) g_reset();
-    pthread_mutex_unlock(&g_core_mu);
-}
-
-void core_key(int retrok, bool down) {
-    pthread_mutex_lock(&g_core_mu);
-    key_unlocked(retrok, down);
-    pthread_mutex_unlock(&g_core_mu);
-}
-
 void core_release_all_keys(void) {
-    pthread_mutex_lock(&g_core_mu);
+    pthread_mutex_lock(&g_exec_mu);
     release_all_keys_unlocked();
-    pthread_mutex_unlock(&g_core_mu);
+    pthread_mutex_unlock(&g_exec_mu);
 }
 
 void core_mouse_move(int dx, int dy) {
-    pthread_mutex_lock(&g_core_mu);
+    pthread_mutex_lock(&g_exec_mu);
     g_mouse_dx += dx;
     g_mouse_dy += dy;
-    pthread_mutex_unlock(&g_core_mu);
+    pthread_mutex_unlock(&g_exec_mu);
 }
 
 void core_mouse_button(int button, bool down) {
-    pthread_mutex_lock(&g_core_mu);
+    pthread_mutex_lock(&g_exec_mu);
     if (button >= 0 && button < 3) g_mouse_btn[button] = down ? 1 : 0;
-    pthread_mutex_unlock(&g_core_mu);
+    pthread_mutex_unlock(&g_exec_mu);
 }
 
 bool core_save_state(const char *path) {
-    if (!g_ser_size || !g_ser) return false;
-    pthread_mutex_lock(&g_core_mu);
+    pthread_mutex_lock(&g_exec_mu);
+    if (!g_ser_size || !g_ser) {
+        pthread_mutex_unlock(&g_exec_mu);
+        return false;
+    }
     size_t n = g_ser_size();
-    pthread_mutex_unlock(&g_core_mu);
-    if (n == 0) { set_err("core reports zero savestate size"); return false; }
+    if (n == 0) {
+        pthread_mutex_unlock(&g_exec_mu);
+        set_err("core reports zero savestate size");
+        return false;
+    }
     void *buf = malloc(n);
-    if (!buf) return false;
-    pthread_mutex_lock(&g_core_mu);
+    if (!buf) { pthread_mutex_unlock(&g_exec_mu); return false; }
     bool ok = g_ser(buf, n);
-    pthread_mutex_unlock(&g_core_mu);
+    pthread_mutex_unlock(&g_exec_mu);
     if (ok) {
         FILE *f = fopen(path, "wb");
         if (!f) { free(buf); set_err("cannot open savestate for write"); return false; }
@@ -488,7 +516,6 @@ bool core_save_state(const char *path) {
 }
 
 bool core_load_state(const char *path) {
-    if (!g_unser) return false;
     FILE *f = fopen(path, "rb");
     if (!f) return false;
     fseek(f, 0, SEEK_END);
@@ -500,13 +527,14 @@ bool core_load_state(const char *path) {
     size_t got = fread(buf, 1, (size_t)n, f);
     fclose(f);
     if (got != (size_t)n) { free(buf); return false; }
-    pthread_mutex_lock(&g_core_mu);
+    pthread_mutex_lock(&g_exec_mu);
     release_all_keys_unlocked();
-    bool ok = g_unser(buf, (size_t)n);
-    pthread_mutex_unlock(&g_core_mu);
-    free(buf);
+    /* Shutdown can complete while the state file is being read. */
+    bool ok = g_unser && g_unser(buf, (size_t)n);
     if (ok) core_audio_reset();
-    else set_err("retro_unserialize failed");
+    pthread_mutex_unlock(&g_exec_mu);
+    free(buf);
+    if (!ok) set_err("retro_unserialize failed");
     return ok;
 }
 

--- a/server/RECORDING.md
+++ b/server/RECORDING.md
@@ -1,0 +1,30 @@
+# Full session recordings
+
+Set `QUNXIA_RECORDING_DIR` to a writable disk directory. The single server uses
+`<port>.jsonl`; `QUNXIA_RECORDING_FILE` can select a file within persistent storage.
+The benchmark broker assigns a separate file per run, outside the disposable
+game copy. A reset archives the previous recording rather than deleting it.
+
+Every tile delta and key/action event produced by the existing stream is appended
+and flushed to JSONL. The server retains no history list. A storage error pauses
+interactive input and retries the bounded pending write; a benchmark storage
+failure invalidates the run. This retains the existing stream cadence; it does
+not claim to capture every native emulator frame.
+
+`GET /api/recording` still exports the original JSON envelope, now as a stream.
+`?format=jsonl` downloads the raw journal. The existing 4x browser replay and
+MediaRecorder MP4/WebM export read bounded pages of one fixed snapshot. Benchmark
+MP4 rendering and its timeline publication also consume the disk recording.
+Browser MediaRecorder output chunks are still held in the browser until download;
+this change bounds the server history and replay input, not all browser memory.
+
+Cloud Run's writable container filesystem uses instance memory and disappears
+when the instance stops. A path under `/tmp` does not solve that problem. Configure
+an actual POSIX persistent volume and point `QUNXIA_RECORDING_DIR` to it; startup
+rejects the container root filesystem and tmpfs. NFS buffering, game copies,
+process working memory and host page caches still count toward deployment limits.
+The directory probe checks write/fsync/rename, not crash durability of a remote
+storage service. No volume or cloud deployment is created by this change.
+
+Sources: [Cloud Run filesystem contract](https://docs.cloud.google.com/run/docs/container-contract),
+[NFS volume behavior](https://docs.cloud.google.com/run/docs/configuring/services/nfs-volume-mounts).

--- a/server/build.sh
+++ b/server/build.sh
@@ -1,9 +1,16 @@
 #!/bin/sh
-# Build the shared library the Python server loads. Linux/x86_64.
+# Build without overwriting a library that a live process has mapped.
 set -e
 cd "$(dirname "$0")"
-gcc -O2 -fPIC -shared -pthread \
+case "$(uname -s)" in
+  Darwin) SHARED="-dynamiclib"; DL_LIBS="" ;;
+  *) SHARED="-shared"; DL_LIBS="-ldl" ;;
+esac
+OUTPUT="libqunxia.so.build.$$"
+trap 'rm -f "$OUTPUT"' EXIT HUP INT TERM
+cc -std=c11 -O2 -fPIC "$SHARED" -pthread \
   -I../Sources/CoreHost/include \
   ../Sources/CoreHost/CoreHost.c tiles.c \
-  -o libqunxia.so -ldl -lpthread
+  -o "$OUTPUT" $DL_LIBS -lpthread
+mv -f "$OUTPUT" libqunxia.so
 echo "built $(pwd)/libqunxia.so"

--- a/server/health.py
+++ b/server/health.py
@@ -76,7 +76,7 @@ class Health:
             elif not self.paused() and now - self.tick_at > self.timeout:
                 self.fail('core_stalled')
         return {'pid': os.getpid(), 'at': now, 'phase': self.phase, 'phase_at': self.phase_at,
-                'core_ticks': tick, 'healthy': not self.fault and self.phase == 'running' and tick > 0,
+                'core_ticks': tick, 'healthy': not self.fault and self.phase == 'running' and tick > 0 and not self.paused(),
                 'failure': self.fault}
 
     def start(self):

--- a/server/health.py
+++ b/server/health.py
@@ -1,0 +1,100 @@
+"""Detect an execution stall without waiting for the core mutex or HTTP loop."""
+import json
+import os
+from pathlib import Path
+import threading
+import time
+
+
+def clock():
+    # Older Python/macOS monotonic() epochs differ between processes.
+    return time.clock_gettime(time.CLOCK_MONOTONIC) if hasattr(time, 'clock_gettime') else time.monotonic()
+
+
+def read_json(path):
+    try:
+        value = json.loads(Path(path).read_text())
+        return value if isinstance(value, dict) else None
+    except (OSError, ValueError):
+        return None
+
+
+def write_json(path, value):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + '.tmp')
+    tmp.write_text(json.dumps(value))
+    os.replace(tmp, path)
+
+
+def failure(reason):
+    return {'ok': False, 'ended': True, 'valid': False, 'error': 'environment_failure',
+            'reason': reason, 'retryable': False}
+
+
+class EnvironmentFailure(RuntimeError):
+    pass
+
+
+class Health:
+    def __init__(self, ticks, paused, directory):
+        self.ticks, self.paused = ticks, paused
+        self.directory = Path(directory)
+        self.timeout = float(os.environ.get('QUNXIA_STALL_SECONDS', '15'))
+        self.started = self.loop_at = self.tick_at = clock()
+        self.tick = int(ticks())
+        self.phase, self.phase_at = 'starting', self.started
+        self.fault = None
+        self.stop_event = threading.Event()
+
+    def pulse(self):
+        self.loop_at = clock()
+
+    def set_phase(self, phase):
+        self.phase, self.phase_at = phase, clock()
+
+    def fail(self, reason):
+        self.fault = self.fault or failure(reason)
+
+    def check(self):
+        if self.fault:
+            raise EnvironmentFailure(self.fault['reason'])
+
+    def sample(self):
+        now, tick = clock(), int(self.ticks())  # atomic C load; no execution lock
+        if tick != self.tick:
+            self.tick, self.tick_at = tick, now
+        if self.phase == 'starting':
+            if now - self.started > 30:
+                self.fail('startup_stalled')
+        elif self.phase == 'finalizing':
+            if now - self.phase_at > 300:
+                self.fail('finalization_stalled')
+        else:
+            if now - self.loop_at > self.timeout:
+                self.fail('event_loop_stalled')
+            elif not self.paused() and now - self.tick_at > self.timeout:
+                self.fail('core_stalled')
+        return {'pid': os.getpid(), 'at': now, 'phase': self.phase, 'phase_at': self.phase_at,
+                'core_ticks': tick, 'healthy': not self.fault and self.phase == 'running' and tick > 0,
+                'failure': self.fault}
+
+    def start(self):
+        self.directory.mkdir(parents=True, exist_ok=True)
+        (self.directory / 'failure.json').unlink(missing_ok=True)
+        def watch():
+            while not self.stop_event.wait(.25):
+                try:
+                    state = self.sample()
+                    write_json(self.directory / 'heartbeat.json', state)
+                    if self.fault:
+                        write_json(self.directory / 'failure.json', self.fault)
+                        os._exit(75)
+                except OSError:
+                    os._exit(75)
+        self.thread = threading.Thread(target=watch, daemon=True)
+        self.thread.start()
+
+    def stop(self):
+        self.stop_event.set()
+        self.thread.join(timeout=1)

--- a/server/index.html
+++ b/server/index.html
@@ -243,6 +243,7 @@
 </aside>
 </div>
 
+<script src="/recording.js"></script>
 <script>
 const cv = document.getElementById("screen");
 const ctx = cv.getContext("2d", { alpha: false });
@@ -343,13 +344,13 @@ saveBtn.onclick = async () => {
   playBtn.disabled = true;
   saveBtn.title = "encodes in real time at 4x, so about a quarter of the session length";
   saveBtn.textContent = "loading";
-  let events;
+  let recording;
   // MediaRecorder samples in real time, so the export takes the recording
   // length divided by the playback speed. Say so rather than appear stuck.
   try {
-    events = (await (await fetch("/api/recording")).json()).events || [];
+    recording = await ReplayRecording.open();
   } catch { saveBtn.disabled = playBtn.disabled = false; saveBtn.textContent = "⤓ mp4"; return; }
-  if (!events.length) { saveBtn.disabled = playBtn.disabled = false; saveBtn.textContent = "⤓ mp4"; return; }
+  if (!(await recording.peek())) { recording.close(); saveBtn.disabled = playBtn.disabled = false; saveBtn.textContent = "⤓ mp4"; return; }
 
   // 640x400 keeps both game modes at a whole multiple, plus a strip for keys.
   const W = 640, H = 400, BAR = 56;
@@ -411,16 +412,18 @@ saveBtn.onclick = async () => {
   mr.start();
 
   const SPEED = 4;
-  const total = events[events.length - 1].t || 1;
+  const total = recording.duration || 1;
   const t0 = performance.now();
-  let i = 0;
+  let exportError = null;
   let raf = requestAnimationFrame(function loop() { compose(); raf = requestAnimationFrame(loop); });
 
-  while (i < events.length) {
-    const ev = events[i];
+  try {
+  while (true) {
+    const ev = await recording.peek();
+    if (!ev) break;
     const wait = t0 + (ev.t * 1000) / SPEED - performance.now();
     if (wait > 2) { await new Promise(r => setTimeout(r, wait)); continue; }
-    i++;
+    recording.take();
     clock = ev.t;
     if (ev.d) {
       paintDelta(await inflate(b64bytes(ev.d)), work, wctx, cache);
@@ -432,10 +435,20 @@ saveBtn.onclick = async () => {
     saveBtn.textContent = Math.round((ev.t / total) * 100) + "% " + fmt(left);
   }
 
+  } catch (error) { exportError = error; }
+  finally { recording.close(); }
+
   await new Promise(r => setTimeout(r, 300));   // let the tail frames be sampled
   cancelAnimationFrame(raf);
   mr.stop();
   await finished;
+
+  if (exportError) {
+    saveBtn.textContent = "export failed";
+    saveBtn.title = exportError.message;
+    saveBtn.disabled = playBtn.disabled = false;
+    return;
+  }
 
   const ext = mime.startsWith("video/mp4") ? "mp4" : "webm";
   const blob = new Blob(chunks, { type: mime });
@@ -454,10 +467,9 @@ playBtn.onclick = async () => {
   playBtn.textContent = "loading";
   let recording;
   try {
-    recording = await (await fetch("/api/recording")).json();
+    recording = await ReplayRecording.open();
   } catch { playBtn.disabled = false; playBtn.textContent = "▶ 4×"; return; }
-  const events = recording.events || [];
-  if (!events.length) { playBtn.disabled = false; playBtn.textContent = "▶ 4×"; return; }
+  if (!(await recording.peek())) { recording.close(); playBtn.disabled = false; playBtn.textContent = "▶ 4×"; return; }
 
   playBtn.textContent = "playing";
   vcr.classList.add("on");
@@ -466,20 +478,22 @@ playBtn.onclick = async () => {
   vcrKeys.textContent = "";
 
   const SPEED = 4;
-  const total = events[events.length - 1].t;
+  const total = recording.duration || 1;
   const cache = {};
   const down = new Set();
-  let cancelled = false, i = 0;
-  vcrStop = () => { cancelled = true; };
+  let cancelled = false;
+  vcrStop = () => { cancelled = true; recording.close(); };
 
   const t0 = performance.now();
   const step = async () => {
-    while (i < events.length && !cancelled) {
-      const ev = events[i];
+    try {
+    while (!cancelled) {
+      const ev = await recording.peek();
+      if (!ev) break;
       const due = t0 + (ev.t * 1000) / SPEED;
       const wait = due - performance.now();
       if (wait > 4) { setTimeout(step, wait); return; }
-      i++;
+      recording.take();
       if (ev.d) {
         paintDelta(await inflate(b64bytes(ev.d)), vcv, vctx, cache);
       } else if (ev.key) {
@@ -502,7 +516,12 @@ playBtn.onclick = async () => {
       document.getElementById("vcrfill").style.width = (ev.t / total) * 100 + "%";
       document.getElementById("vcrtime").textContent = fmt(ev.t);
     }
+    recording.close();
     if (!cancelled) { playBtn.textContent = "▶ 4×"; }
+    } catch (error) {
+      recording.close();
+      if (!cancelled) { playBtn.textContent = "replay unavailable"; playBtn.title = error.message; }
+    }
   };
   step();
 };

--- a/server/peers.py
+++ b/server/peers.py
@@ -55,5 +55,3 @@ class Peer:
             if self.close_task is None:
                 self.close_task = asyncio.create_task(self.close_socket())
             await self.close_task
-
-

--- a/server/peers.py
+++ b/server/peers.py
@@ -1,0 +1,59 @@
+"""Bounded per-viewer sends; a slow socket cannot stop the shared pump."""
+import asyncio
+import contextlib
+
+
+class Peer:
+    """One bounded queue per viewer. Encoding never waits for a socket."""
+    def __init__(self, ws, timeout, on_drop):
+        self.ws, self.timeout, self.on_drop = ws, timeout, on_drop
+        self.queue = asyncio.Queue(maxsize=8)
+        self.bytes = 0
+        self.closed = False
+        self.close_task = None
+        self.task = asyncio.create_task(self.send())
+
+    def put(self, data, text=False):
+        size = len(data.encode()) if text else len(data)
+        if self.closed:
+            return
+        if self.queue.full() or self.bytes + size > 2 << 20:
+            self.drop()
+            return
+        self.bytes += size
+        self.queue.put_nowait((data, text, size))
+
+    def drop(self):
+        if not self.closed:
+            self.closed = True
+            self.on_drop(self.ws)
+            self.task.cancel()
+            self.close_task = asyncio.create_task(self.close_socket())
+
+    async def close_socket(self):
+        while not self.queue.empty():
+            self.queue.get_nowait()
+        self.bytes = 0
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.wait_for(self.ws.close(code=1013, message=b"reconnect for a full frame"), 1)
+
+    async def send(self):
+        try:
+            while True:
+                data, text, size = await self.queue.get()
+                try:
+                    await asyncio.wait_for(self.ws.send_str(data) if text else self.ws.send_bytes(data),
+                                           timeout=self.timeout)
+                finally:
+                    self.bytes = max(0, self.bytes - size)
+        except (Exception, asyncio.CancelledError):
+            pass
+        finally:
+            if not self.closed:
+                self.closed = True
+                self.on_drop(self.ws)
+            if self.close_task is None:
+                self.close_task = asyncio.create_task(self.close_socket())
+            await self.close_task
+
+

--- a/server/recording.js
+++ b/server/recording.js
@@ -1,0 +1,35 @@
+// One page at a time; the server pins the recording so reset cannot change it.
+class ReplayRecording {
+  static async open() {
+    const source = new ReplayRecording();
+    await source.load({});
+    source.keepalive = setInterval(() => source.request({touch:'1'}).catch(() => {}), 60000);
+    return source;
+  }
+  async request(extra) {
+    const query = new URLSearchParams({view:'paged', ...(this.token ? {token:this.token} : {}), ...extra});
+    const response = await fetch('/api/recording?' + query);
+    const page = await response.json();
+    if (!response.ok) throw new Error(page.error || 'Recording unavailable');
+    return page;
+  }
+  async load(extra) {
+    this.page = await this.request(extra);
+    this.token = this.page.token;
+    this.duration = this.page.duration;
+    this.index = 0;
+  }
+  async peek() {
+    if (this.closed) return null;
+    if (this.index >= this.page.events.length && !this.page.done) await this.load({start:this.page.next});
+    return this.closed ? null : (this.page.events[this.index] || null);
+  }
+  take() { this.index++; }
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    clearInterval(this.keepalive);
+    this.request({close:'1'}).catch(() => {});
+    this.page = {events:[],done:true};
+  }
+}

--- a/server/recording.py
+++ b/server/recording.py
@@ -1,0 +1,151 @@
+"""Bounded reads of an immutable prefix of the append-only recording."""
+import json
+import os
+import time
+from pathlib import Path
+
+MAX_LINE = 4 << 20
+
+
+class Snapshot:
+    def __init__(self, path, fd, end, last_timestamp=0):
+        self.path, self.fd, self.end = Path(path), fd, end
+        self.closed = False
+        try:
+            _, header = next(self.lines(0))
+            self.header = json.loads(header)
+            self.begin = len(header)
+            self.duration = last_timestamp
+            self.elapsed = round(max(0, time.time() - self.header["started"]), 2)
+        except BaseException:
+            self.close()
+            raise
+
+    def lines(self, start):
+        # dup pins the inode but shares the writer's file offset. pread uses
+        # an independent cursor even while the writer appends or resets.
+        offset, pending = start, b''
+        while offset + len(pending) < self.end:
+            chunk = os.pread(self.fd, min(64 << 10, self.end-offset-len(pending)), offset+len(pending))
+            if not chunk:
+                raise ValueError('recording was truncated')
+            pending += chunk
+            while b'\n' in pending:
+                line, pending = pending.split(b'\n', 1)
+                line += b'\n'
+                if len(line) > MAX_LINE:
+                    raise ValueError('recording event is too large')
+                yield offset, line
+                offset += len(line)
+            if len(pending) > MAX_LINE:
+                raise ValueError('recording event is too large')
+        if pending:
+            raise ValueError('recording has an incomplete trailing event')
+
+    def __iter__(self):
+        for _, line in self.lines(self.begin):
+            event = json.loads(line)
+            if not isinstance(event, dict) or 't' not in event:
+                raise ValueError('invalid recording event; raw JSONL remains available')
+            yield event
+
+    def page(self, start=None, byte_limit=1 << 20):
+        start = self.begin if start is None else int(start)
+        if not self.begin <= start <= self.end or (start > self.begin and os.pread(self.fd, 1, start-1) != b'\n'):
+            raise ValueError('invalid recording cursor')
+        events, size, cursor = [], 0, start
+        for offset, line in self.lines(start):
+            if events and (size + len(line) > byte_limit or len(events) >= 2048):
+                break
+            event = json.loads(line)
+            if not isinstance(event, dict) or 't' not in event:
+                raise ValueError('invalid recording event; raw JSONL remains available')
+            events.append(event)
+            size += len(line)
+            cursor = offset + len(line)
+        return {'events': events, 'next': cursor, 'end': self.end,
+                'done': cursor == self.end, 'duration': self.duration,
+                'started': self.header.get('started')}
+
+    def close(self):
+        if not self.closed:
+            self.closed = True
+            os.close(self.fd)
+
+    def __del__(self):
+        if hasattr(self, 'closed'):
+            self.close()
+
+
+class RecordingAPI:
+    def __init__(self, store):
+        self.store = store
+        self.readers = {}
+
+    def snapshot(self):
+        return Snapshot(**self.store.pin())
+
+    async def handle(self, request):
+        from aiohttp import web
+        import uuid
+        if request.query.get('view') == 'paged':
+            now = time.monotonic()
+            for token, (reader, touched) in list(self.readers.items()):
+                if now - touched > 120:
+                    reader.close()
+                    del self.readers[token]
+            token = request.query.get('token')
+            if not token:
+                if len(self.readers) >= 4:
+                    return web.json_response({'error': 'too many replay readers'}, status=429)
+                token = uuid.uuid4().hex
+                self.readers[token] = (self.snapshot(), now)
+            elif token not in self.readers:
+                return web.json_response({'error': 'replay expired; reopen it'}, status=410)
+            reader, _ = self.readers[token]
+            if request.query.get('close') == '1':
+                reader.close()
+                del self.readers[token]
+                return web.json_response({'ok': True})
+            self.readers[token] = (reader, now)
+            if request.query.get('touch') == '1':
+                return web.json_response({'ok': True})
+            try:
+                return web.json_response(dict(reader.page(request.query.get('start')), token=token))
+            except ValueError as exc:
+                return web.json_response({'error': str(exc)}, status=400)
+
+        pin = self.store.pin()
+        raw = request.query.get('format') == 'jsonl'
+        response = web.StreamResponse(headers={'Content-Type': 'application/x-ndjson' if raw else 'application/json'})
+        reader = None
+        try:
+            if not raw:
+                reader = Snapshot(**pin)
+            await response.prepare(request)
+            if raw:
+                for start in range(0, pin['end'], 64 << 10):
+                    await response.write(os.pread(pin['fd'], min(64 << 10, pin['end']-start), start))
+            else:
+                head = json.dumps({'started': reader.header['started'], 'duration': reader.elapsed})[:-1]
+                await response.write((head + ',"events":[').encode())
+                first = True
+                payload_bytes = 0
+                for event in reader:
+                    data = event.get("d", "")
+                    payload_bytes += len(data) * 3 // 4 - (len(data) - len(data.rstrip("=")))
+                    await response.write((('' if first else ',')+json.dumps(event, separators=(',', ':'))).encode())
+                    first = False
+                await response.write(('],"bytes":' + str(payload_bytes) + '}').encode())
+            await response.write_eof()
+            return response
+        finally:
+            if reader:
+                reader.close()
+            elif raw:
+                os.close(pin['fd'])
+
+    def close(self):
+        for reader, _ in self.readers.values():
+            reader.close()
+        self.readers.clear()

--- a/server/recording_store.py
+++ b/server/recording_store.py
@@ -1,0 +1,228 @@
+"""Append-only JSONL recording. Successful append means write + fsync finished."""
+from collections import deque
+import json
+import fcntl
+import math
+import os
+from pathlib import Path
+import threading
+import time
+import uuid
+
+
+def sync_directory(path):
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+class RecordingStore:
+    MAX_PENDING = 4 << 20
+
+    def __init__(self, path, started=None):
+        self.fd = self.lease_fd = None
+        try:
+            self.path = Path(path)
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self.lock = threading.RLock()
+            self.lease_fd = os.open(self.path.with_suffix(self.path.suffix + '.lock'),
+                                    os.O_CREAT | os.O_RDWR, 0o600)
+            try:
+                fcntl.flock(self.lease_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                os.close(self.lease_fd)
+                self.lease_fd = None
+                raise RuntimeError('another process owns this recording directory')
+            self.pending = deque()
+            self.pending_bytes = 0
+            self.error = ''
+            self.directory_pending = False
+            self.fd = None
+            self.pending_start = None
+            self.last_timestamp = 0.0
+            self.started = time.time() if started is None else started
+            fallback_started = self.started
+            if self.path.exists():
+                try:
+                    with self.path.open('rb') as stream:
+                        header = json.loads(stream.readline(64 << 10))
+                        self.started = float(header['started'])
+                        if not math.isfinite(self.started):
+                            raise ValueError('recording origin is not finite')
+                        size = os.fstat(stream.fileno()).st_size
+                        # A timestamp is all startup needs from old content. Keep
+                        # at most one bounded tail, never a replay cache.
+                        header_end = stream.tell()
+                        start = max(header_end, size - self.MAX_PENDING)
+                        stream.seek(start)
+                        if start > header_end:
+                            stream.readline()
+                        for line in stream:
+                            try:
+                                event = json.loads(line)
+                                when = float(event.get('t', 0))
+                                if math.isfinite(when) and when >= 0:
+                                    self.last_timestamp = max(self.last_timestamp, when)
+                            except (ValueError, TypeError, UnicodeError, AttributeError):
+                                continue
+                except (OSError, ValueError, KeyError, TypeError):
+                    # Never clear an unreadable recording. Archive its exact bytes
+                    # before opening a new journal so it remains recoverable.
+                    self.started = fallback_started
+                    self.archive()
+            if not self.path.exists():
+                self._new_file()
+            self.fd = os.open(self.path, os.O_RDWR | os.O_APPEND)
+            size = os.fstat(self.fd).st_size
+            if size and os.pread(self.fd, 1, size - 1) != b'\n':
+                os.write(self.fd, b'\n')
+                os.fsync(self.fd)
+            self.committed_size = os.fstat(self.fd).st_size
+        except BaseException:
+            for descriptor in (self.fd, self.lease_fd):
+                if descriptor is not None:
+                    os.close(descriptor)
+            self.fd = self.lease_fd = None
+            raise
+
+    def _prepare_file(self, started):
+        data = (json.dumps({'version': 1, 'started': started}) + '\n').encode()
+        tmp = self.path.with_name(self.path.name + '.' + uuid.uuid4().hex + '.tmp')
+        try:
+            with tmp.open('xb') as stream:
+                stream.write(data)
+                stream.flush()
+                os.fsync(stream.fileno())
+            return tmp
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
+
+    def _new_file(self):
+        tmp = self._prepare_file(self.started)
+        try:
+            os.replace(tmp, self.path)
+            sync_directory(self.path.parent)
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    def _write(self, data):
+        if self.pending_start is None:
+            self.pending_start = os.fstat(self.fd).st_size
+        start = self.pending_start
+        try:
+            if os.fstat(self.fd).st_size != start:
+                os.ftruncate(self.fd, start)
+            view = memoryview(data)
+            while view:
+                written = os.write(self.fd, view)
+                if written <= 0:
+                    raise OSError('recording write made no progress')
+                view = view[written:]
+            os.fsync(self.fd)
+            self.committed_size = start + len(data)
+            self.pending_start = None
+        except OSError:
+            # Only the uncommitted suffix belongs to this attempt. Keep its
+            # bytes in pending and remove a partial append before retrying.
+            os.ftruncate(self.fd, start)
+            raise
+
+    def append(self, event):
+        if not isinstance(event, dict):
+            raise ValueError('recording event must be an object')
+        when = float(event.get('t', -1))
+        if not math.isfinite(when) or when < 0:
+            raise ValueError('recording event time must be finite and non-negative')
+        data = (json.dumps(event, separators=(',', ':'), ensure_ascii=False) + '\n').encode()
+        with self.lock:
+            if self.pending_bytes + len(data) > self.MAX_PENDING:
+                raise BufferError('recording storage is blocked; input must wait')
+            self.pending.append(data)
+            self.pending_bytes += len(data)
+            return self.flush()
+
+    def flush(self):
+        with self.lock:
+            if self.directory_pending:
+                try:
+                    sync_directory(self.path.parent)
+                    self.directory_pending = False
+                except OSError as error:
+                    self.error = str(error)
+                    return False
+            while self.pending:
+                try:
+                    self._write(self.pending[0])
+                except OSError as error:
+                    self.error = str(error)
+                    return False
+                data = self.pending.popleft()
+                self.pending_bytes -= len(data)
+                self.last_timestamp = max(self.last_timestamp, float(json.loads(data).get('t', 0)))
+            self.error = ''
+            return True
+
+    def archive(self, unlink=True):
+        with self.lock:
+            if self.pending and not self.flush():
+                raise OSError('cannot archive while recording writes are pending: ' + self.error)
+            folder = self.path.parent / 'recordings'
+            folder.mkdir(exist_ok=True)
+            sync_directory(self.path.parent)
+            target = folder / (time.strftime('%Y%m%d-%H%M%S') + '-' + uuid.uuid4().hex[:12] + '.jsonl')
+            if self.path.exists():
+                # Link first, then remove the active name. A failed operation
+                # always leaves at least one durable name for the old content.
+                os.link(self.path, target)
+                sync_directory(folder)
+                if unlink:
+                    self.path.unlink()
+                    sync_directory(self.path.parent)
+            if unlink and self.fd is not None:
+                os.close(self.fd)
+                self.fd = None
+            return target
+
+    def reset(self, started):
+        with self.lock:
+            tmp = self._prepare_file(started)
+            new_fd = None
+            try:
+                archived = self.archive(unlink=False)
+                new_fd = os.open(tmp, os.O_RDWR | os.O_APPEND)
+                os.replace(tmp, self.path)
+                # Once replace succeeds, the descriptor and metadata must
+                # follow the active inode even if directory fsync fails.
+                old_fd, self.fd = self.fd, new_fd
+                new_fd = None
+                if old_fd is not None:
+                    os.close(old_fd)
+                self.committed_size = os.fstat(self.fd).st_size
+                self.started, self.last_timestamp = started, 0.0
+                self.directory_pending = True
+                if not self.flush():
+                    raise OSError(self.error)
+                return archived
+            finally:
+                if new_fd is not None:
+                    os.close(new_fd)
+                tmp.unlink(missing_ok=True)
+
+    def pin(self):
+        """Pin only acknowledged bytes, even if a reset follows immediately."""
+        with self.lock:
+            return {'path': self.path, 'fd': os.dup(self.fd), 'end': self.committed_size, 'last_timestamp': self.last_timestamp}
+
+    def close(self):
+        with self.lock:
+            if self.fd is not None:
+                if not self.flush():
+                    raise OSError(self.error)
+                os.close(self.fd)
+                self.fd = None
+            if self.lease_fd is not None:
+                os.close(self.lease_fd)
+                self.lease_fd = None

--- a/server/server.py
+++ b/server/server.py
@@ -27,6 +27,9 @@ from PIL import Image
 from prompt import system_prompt
 from health import Health, EnvironmentFailure
 from peers import Peer
+from recording_store import RecordingStore
+from recording import RecordingAPI
+from storage import validate_recording_directory
 
 ROOT = pathlib.Path(__file__).resolve().parent
 LIB = ctypes.CDLL(str(ROOT / "libqunxia.so"))
@@ -59,6 +62,12 @@ LIB.core_load_state.argtypes = [ctypes.c_char_p]
 LIB.core_load_state.restype = ctypes.c_bool
 
 health = None
+recording_store = recording_api = None
+recording_blocked = False
+
+class RecordingUnavailable(RuntimeError):
+    pass
+
 peers = {}
 emulator_stop = threading.Event()
 BUF = ctypes.create_string_buffer(4 << 20)
@@ -109,10 +118,7 @@ stats = {"frames": 0, "sent": 0, "bytes": 0, "tiles": 0, "dropped": 0,
 SEND_TIMEOUT = float(os.environ.get("QUNXIA_SEND_TIMEOUT", "3"))
 # Recording. Tile deltas are what the stream already produces, so a recording is
 # just those kept with timestamps, plus the keys that caused them.
-IDLE_AFTER = 3.0          # no action for this long and the tail is idle
-IDLE_TAIL = 30.0          # of which only the last this much is kept
-KEYFRAME_EVERY = 30.0     # so pruning can always start from a whole picture
-REC_MAX_BYTES = 12 << 20
+KEYFRAME_EVERY = 30.0     # periodic complete frames in the disk recording
 LOCK_TIMEOUT = float(os.environ.get("QUNXIA_LOCK_TIMEOUT", "30"))
 # Four frames can fit inside one slow game-loop redraw, so a short keydown and
 # keyup may be consumed together without producing a map step. Ten frames are
@@ -241,10 +247,11 @@ async def pump():
     while True:
         try:
             await asyncio.sleep(period)
+            if recording_blocked:
+                continue
             stats["pump_ticks"] += 1
             now = time.time()
-            # A whole picture at intervals, so a pruned recording always has
-            # somewhere to start replaying from.
+            # Periodic complete frames preserve standalone replay boundaries.
             force = now - last_key_at >= KEYFRAME_EVERY
             serial = LIB.core_frame_serial()
             if serial == last_serial and not force:
@@ -298,40 +305,37 @@ def rec_add(kind, payload=None, key=None, down=None, keyframe=False):
         ev["down"] = bool(down)
         if rec["actor"]:
             ev["who"] = rec["actor"]
-    rec["events"].append(ev)
-    rec_prune(now)
+    if recording_store:
+        try:
+            ok = recording_store.append(ev)
+        except (OSError, BufferError) as exc:
+            recording_store.error = str(exc)
+            ok = False
+        if not ok:
+            block_recording()
+            raise RecordingUnavailable(recording_store.error)
+        rec["bytes"] = recording_store.committed_size
 
 
-def rec_prune(now):
-    """Two bounds. A long idle tail keeps only its last IDLE_TAIL seconds, so an
-    untouched game does not grow forever while still showing its own animation.
-    And the whole thing is capped, dropping from the front to the oldest
-    keyframe that fits, because deltas cannot be replayed from the middle."""
-    idle_for = now - rec["last_activity"]
-    if idle_for > IDLE_AFTER:
-        cutoff = round(now - rec["started"] - IDLE_TAIL, 3)
-        head, tail = [], []
-        for ev in rec["events"]:
-            (tail if ev["t"] >= cutoff else head).append(ev)
-        # only trailing idle frames are droppable; anything before the idle
-        # stretch began is real history
-        idle_began = round(now - rec["started"] - idle_for, 3)
-        keep = [e for e in head if e["t"] <= idle_began] + tail
-        if len(keep) < len(rec["events"]):
-            rec["events"] = keep
-
-    if rec["bytes"] > REC_MAX_BYTES:
-        for i, ev in enumerate(rec["events"]):
-            if ev.get("k") and i > 0:
-                dropped = rec["events"][:i]
-                rec["bytes"] -= sum(len(e.get("d", "")) * 3 // 4 for e in dropped)
-                rec["events"] = rec["events"][i:]
-                break
+def block_recording():
+    global recording_blocked
+    recording_blocked = True
+    paused.set()
 
 
 def rec_reset():
-    rec.update(started=time.time(), events=[], bytes=0, last_key=0.0,
-               last_activity=time.time())
+    if recording_store:
+        try:
+            recording_store.reset(time.time())
+        except OSError as exc:
+            recording_store.error = str(exc)
+            block_recording()
+            raise RecordingUnavailable(str(exc)) from exc
+        finally:
+            rec.update(started=recording_store.started, events=[], bytes=recording_store.committed_size,
+                       last_key=0.0, last_activity=time.time())
+    else:
+        rec.update(started=time.time(), events=[], bytes=0, last_key=0.0, last_activity=time.time())
 
 
 def session_summary():
@@ -353,9 +357,13 @@ async def reap():
 
 
 async def send_keyframe(ws):
+    # Encoding changes the shared delta baseline. Persist and broadcast that
+    # full frame before any later delta is allowed to use it.
     n = LIB.fb_encode_delta(BUF, len(BUF), 1)
     if n > 0:
-        peers[ws].put(zlib.compress(BUF.raw[:n], 6))
+        payload = zlib.compress(BUF.raw[:n], 6)
+        rec_add("f", payload, keyframe=True)
+        await fanout(payload)
 
 
 async def ws_handler(request):
@@ -363,7 +371,11 @@ async def ws_handler(request):
     await ws.prepare(request)
     clients.add(ws)
     peers[ws] = Peer(ws, SEND_TIMEOUT, drop_peer)
-    await send_keyframe(ws)
+    try:
+        await send_keyframe(ws)
+    except BaseException:
+        peers[ws].drop()
+        raise
     peers[ws].put(json.dumps({"t": "log", "e": list(history)[-80:],
                                   "s": session_summary()}), text=True)
     # code -> (name, core tick at keydown). Browser automation can emit keydown
@@ -382,6 +394,8 @@ async def ws_handler(request):
             if not isinstance(d, dict):
                 continue
             t = d.get("t")
+            if recording_blocked and not (t == "key" and not d.get("down")):
+                continue
             if t == "key":
                 name = str(d.get("k", "")).lower()
                 code = KEYS.get(name)
@@ -428,7 +442,10 @@ async def ws_handler(request):
     finally:
         for code, (name, _) in list(holding.items()):
             LIB.core_key(code, False)
-            key_event(name, False)
+            try:
+                key_event(name, False)
+            except RecordingUnavailable:
+                pass
         holding.clear()
         if lock_held:
             action_lock().release()
@@ -532,6 +549,8 @@ async def pause_emulator():
 
 
 def resume_emulator():
+    if recording_blocked:
+        return
     paused.clear()
     # Do not let a following pause observe the acknowledgement from this one.
     paused_ack.clear()
@@ -601,9 +620,9 @@ def key_event(name, down):
 
 
 async def tap(code, hold_frames, name=None):
-    key_event(name, True)
-    LIB.core_key(code, True)
     try:
+        key_event(name, True)
+        LIB.core_key(code, True)
         await wait_core_frames(hold_frames)
     finally:
         LIB.core_key(code, False)
@@ -1024,11 +1043,7 @@ async def api_reset(request):
         await asyncio.sleep(0.4 if restored else 1.5)
 
     await fanout(json.dumps({"t": "clear"}), text=True)
-    for ws in list(clients):
-        try:
-            await asyncio.wait_for(send_keyframe(ws), timeout=SEND_TIMEOUT)
-        except Exception:
-            clients.discard(ws)
+    await send_keyframe(None)
     log_action("api", "RESET", "restored start state" if restored else "rebooted to title")
     return web.json_response({"ok": True, "reset": True, "restored": restored})
 
@@ -1052,14 +1067,10 @@ async def api_snapshot(request):
     return web.json_response({"ok": ok, "path": START_STATE, "bytes": size})
 
 
-async def api_recording(_request):
-    """The session so far as tile deltas and key presses, for playback."""
-    return web.json_response({
-        "started": rec["started"],
-        "duration": round(time.time() - rec["started"], 2),
-        "events": rec["events"],
-        "bytes": rec["bytes"],
-    })
+async def api_recording(request):
+    if recording_api:
+        return await recording_api.handle(request)
+    return web.json_response({"started": rec["started"], "duration": 0, "events": [], "bytes": 0})
 
 
 async def api_history(request):
@@ -1081,6 +1092,10 @@ async def api_help(request):
                         content_type="text/plain", charset="utf-8")
 
 
+async def recording_script(_request):
+    return web.FileResponse(ROOT / "recording.js")
+
+
 async def index(_request):
     return web.FileResponse(ROOT / "index.html")
 
@@ -1091,15 +1106,21 @@ async def status(_request):
         "fps": round(LIB.core_fps(), 3), "frame": LIB.core_frame_serial(),
         "clients": len(clients), "session": session_summary(), **stats,
         **(health.sample() if health else {}),
+        "recording": {"cache_bytes": 0, "pending_bytes": recording_store.pending_bytes if recording_store else 0,
+                      "error": recording_store.error if recording_store else ""},
     })
 
 
 @web.middleware
 async def json_errors(request, handler):
     try:
+        if recording_blocked and request.method == "POST" and request.path.startswith("/api/"):
+            raise RecordingUnavailable(recording_store.error)
         if health:
             health.check()
         return await handler(request)
+    except RecordingUnavailable as exc:
+        return web.json_response({"ok": False, "error": "recording_unavailable", "message": str(exc)}, status=503)
     except EnvironmentFailure as exc:
         if health:
             health.fail(str(exc))
@@ -1117,8 +1138,13 @@ async def startup(app):
 
 
 async def pulse_health():
+    global recording_blocked
     while True:
         health.pulse()
+        if recording_blocked and recording_store.flush():
+            recording_blocked = False
+            LIB.fb_reset()
+            resume_emulator()
         await asyncio.sleep(.25)
 
 
@@ -1133,10 +1159,20 @@ async def cleanup(app):
     if health:
         LIB.core_shutdown()
         health.stop()
+    if recording_api:
+        recording_api.close()
+        recording_store.close()
 
 
 def main():
-    global health
+    global health, recording_store, recording_api
+    directory = os.environ.get("QUNXIA_RECORDING_DIR", str(ROOT.parent / "recordings"))
+    validate_recording_directory(directory)
+    path = pathlib.Path(os.environ.get("QUNXIA_RECORDING_FILE", str(pathlib.Path(directory) / f"{PORT}.jsonl")))
+    validate_recording_directory(path.parent)
+    recording_store = RecordingStore(path)
+    recording_api = RecordingAPI(recording_store)
+    rec.update(started=recording_store.started, events=[], bytes=recording_store.committed_size)
     health = Health(LIB.core_ticks, paused.is_set, os.environ.get("QUNXIA_HEALTH_DIR", str(pathlib.Path(SAVES) / ".health")))
     health.start()
     os.makedirs(SAVES, exist_ok=True)
@@ -1157,6 +1193,7 @@ def main():
     app = web.Application(middlewares=[json_errors])
     app.add_routes([
         web.get("/", index),
+        web.get("/recording.js", recording_script),
         web.get("/ws", ws_handler),
         web.get("/status", status),
         web.get("/api/screen", api_screen),

--- a/server/server.py
+++ b/server/server.py
@@ -25,6 +25,8 @@ from aiohttp import WSMsgType, web
 from PIL import Image
 
 from prompt import system_prompt
+from health import Health, EnvironmentFailure
+from peers import Peer
 
 ROOT = pathlib.Path(__file__).resolve().parent
 LIB = ctypes.CDLL(str(ROOT / "libqunxia.so"))
@@ -56,6 +58,9 @@ LIB.core_save_state.restype = ctypes.c_bool
 LIB.core_load_state.argtypes = [ctypes.c_char_p]
 LIB.core_load_state.restype = ctypes.c_bool
 
+health = None
+peers = {}
+emulator_stop = threading.Event()
 BUF = ctypes.create_string_buffer(4 << 20)
 
 # Key name -> RETROK. Same vocabulary as the native runner.
@@ -183,36 +188,19 @@ def log_action(src, verb, target, detail="", ok=True, thumb=False):
     return entry
 
 
-async def _send_one(ws, data, text):
-    """One send, bounded. A peer that vanished without closing the TCP
-    connection blocks forever once its window fills, so every send needs a
-    deadline of its own."""
-    try:
-        send = ws.send_str(data) if text else ws.send_bytes(data)
-        await asyncio.wait_for(send, timeout=SEND_TIMEOUT)
-        return ws, True
-    except Exception:
-        return ws, False
+def drop_peer(ws):
+    clients.discard(ws)
+    if peers.pop(ws, None) is not None:
+        stats["dropped"] += 1
 
 
 async def fanout(data, text=False):
-    """Send to every client at once and drop the ones that fail.
-
-    Sending serially meant a single stuck client stalled the broadcast for
-    everyone, which is how streaming died while the emulator kept running.
-    """
-    targets = []
     for ws in list(clients):
-        if ws.closed:
+        peer = peers.get(ws)
+        if ws.closed or peer is None:
             clients.discard(ws)
         else:
-            targets.append(ws)
-    if not targets:
-        return
-    for ws, ok in await asyncio.gather(*(_send_one(ws, data, text) for ws in targets)):
-        if not ok:
-            clients.discard(ws)
-            stats["dropped"] += 1
+            peer.put(data, text)
 
 
 async def broadcast_log(entry):
@@ -223,7 +211,7 @@ def emulate():
     """Own thread. ctypes drops the GIL for each call, so asyncio keeps running."""
     budget = 1.0 / max(1.0, LIB.core_fps())
     nxt = time.perf_counter()
-    while True:
+    while not emulator_stop.is_set():
         if paused.is_set():
             paused_ack.set()
             time.sleep(0.02)
@@ -367,16 +355,17 @@ async def reap():
 async def send_keyframe(ws):
     n = LIB.fb_encode_delta(BUF, len(BUF), 1)
     if n > 0:
-        await ws.send_bytes(zlib.compress(BUF.raw[:n], 6))
+        peers[ws].put(zlib.compress(BUF.raw[:n], 6))
 
 
 async def ws_handler(request):
-    ws = web.WebSocketResponse(max_msg_size=0, heartbeat=30)
+    ws = web.WebSocketResponse(max_msg_size=4096, heartbeat=30, compress=False)
     await ws.prepare(request)
     clients.add(ws)
+    peers[ws] = Peer(ws, SEND_TIMEOUT, drop_peer)
     await send_keyframe(ws)
-    await ws.send_str(json.dumps({"t": "log", "e": list(history)[-80:],
-                                  "s": session_summary()}))
+    peers[ws].put(json.dumps({"t": "log", "e": list(history)[-80:],
+                                  "s": session_summary()}), text=True)
     # code -> (name, core tick at keydown). Browser automation can emit keydown
     # and keyup within one emulated frame, so remember when each press reached
     # the core and fence short pulses on release.
@@ -386,7 +375,12 @@ async def ws_handler(request):
         async for msg in ws:
             if msg.type != WSMsgType.TEXT:
                 continue
-            d = msg.json()
+            try:
+                d = msg.json()
+            except ValueError:
+                continue
+            if not isinstance(d, dict):
+                continue
             t = d.get("t")
             if t == "key":
                 name = str(d.get("k", "")).lower()
@@ -438,6 +432,9 @@ async def ws_handler(request):
         holding.clear()
         if lock_held:
             action_lock().release()
+        peer = peers.get(ws)
+        if peer:
+            peer.drop()
         clients.discard(ws)
     return ws
 
@@ -480,7 +477,7 @@ async def settle(baseline, react=30, stable=9, maxframes=120):
     last, runs, n = baseline, 0, 0
     seen: dict[int, int] = {}
     while n < maxframes:
-        await asyncio.sleep(ft)
+        await wait_core_frames(1)
         n += 1
         h = LIB.core_frame_hash()
         if not reacted:
@@ -514,7 +511,9 @@ async def wait_core_frames(frames):
     poll = min(0.01, 0.5 / fps)
     while LIB.core_ticks() < target:
         if loop.time() >= deadline:
-            raise RuntimeError("emulator frame clock stalled during input")
+            if health:
+                health.fail("core_stalled")
+            raise EnvironmentFailure("emulator frame clock stalled during input")
         await asyncio.sleep(poll)
 
 
@@ -526,7 +525,9 @@ async def pause_emulator():
     while not paused_ack.is_set():
         if loop.time() >= deadline:
             paused.clear()
-            raise RuntimeError("emulator did not pause")
+            if health:
+                health.fail("pause_stalled")
+            raise EnvironmentFailure("emulator did not pause")
         await asyncio.sleep(0.005)
 
 
@@ -1089,7 +1090,20 @@ async def status(_request):
         "width": LIB.core_width(), "height": LIB.core_height(),
         "fps": round(LIB.core_fps(), 3), "frame": LIB.core_frame_serial(),
         "clients": len(clients), "session": session_summary(), **stats,
+        **(health.sample() if health else {}),
     })
+
+
+@web.middleware
+async def json_errors(request, handler):
+    try:
+        if health:
+            health.check()
+        return await handler(request)
+    except EnvironmentFailure as exc:
+        if health:
+            health.fail(str(exc))
+        return web.json_response(health.fault, status=503)
 
 
 async def startup(app):
@@ -1097,9 +1111,34 @@ async def startup(app):
     api_lock = asyncio.Lock()
     app["pump"] = asyncio.create_task(pump())
     app["reaper"] = asyncio.create_task(reap())
+    if health:
+        app["heartbeat"] = asyncio.create_task(pulse_health())
+        health.set_phase("running")
+
+
+async def pulse_health():
+    while True:
+        health.pulse()
+        await asyncio.sleep(.25)
+
+
+async def cleanup(app):
+    for task in app.values():
+        if isinstance(task, asyncio.Task):
+            task.cancel()
+    await asyncio.gather(*(t for t in app.values() if isinstance(t, asyncio.Task)), return_exceptions=True)
+    for peer in list(peers.values()):
+        peer.drop()
+    emulator_stop.set()
+    if health:
+        LIB.core_shutdown()
+        health.stop()
 
 
 def main():
+    global health
+    health = Health(LIB.core_ticks, paused.is_set, os.environ.get("QUNXIA_HEALTH_DIR", str(pathlib.Path(SAVES) / ".health")))
+    health.start()
     os.makedirs(SAVES, exist_ok=True)
     # Measured on this class of VM: 77000 cycles leaves only 1.75x headroom over
     # the 70.09 fps the core needs, which a shared-core instance cannot hold once
@@ -1115,7 +1154,7 @@ def main():
         raise SystemExit("core_init failed: " + LIB.core_last_error().decode())
     threading.Thread(target=emulate, daemon=True).start()
 
-    app = web.Application()
+    app = web.Application(middlewares=[json_errors])
     app.add_routes([
         web.get("/", index),
         web.get("/ws", ws_handler),
@@ -1137,6 +1176,7 @@ def main():
     # Startup handlers are awaited, so the workers are detached tasks rather
     # than returned, or startup would block on loops that never end.
     app.on_startup.append(startup)
+    app.on_cleanup.append(cleanup)
     web.run_app(app, host="0.0.0.0", port=PORT, access_log=None)
 
 

--- a/server/server.py
+++ b/server/server.py
@@ -527,7 +527,11 @@ async def wait_core_frames(frames):
     deadline = loop.time() + max(1.0, frames / fps * 5 + 0.5)
     poll = min(0.01, 0.5 / fps)
     while LIB.core_ticks() < target:
+        if recording_blocked:
+            raise RecordingUnavailable(recording_store.error or "recording storage is paused")
         if loop.time() >= deadline:
+            if recording_blocked:
+                raise RecordingUnavailable(recording_store.error or "recording storage is paused")
             if health:
                 health.fail("core_stalled")
             raise EnvironmentFailure("emulator frame clock stalled during input")

--- a/server/storage.py
+++ b/server/storage.py
@@ -1,0 +1,63 @@
+"""Validate the recording location without confusing a file with a disk."""
+import os
+from pathlib import Path
+import platform
+import re
+import tempfile
+
+MEMORY_FILESYSTEMS = {'tmpfs', 'ramfs', 'devtmpfs'}
+
+
+def mount_for(path, mountinfo=None):
+    path = Path(path).resolve()
+    if mountinfo is None:
+        try:
+            mountinfo = Path('/proc/self/mountinfo').read_text()
+        except OSError:
+            return {'mount': '/', 'filesystem': 'apfs' if platform.system() == 'Darwin' else 'unknown'}
+    matches = []
+    for line in mountinfo.splitlines():
+        try:
+            before, after = line.split(' - ', 1)
+            raw = before.split()[4]
+            mount = re.sub(r'\\([0-7]{3})', lambda m: chr(int(m[1], 8)), raw)
+            root = Path(mount)
+            if path == root or root in path.parents:
+                matches.append({'mount': str(root), 'filesystem': after.split()[0]})
+        except (ValueError, IndexError):
+            continue
+    return max(matches, key=lambda item: len(item['mount'])) if matches else {'mount': '/', 'filesystem': 'unknown'}
+
+
+def validate_recording_directory(path, *, cloud=None, mountinfo=None):
+    path = Path(path).expanduser().resolve()
+    if cloud is None:
+        cloud = any(os.environ.get(name) for name in ('K_SERVICE', 'CLOUD_RUN_JOB', 'CLOUD_RUN_WORKER_POOL'))
+    backing = mount_for(path, mountinfo)
+    memory = backing['filesystem'] in MEMORY_FILESYSTEMS or (cloud and backing['mount'] == '/')
+    if memory:
+        raise RuntimeError('recording directory uses instance memory; mount real persistent storage '
+                           'and set QUNXIA_RECORDING_DIR (container /tmp is not durable storage)')
+    if cloud and (backing['mount'] == '/' or backing['filesystem'] not in ('nfs', 'nfs4', 'ext4', 'xfs', 'btrfs')):
+        raise RuntimeError('Cloud Run recording storage must be an explicit POSIX persistent volume; '
+                           'GCS/FUSE append semantics are not implemented by this file recorder')
+    path.mkdir(parents=True, exist_ok=True)
+    # Fail before starting a game if basic write/sync/rename semantics fail.
+    fd, probe = tempfile.mkstemp(prefix='.storage-check-', dir=path)
+    probe = Path(probe)
+    moved = probe.with_suffix('.moved')
+    try:
+        with os.fdopen(fd, 'wb') as stream:
+            stream.write(b'qunxia recording storage probe\n')
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(probe, moved)
+        if moved.read_bytes() != b'qunxia recording storage probe\n':
+            raise RuntimeError('recording storage readback did not match')
+    finally:
+        probe.unlink(missing_ok=True)
+        moved.unlink(missing_ok=True)
+    return {'path': str(path), **backing, 'memory_backed': False,
+            'cloud_run': bool(cloud), 'persistent_mount': backing['mount'] != '/',
+            'python_history_cache_bytes': 0,
+            'scope': 'file write/sync/rename checked; host/container memory is a separate resource limit'}

--- a/server/test_core_thread_safety.py
+++ b/server/test_core_thread_safety.py
@@ -1,0 +1,232 @@
+"""Build a tiny fake core so concurrency regressions need no game assets."""
+import ctypes
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+@unittest.skipUnless(shutil.which("cc"), "C compiler required")
+class CoreThreadSafetyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.temp = tempfile.TemporaryDirectory(prefix="qunxia-thread-test-")
+        cls.addClassCleanup(cls.temp.cleanup)
+        cls.directory = pathlib.Path(cls.temp.name)
+        shared = "-dynamiclib" if sys.platform == "darwin" else "-shared"
+        common = ["cc", "-std=c11", "-O2", "-fPIC", shared, "-pthread",
+                  "-I" + str(ROOT / "Sources/CoreHost/include")]
+        cls.core_path = cls.directory / "probe-core.so"
+        host = cls.directory / "host.so"
+        subprocess.run(common + [str(ROOT / "server/test_fixtures/thread_probe_core.c"),
+                                 "-o", str(cls.core_path)], check=True)
+        subprocess.run(common + [str(ROOT / "Sources/CoreHost/CoreHost.c"),
+                                 "-o", str(host)] + ([] if sys.platform == "darwin" else ["-ldl"]), check=True)
+        cls.lib = ctypes.CDLL(str(host))
+        cls.probe = ctypes.CDLL(str(cls.core_path))
+        cls.lib.core_init.argtypes = [ctypes.c_char_p] * 3
+        cls.lib.core_init.restype = ctypes.c_bool
+        cls.has_state_access = hasattr(cls.lib, "core_state_size")
+        if cls.has_state_access:
+            cls.lib.core_state_size.restype = ctypes.c_size_t
+            cls.lib.core_state_copy.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+            cls.lib.core_state_copy.restype = ctypes.c_int
+            cls.lib.core_state_peek.argtypes = [ctypes.POINTER(ctypes.c_size_t), ctypes.c_int,
+                                              ctypes.POINTER(ctypes.c_int16)]
+        cls.lib.core_key.argtypes = [ctypes.c_int, ctypes.c_bool]
+        cls.lib.core_ticks.restype = ctypes.c_uint64
+        cls.lib.core_last_error.restype = ctypes.c_char_p
+        if cls.has_state_access:
+            cls.lib.core_mem_size.argtypes = [ctypes.c_uint]
+            cls.lib.core_mem_size.restype = ctypes.c_size_t
+            cls.lib.core_mem_read.argtypes = [ctypes.c_uint, ctypes.c_size_t, ctypes.c_void_p, ctypes.c_size_t]
+            cls.lib.core_mem_read.restype = ctypes.c_bool
+        for name in ("core_save_state", "core_load_state"):
+            getattr(cls.lib, name).argtypes = [ctypes.c_char_p]
+            getattr(cls.lib, name).restype = ctypes.c_bool
+
+    def setUp(self):
+        self.probe.probe_reset()
+        self.assertTrue(self.lib.core_init(str(self.core_path).encode(), b"unused", str(self.directory).encode()))
+        self.lib.core_release_all_keys()
+
+    def assert_serialized(self, operation):
+        runner = threading.Thread(target=self.lib.core_run_frame, daemon=True)
+        runner.start()
+        deadline = time.monotonic() + 2
+        while not self.probe.probe_running() and time.monotonic() < deadline:
+            time.sleep(.001)
+        self.assertTrue(self.probe.probe_running())
+        started, finished = threading.Event(), threading.Event()
+        result = []
+        def invoke():
+            started.set()
+            result.append(operation())
+            finished.set()
+        reader = threading.Thread(target=invoke, daemon=True)
+        reader.start()
+        try:
+            self.assertTrue(started.wait(1))
+            self.assertFalse(finished.wait(.05), "core access overlapped retro_run")
+        finally:
+            self.probe.probe_release()
+            runner.join(2)
+            reader.join(2)
+        self.assertFalse(runner.is_alive(), "video callback deadlocked on the execution lock")
+        self.assertFalse(reader.is_alive(), "core operation failed to release its lock")
+        self.assertEqual(self.probe.probe_overlaps(), 0)
+        return result[0]
+
+    def test_state_size_waits_for_frame(self):
+        if not self.has_state_access:
+            self.skipTest("benchmark-only private state access")
+        self.assertEqual(self.assert_serialized(self.lib.core_state_size), 16)
+
+    def test_state_copy_waits_for_frame_and_preserves_bytes(self):
+        if not self.has_state_access:
+            self.skipTest("benchmark-only private state access")
+        buf = ctypes.create_string_buffer(16)
+        self.assertEqual(self.assert_serialized(lambda: self.lib.core_state_copy(buf, 16)), 16)
+        self.assertEqual(buf.raw[0], 123)
+
+    def test_state_peek_waits_for_frame(self):
+        if not self.has_state_access:
+            self.skipTest("benchmark-only private state access")
+        offsets = (ctypes.c_size_t * 1)(0)
+        values = (ctypes.c_int16 * 1)()
+        self.assertEqual(self.assert_serialized(lambda: self.lib.core_state_peek(offsets, 1, values)), 0)
+        self.assertEqual(values[0], 123)
+
+    def test_save_waits_for_frame(self):
+        path = self.directory / "save.state"
+        self.assertTrue(self.assert_serialized(lambda: self.lib.core_save_state(str(path).encode())))
+        self.assertEqual(path.read_bytes()[0], 123)
+
+    def test_load_waits_for_frame(self):
+        path = self.directory / "load.state"
+        path.write_bytes(bytes(16))
+        self.assertTrue(self.assert_serialized(lambda: self.lib.core_load_state(str(path).encode())))
+
+    def test_keyboard_callback_waits_for_frame(self):
+        self.assert_serialized(lambda: self.lib.core_key(13, True))
+
+    def test_release_keys_waits_for_frame(self):
+        self.lib.core_key(13, True)
+        self.assert_serialized(self.lib.core_release_all_keys)
+
+    def test_reset_waits_for_frame_without_recursive_locking(self):
+        self.lib.core_key(13, True)
+        self.assert_serialized(self.lib.core_reset)
+
+    def test_shutdown_waits_for_frame_and_clears_callbacks(self):
+        self.assert_serialized(self.lib.core_shutdown)
+        if self.has_state_access:
+            self.assertEqual(self.lib.core_state_size(), 0)
+        self.lib.core_run_frame()  # must not call the deinitialized core
+
+    def test_load_after_shutdown_returns_failure(self):
+        path = self.directory / "shutdown-load.state"
+        path.write_bytes(bytes(16))
+        self.lib.core_shutdown()
+        self.assertFalse(self.lib.core_load_state(str(path).encode()))
+
+    def test_shutdown_unloads_game_before_deinit_and_only_once(self):
+        self.lib.core_shutdown()
+        self.assertEqual(self.probe.probe_unloads(), 1)
+        self.assertEqual(self.probe.probe_premature_deinit(), 0)
+        self.lib.core_shutdown()
+        self.assertEqual(self.probe.probe_unloads(), 1)
+
+    def test_memory_size_waits_for_frame(self):
+        if not self.has_state_access:
+            self.skipTest("benchmark-only private state access")
+        self.assertEqual(self.assert_serialized(lambda: self.lib.core_mem_size(0)), 16)
+
+    def test_memory_read_waits_for_frame(self):
+        if not self.has_state_access:
+            self.skipTest("benchmark-only private state access")
+        buf = ctypes.create_string_buffer(16)
+        self.assertTrue(self.assert_serialized(lambda: self.lib.core_mem_read(0, 0, buf, 16)))
+        self.assertEqual(buf.raw[0], 42)
+
+    def test_mouse_move_waits_for_frame(self):
+        self.assert_serialized(lambda: self.lib.core_mouse_move(1, 2))
+
+    def test_mouse_button_waits_for_frame(self):
+        self.assert_serialized(lambda: self.lib.core_mouse_button(0, True))
+
+    def test_failure_paths_release_execution_lock(self):
+        if not self.has_state_access:
+            self.skipTest("benchmark-only private state access")
+        buf = ctypes.create_string_buffer(16)
+        self.assertEqual(self.lib.core_state_copy(buf, 0), -1)
+        self.probe.probe_fail_serialize(1)
+        self.assertEqual(self.lib.core_state_copy(buf, 16), -1)
+        self.assertFalse(self.lib.core_save_state(str(self.directory / "failed.state").encode()))
+        self.probe.probe_fail_serialize(0)
+        offsets = (ctypes.c_size_t * 1)(16)
+        values = (ctypes.c_int16 * 1)()
+        self.assertEqual(self.lib.core_state_peek(offsets, 1, values), -1)
+        path = self.directory / "invalid.state"
+        path.write_bytes(b"invalid")
+        self.assertFalse(self.lib.core_load_state(str(path).encode()))
+        before = self.lib.core_ticks()
+        self.probe.probe_release()
+        runner = threading.Thread(target=self.lib.core_run_frame, daemon=True)
+        runner.start()
+        runner.join(2)
+        self.assertFalse(runner.is_alive())
+        self.assertGreater(self.lib.core_ticks(), before)
+
+    def test_zero_state_size_keeps_existing_save_diagnostic(self):
+        self.probe.probe_state_size(0)
+        self.assertFalse(self.lib.core_save_state(str(self.directory / "zero.state").encode()))
+        self.assertEqual(self.lib.core_last_error(), b"core reports zero savestate size")
+        self.probe.probe_state_size(16)
+        if self.has_state_access:
+            self.assertEqual(self.lib.core_state_size(), 16)
+
+
+    def test_shutdown_does_not_report_frames_that_never_ran(self):
+        self.lib.core_shutdown()
+        before = self.lib.core_ticks()
+        self.lib.core_run_frame()
+        self.assertEqual(self.lib.core_ticks(), before)
+
+    def test_failed_save_releases_gate_for_the_next_frame(self):
+        self.probe.probe_fail_serialize(1)
+        self.assertFalse(self.lib.core_save_state(str(self.directory / "failed.state").encode()))
+        self.probe.probe_fail_serialize(0)
+        self.probe.probe_release()
+        before = self.lib.core_ticks()
+        runner = threading.Thread(target=self.lib.core_run_frame, daemon=True)
+        runner.start()
+        runner.join(2)
+        self.assertFalse(runner.is_alive())
+        self.assertGreater(self.lib.core_ticks(), before)
+
+    def test_state_peek_rejects_overflow_and_null_arguments(self):
+        if not self.has_state_access:
+            self.skipTest("benchmark-only private state access")
+        offsets = (ctypes.c_size_t * 1)(ctypes.c_size_t(-1).value)
+        values = (ctypes.c_int16 * 1)()
+        self.assertEqual(self.lib.core_state_peek(offsets, 1, values), -1)
+        self.assertEqual(self.lib.core_state_peek(None, 1, values), -1)
+        self.assertEqual(self.lib.core_state_peek(offsets, -1, values), -1)
+
+    def test_memory_read_rejects_wrapped_range(self):
+        if not self.has_state_access:
+            self.skipTest("benchmark-only private state access")
+        data = ctypes.create_string_buffer(16)
+        self.assertFalse(self.lib.core_mem_read(0, ctypes.c_size_t(-1).value, data, 2))
+        self.assertFalse(self.lib.core_mem_read(0, 0, None, 1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/test_fixtures/thread_probe_core.c
+++ b/server/test_fixtures/thread_probe_core.c
@@ -1,0 +1,83 @@
+/* Minimal libretro fixture: keep retro_run active until the test releases it. */
+#include "libretro.h"
+#include <stdatomic.h>
+#include <string.h>
+#include <time.h>
+
+static retro_environment_t environment;
+static retro_video_refresh_t video;
+static atomic_int running, release_run, overlaps, fail_serialize, state_size;
+static atomic_int game_loaded, unloads, premature_deinit;
+static void touch_core(void) {
+    if (atomic_load(&running)) atomic_fetch_add(&overlaps, 1);
+}
+static void keyboard(bool down, unsigned key, uint32_t character, uint16_t mods) {
+    (void)down; (void)key; (void)character; (void)mods;
+    touch_core();
+}
+void probe_reset(void) {
+    atomic_store(&running, 0); atomic_store(&release_run, 0);
+    atomic_store(&overlaps, 0); atomic_store(&fail_serialize, 0);
+    atomic_store(&state_size, 16);
+    atomic_store(&game_loaded, 0); atomic_store(&unloads, 0);
+    atomic_store(&premature_deinit, 0);
+}
+int probe_running(void) { return atomic_load(&running); }
+int probe_overlaps(void) { return atomic_load(&overlaps); }
+void probe_release(void) { atomic_store(&release_run, 1); }
+void probe_fail_serialize(int value) { atomic_store(&fail_serialize, value); }
+void probe_state_size(int value) { atomic_store(&state_size, value); }
+int probe_unloads(void) { return atomic_load(&unloads); }
+int probe_premature_deinit(void) { return atomic_load(&premature_deinit); }
+void retro_set_environment(retro_environment_t cb) { environment = cb; }
+void retro_set_video_refresh(retro_video_refresh_t cb) { video = cb; }
+void retro_set_audio_sample(retro_audio_sample_t cb) { (void)cb; }
+void retro_set_audio_sample_batch(retro_audio_sample_batch_t cb) { (void)cb; }
+void retro_set_input_poll(retro_input_poll_t cb) { (void)cb; }
+void retro_set_input_state(retro_input_state_t cb) { (void)cb; }
+void retro_set_controller_port_device(unsigned port, unsigned device) { (void)port; (void)device; }
+void retro_init(void) {
+    struct retro_keyboard_callback cb = { keyboard };
+    environment(RETRO_ENVIRONMENT_SET_KEYBOARD_CALLBACK, &cb);
+}
+void retro_deinit(void) {
+    touch_core();
+    if (atomic_load(&game_loaded)) atomic_fetch_add(&premature_deinit, 1);
+}
+bool retro_load_game(const struct retro_game_info *info) {
+    (void)info; atomic_store(&game_loaded, 1); return true;
+}
+void retro_unload_game(void) {
+    touch_core(); atomic_store(&game_loaded, 0); atomic_fetch_add(&unloads, 1);
+}
+void retro_get_system_av_info(struct retro_system_av_info *av) {
+    memset(av, 0, sizeof(*av));
+    av->timing.fps = 60; av->timing.sample_rate = 48000;
+}
+void retro_run(void) {
+    atomic_store(&running, 1);
+    while (!atomic_load(&release_run)) {
+        struct timespec delay = { 0, 1000000 };
+        nanosleep(&delay, NULL);
+    }
+    uint32_t pixel = 0x00123456;
+    video(&pixel, 1, 1, sizeof(pixel));
+    atomic_store(&running, 0);
+}
+void retro_reset(void) { touch_core(); }
+size_t retro_serialize_size(void) { touch_core(); return (size_t)atomic_load(&state_size); }
+bool retro_serialize(void *data, size_t size) {
+    touch_core();
+    if (size < 16 || atomic_load(&fail_serialize)) return false;
+    memset(data, 0, size);
+    ((unsigned char *)data)[0] = 123;
+    return true;
+}
+bool retro_unserialize(const void *data, size_t size) {
+    (void)data; touch_core(); return size == 16;
+}
+size_t retro_get_memory_size(unsigned id) { (void)id; touch_core(); return 16; }
+void *retro_get_memory_data(unsigned id) {
+    static unsigned char memory[16] = { 42 };
+    (void)id; touch_core(); return memory;
+}

--- a/server/test_fixtures/thread_probe_core.c
+++ b/server/test_fixtures/thread_probe_core.c
@@ -2,6 +2,7 @@
 #include "libretro.h"
 #include <stdatomic.h>
 #include <string.h>
+#include <stdlib.h>
 #include <time.h>
 
 static retro_environment_t environment;
@@ -14,6 +15,9 @@ static void touch_core(void) {
 static void keyboard(bool down, unsigned key, uint32_t character, uint16_t mods) {
     (void)down; (void)key; (void)character; (void)mods;
     touch_core();
+    if (down && getenv("PROBE_HANG_ON_KEY")) {
+        for (;;) { struct timespec delay = {0, 1000000}; nanosleep(&delay, NULL); }
+    }
 }
 void probe_reset(void) {
     atomic_store(&running, 0); atomic_store(&release_run, 0);
@@ -37,6 +41,7 @@ void retro_set_input_poll(retro_input_poll_t cb) { (void)cb; }
 void retro_set_input_state(retro_input_state_t cb) { (void)cb; }
 void retro_set_controller_port_device(unsigned port, unsigned device) { (void)port; (void)device; }
 void retro_init(void) {
+    if (getenv("PROBE_AUTORUN")) { probe_reset(); probe_release(); }
     struct retro_keyboard_callback cb = { keyboard };
     environment(RETRO_ENVIRONMENT_SET_KEYBOARD_CALLBACK, &cb);
 }
@@ -55,6 +60,9 @@ void retro_get_system_av_info(struct retro_system_av_info *av) {
     av->timing.fps = 60; av->timing.sample_rate = 48000;
 }
 void retro_run(void) {
+    static unsigned frames;
+    const char *limit = getenv("PROBE_HANG_AFTER_FRAMES");
+    if (limit && ++frames > (unsigned)atoi(limit)) atomic_store(&release_run, 0);
     atomic_store(&running, 1);
     while (!atomic_load(&release_run)) {
         struct timespec delay = { 0, 1000000 };

--- a/server/test_recording.py
+++ b/server/test_recording.py
@@ -1,0 +1,144 @@
+"""File recording regressions: complete history, stable readers and exact retry."""
+import base64
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+from recording import Snapshot, RecordingAPI
+from recording_store import RecordingStore
+from storage import validate_recording_directory
+
+
+class RecordingTests(unittest.TestCase):
+    def setUp(self):
+        self.temp=tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.path=Path(self.temp.name)/'run.jsonl'
+        self.store=RecordingStore(self.path,started=10)
+        self.addCleanup(self.store.close)
+
+    def snapshot(self):
+        snap=Snapshot(**self.store.pin())
+        self.addCleanup(snap.close)
+        return snap
+
+    def test_reset_keeps_full_old_recording_and_open_reader(self):
+        self.store.append({'t':0,'d':'old'})
+        old=self.snapshot()
+        archive=self.store.reset(20)
+        self.store.append({'t':1,'d':'new'})
+        self.assertEqual(list(old),[{'t':0,'d':'old'}])
+        self.assertEqual(list(self.snapshot()),[{'t':1,'d':'new'}])
+        self.assertIn(b'old',archive.read_bytes())
+        self.assertEqual(old.header['started'],10)
+
+    def test_failed_partial_append_and_fsync_retry_exactly_once(self):
+        self.store.append({'t':0,'key':'up','down':True})
+        before=self.path.read_bytes()
+        real=os.write
+        calls=[0]
+        def broken(fd,data):
+            calls[0]+=1
+            if calls[0]==1:return real(fd,data[:4])
+            raise OSError('disk full')
+        with mock.patch('recording_store.os.write',side_effect=broken):
+            self.assertFalse(self.store.append({'t':1,'key':'up','down':False}))
+        self.assertEqual(self.path.read_bytes(),before)
+        with mock.patch('recording_store.os.fsync',side_effect=OSError('flush failed')):
+            self.assertFalse(self.store.flush())
+        self.assertEqual(self.path.read_bytes(),before)
+        self.assertTrue(self.store.flush())
+        self.assertEqual([e['down'] for e in self.snapshot()],[True,False])
+        self.assertEqual(self.store.pending_bytes,0)
+
+    def test_complete_history_exceeds_old_memory_cap_with_bounded_pages(self):
+        payload=base64.b64encode(b'x'*(768<<10)).decode()
+        for i in range(14):self.store.append({'t':i*40,'d':payload})
+        self.assertGreater(self.path.stat().st_size,12<<20)
+        snap=self.snapshot()
+        start=None;count=0
+        while True:
+            page=snap.page(start)
+            self.assertLessEqual(len(page['events']),1)
+            count+=len(page['events'])
+            if page['done']:break
+            start=page['next']
+        self.assertEqual(count,14)
+        self.assertEqual(snap.duration,520)
+        self.assertEqual(self.store.pending_bytes,0)
+
+    def test_reader_excludes_later_appends_and_rejects_midline_cursor(self):
+        self.store.append({'t':1,'key':'up','down':True})
+        old=self.snapshot()
+        self.store.append({'t':2,'key':'up','down':False})
+        self.assertEqual(len(list(old)),1)
+        with self.assertRaises(ValueError):old.page(old.begin+1)
+
+    def test_reset_failure_keeps_active_file_and_lease(self):
+        self.store.append({'t':0,'key':'up','down':True})
+        before=self.path.read_bytes()
+        with mock.patch.object(self.store,'_prepare_file',side_effect=OSError('full')):
+            with self.assertRaises(OSError):self.store.reset(20)
+        self.assertEqual(self.path.read_bytes(),before)
+        with self.assertRaises(RuntimeError):RecordingStore(self.path)
+        self.store.reset(20)
+        with self.assertRaises(RuntimeError):RecordingStore(self.path)
+
+    def test_cloud_container_root_is_not_accepted_as_disk(self):
+        mount='1 0 0:1 / / rw - overlay overlay rw\n'
+        with self.assertRaises(RuntimeError):
+            validate_recording_directory(self.temp.name,cloud=True,mountinfo=mount)
+
+
+class RecordingApiTests(unittest.IsolatedAsyncioTestCase):
+    async def test_paged_reader_survives_reset_and_can_close(self):
+        from types import SimpleNamespace
+        with tempfile.TemporaryDirectory() as directory:
+            store=RecordingStore(Path(directory)/'run.jsonl',started=10)
+            api=RecordingAPI(store)
+            try:
+                store.append({'t':1,'key':'up','down':True})
+                response=await api.handle(SimpleNamespace(query={'view':'paged'}))
+                page=json.loads(response.body)
+                store.reset(20)
+                response=await api.handle(SimpleNamespace(query={'view':'paged','token':page['token']}))
+                self.assertEqual(json.loads(response.body)['events'],page['events'])
+                await api.handle(SimpleNamespace(query={'view':'paged','token':page['token'],'close':'1'}))
+                self.assertFalse(api.readers)
+            finally:
+                api.close();store.close()
+
+
+class RecordingWorkerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import test_worker_health as workers
+        workers.WorkerIntegrationTests.setUpClass.__func__(cls)
+
+    def setUp(self):
+        import test_worker_health as workers
+        workers.WorkerIntegrationTests.setUp(self)
+
+    def test_reset_without_viewers_records_full_frame_and_preserves_old_reader(self):
+        import test_worker_health as workers
+        import zlib
+        workers.WorkerIntegrationTests.launch(self)
+        def healthy():return workers.WorkerIntegrationTests.healthy(self)
+        workers.wait_for(healthy)
+        status,body=workers.request(self.port,'/api/reset?token=test',{})
+        self.assertEqual(status,200,body)
+        page=json.loads(workers.request(self.port,'/api/recording?view=paged')[1])
+        picture=next(e for e in page['events'] if 'd' in e)
+        self.assertEqual(zlib.decompress(base64.b64decode(picture['d']))[0],1)
+        status,body=workers.request(self.port,'/api/reset?token=test',{})
+        self.assertEqual(status,200,body)
+        old=json.loads(workers.request(self.port,'/api/recording?view=paged&token='+page['token'])[1])
+        self.assertEqual(old['events'],page['events'])
+        raw=workers.request(self.port,'/api/recording?format=jsonl')[1]
+        self.assertIn('version',json.loads(raw.splitlines()[0]))
+        exported=json.loads(workers.request(self.port,'/api/recording')[1])
+        self.assertTrue(any('d' in e for e in exported['events']))
+        self.assertEqual(healthy()['recording']['cache_bytes'],0)

--- a/server/test_recording.py
+++ b/server/test_recording.py
@@ -142,3 +142,73 @@ class RecordingWorkerTests(unittest.TestCase):
         exported=json.loads(workers.request(self.port,'/api/recording')[1])
         self.assertTrue(any('d' in e for e in exported['events']))
         self.assertEqual(healthy()['recording']['cache_bytes'],0)
+
+    def run_storage_pause(self, benchmark=False):
+        import subprocess
+        import sys
+        import test_worker_health as workers
+        launcher=self.server/'storage_pause_probe.py'
+        launcher.write_text('''import json, os, pathlib, time
+import server
+server.KEYFRAME_EVERY = .05
+original_event = server.key_event
+original_write = server.RecordingStore._write
+original_key = server.LIB.core_key
+armed = False
+fail_until = 0.0
+def key_event(name, down):
+    global armed
+    original_event(name, down)
+    if down: armed = True
+def fail_write(self, data):
+    global fail_until
+    if armed and not fail_until and "d" in json.loads(data):
+        fail_until = time.monotonic() + 2.0
+    if time.monotonic() < fail_until:
+        raise OSError("injected recording write failure")
+    return original_write(self, data)
+def core_key(code, down):
+    result = original_key(code, down)
+    with pathlib.Path(os.environ["KEY_LOG"]).open("a") as stream:
+        stream.write(json.dumps([code, bool(down)]) + "\\n")
+    return result
+server.key_event = key_event
+server.RecordingStore._write = fail_write
+server.LIB.core_key = core_key
+server.main()
+''')
+        env=dict(os.environ,PORT=str(self.port),QUNXIA_CORE=str(self.core),QUNXIA_GAME='unused',
+                 QUNXIA_SAVES=str(self.folder/'saves'),QUNXIA_RECORDING_DIR=str(self.folder/'recordings'),
+                 QUNXIA_STALL_SECONDS='15',QUNXIA_BENCH='1' if benchmark else '0',
+                 PROBE_AUTORUN='1',KEY_LOG=str(self.folder/'keys.jsonl'))
+        with (self.folder/'worker.log').open('wb') as log:
+            process=subprocess.Popen([sys.executable,str(launcher)],env=env,cwd=self.server,stdout=log,stderr=log)
+        self.procs.append(process)
+        def healthy():return workers.WorkerIntegrationTests.healthy(self)
+        before=workers.wait_for(healthy)
+        status,body=workers.request(self.port,'/api/key?react=0&stable=1&maxsettle=6',{'key':'right','hold':6})
+        self.assertEqual(status,503,body)
+        self.assertEqual(json.loads(body)['error'],'recording_unavailable')
+        keys=[json.loads(row) for row in (self.folder/'keys.jsonl').read_text().splitlines()]
+        self.assertEqual(keys[-1],[275,False])  # completed real native key-up
+        if benchmark:
+            process.wait(timeout=4)
+            self.assertEqual(process.returncode,75)
+            fault=workers.read_json(self.folder/'saves/.health/failure.json')
+            self.assertEqual(fault['reason'],'recording_failed')
+        else:
+            after=workers.wait_for(healthy,seconds=5)
+            self.assertIsNone(process.poll())
+            self.assertGreater(after['core_ticks'],before['core_ticks'])
+            self.assertEqual(after['recording']['pending_bytes'],0)
+            self.assertFalse((self.folder/'saves/.health/failure.json').exists())
+            status,body=workers.request(self.port,'/api/key?react=0&stable=1&maxsettle=6',{'key':'up','hold':1})
+            self.assertEqual(status,200,body)
+
+    def test_recoverable_recording_pause_does_not_become_core_stall(self):
+        self.run_storage_pause()
+
+    def test_formal_benchmark_recording_failure_remains_invalid(self):
+        if not (self.server/'warden.py').exists():
+            self.skipTest('benchmark worker only')
+        self.run_storage_pause(benchmark=True)

--- a/server/test_worker_health.py
+++ b/server/test_worker_health.py
@@ -158,4 +158,3 @@ class WorkerIntegrationTests(unittest.TestCase):
         events=json.loads(request(self.port,'/api/recording')[1])['events']
         downs=[e['down'] for e in events if e.get('key')=='right']
         self.assertEqual(downs,[True,False])
-

--- a/server/test_worker_health.py
+++ b/server/test_worker_health.py
@@ -1,0 +1,161 @@
+"""Real worker processes and real native calls; no model/provider requests."""
+import asyncio
+import contextlib
+import ctypes
+import json
+import os
+from pathlib import Path
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError, URLError
+
+import aiohttp
+from health import read_json
+
+def stop_process(p, timeout=.5):
+    if p.poll() is None:
+        p.terminate()
+        try: p.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            p.kill(); p.wait(timeout=timeout)
+
+ROOT = Path(__file__).resolve().parent
+
+
+def free_port():
+    with socket.socket() as s:
+        s.bind(('127.0.0.1', 0))
+        return s.getsockname()[1]
+
+
+def request(port, path, body=None, timeout=5):
+    req=Request(f'http://127.0.0.1:{port}{path}', data=json.dumps(body).encode() if body is not None else None,
+                headers={'Content-Type':'application/json'})
+    try:
+        response=urlopen(req,timeout=timeout)
+    except HTTPError as e:
+        response=e
+    with response:
+        return response.status,response.read()
+
+
+def wait_for(fn, seconds=5):
+    deadline=time.monotonic()+seconds
+    last=None
+    while time.monotonic()<deadline:
+        try:
+            last=fn()
+            if last: return last
+        except (OSError, ValueError):
+            pass
+        time.sleep(.03)
+    raise AssertionError(f'timed out, last={last!r}')
+
+
+@unittest.skipUnless(shutil.which('cc'), 'C compiler required')
+class WorkerIntegrationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.build=tempfile.TemporaryDirectory(prefix='qunxia-worker-tests-')
+        cls.addClassCleanup(cls.build.cleanup)
+        cls.core=Path(cls.build.name)/'probe.so'
+        shared='-dynamiclib' if sys.platform=='darwin' else '-shared'
+        subprocess.run(['cc','-std=c11','-O2','-fPIC',shared,'-pthread',
+                        '-I'+str(ROOT.parent/'Sources/CoreHost/include'),
+                        str(ROOT/'test_fixtures/thread_probe_core.c'),'-o',str(cls.core)],check=True)
+        # The production bridge/tiles implementation is exercised in a private
+        # copy so tests never overwrite a library used by another server.
+        cls.server=Path(cls.build.name)/'server'
+        shutil.copytree(ROOT,cls.server,ignore=shutil.ignore_patterns('__pycache__','libqunxia.so*'))
+        sources=Path(cls.build.name)/'Sources'
+        shutil.copytree(ROOT.parent/'Sources/CoreHost',sources/'CoreHost')
+        subprocess.run(['sh',str(cls.server/'build.sh')],stdout=subprocess.DEVNULL,check=True)
+        # Bench warden imports its renderer from the sibling bench directory.
+        if (ROOT.parent/'bench').exists():
+            shutil.copytree(ROOT.parent/'bench',Path(cls.build.name)/'bench')
+
+    def setUp(self):
+        self.temp=tempfile.TemporaryDirectory(prefix='qunxia-test-session-')
+        self.addCleanup(self.temp.cleanup)
+        self.folder=Path(self.temp.name)
+        self.port=free_port()
+        self.procs=[]
+        self.addCleanup(lambda:[stop_process(p,timeout=.5) for p in self.procs])
+
+    def launch(self, **extra):
+        start=self.folder/'start.state'
+        start.write_bytes(b'{' + bytes(15))
+        env=dict(os.environ,PORT=str(self.port),QUNXIA_CORE=str(self.core),QUNXIA_GAME='unused',
+                 QUNXIA_SAVES=str(self.folder/'saves'),QUNXIA_STATE_DIR=str(self.folder/'slots'),
+                 QUNXIA_START_STATE=str(start),QUNXIA_RESET_TOKEN='test',
+                 QUNXIA_RECORDING_DIR=str(self.folder/'recordings'),QUNXIA_RUN_ID='test-run',
+                 QUNXIA_RUNTIME_CHILD='1',QUNXIA_STALL_SECONDS='1.5',QUNXIA_STARTUP_SECONDS='4',
+                 QUNXIA_BOOT_WAIT='0.1',QUNXIA_CHECKPOINT_SECONDS='0.3',QUNXIA_BENCH='0',
+                 QUNXIA_FINALIZATION_SECONDS='20',QUNXIA_RECOVERY_LIMIT='1',PROBE_AUTORUN='1')
+        env.pop('QUNXIA_SESSION_DIR',None)
+        env.pop('QUNXIA_RUNTIME_DIR',None)
+        env.pop('QUNXIA_PARENT_PID',None)
+        env.update(extra)
+        with (self.folder/'worker.log').open('ab') as log:
+            p=subprocess.Popen([sys.executable,str(self.server/'server.py')],env=env,cwd=self.server,
+                               stdout=log,stderr=log,start_new_session=True)
+        p.qunxia_group=True
+        self.procs.append(p)
+        return p
+
+    def healthy(self):
+        status,body=request(self.port,'/status')
+        value=json.loads(body)
+        return value if status==200 and value.get('healthy') else None
+
+
+    def test_static_pixels_still_report_execution_progress(self):
+        self.launch()
+        before=wait_for(self.healthy)
+        time.sleep(.15)
+        after=self.healthy()
+        self.assertGreater(after['core_ticks'],before['core_ticks'])
+
+    def test_native_key_deadlock_becomes_environment_failure(self):
+        p=self.launch(PROBE_HANG_ON_KEY='1')
+        wait_for(self.healthy)
+        with contextlib.suppress(OSError):
+            request(self.port,'/api/key',{'key':'enter'},timeout=4)
+        p.wait(timeout=5)
+        fault=read_json(self.folder/'saves/.health/failure.json')
+        self.assertEqual(p.returncode,75)
+        self.assertFalse(fault['valid'])
+        self.assertIn(fault['reason'],('core_stalled','event_loop_stalled'))
+
+    def test_native_run_deadlock_without_http_requests_is_detected(self):
+        p=self.launch(PROBE_HANG_AFTER_FRAMES='20')
+        wait_for(self.healthy)
+        p.wait(timeout=5)
+        fault=read_json(self.folder/'saves/.health/failure.json')
+        self.assertEqual(p.returncode,75)
+        self.assertIn(fault['reason'],('core_stalled','pause_stalled'))
+
+
+    def test_websocket_disconnect_releases_input_lease(self):
+        self.launch()
+        wait_for(self.healthy)
+        async def run():
+            async with aiohttp.ClientSession() as http:
+                async with http.ws_connect(f'http://127.0.0.1:{self.port}/ws',compress=15) as ws:
+                    self.assertEqual(ws.compress,0)
+                    await ws.send_json({'t':'key','k':'right','down':True})
+                    await asyncio.sleep(.1)
+                async with http.post(f'http://127.0.0.1:{self.port}/api/key',json={'key':'up'}) as r:
+                    self.assertEqual(r.status,200,await r.text())
+        asyncio.run(run())
+        events=json.loads(request(self.port,'/api/recording')[1])['events']
+        downs=[e['down'] for e in events if e.get('key')=='right']
+        self.assertEqual(downs,[True,False])
+


### PR DESCRIPTION
The recording history lived in `rec["events"]`, so long sessions either accumulated memory or lost earlier events through pruning. Store every produced tile/key event in append-and-fsync JSONL, archive resets, and read fixed committed snapshots in bounded pages. The existing 4x replay, JSON export and browser MediaRecorder MP4/WebM export are preserved.

If a write temporarily fails, input returns a recording-unavailable error, releases held keys and resumes after the bounded pending write succeeds. An intentional storage pause is not classified as a core stall. Cloud Run requires a configured persistent POSIX directory: its container filesystem uses instance memory. Browser MediaRecorder output chunks remain in browser memory as before; this change bounds server history and replay input.

This is stacked on #16. The current full PR diff also includes that unmerged core work; it is not a recording-only diff yet. Use the [recording-only comparison](https://github.com/LYMDLUT/jy-crpg-bench/compare/f260a17af17ed08fcb36ad32a3642dd23f8c9dda...6eacc918739e924ac023c003ad09c4399ec88be7) for this review. After the parent is integrated, this PR is intended to contain only recording changes.

Validation: the initial recording package passed 47 server tests (8 benchmark-only skips). The review correction passed 10 targeted recording tests (1 benchmark-only skip), including a real worker recovering from a 2-second write failure after native keydown, completing key-up and accepting another action. Tests also cover >12 MiB retained history, bounded pages, exact failed-write retry and reset with active readers. The browser export smoke test is supplementary; fixed-source page failure/cancellation behavior was checked in independent review. No model calls or cloud deployment were used.
