### PR TITLE
Distinguish input timeouts and enforce fixed benchmark deadlines

### DIFF
--- a/Sources/CoreHost/CoreHost.c
+++ b/Sources/CoreHost/CoreHost.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "libretro.h"
 
@@ -462,14 +463,30 @@ void core_reset(void) {
     pthread_mutex_unlock(&g_exec_mu);
 }
 
-void core_key(int retrok, bool down) {
-    if (retrok < 0 || retrok >= (int)RETROK_LAST) return;
+bool core_key_before_deadline(int retrok, bool down, double deadline) {
+    if (retrok < 0 || retrok >= (int)RETROK_LAST) return false;
     pthread_mutex_lock(&g_exec_mu);
+    /* Check after acquiring the execution gate: a Python pre-check alone
+       can admit a late key after waiting behind retro_run. Key-up must
+       always remain possible, including during cancellation/teardown. */
+    if (down && deadline > 0) {
+        struct timespec now;
+        if (clock_gettime(CLOCK_MONOTONIC, &now) != 0 ||
+            (double)now.tv_sec + now.tv_nsec / 1e9 >= deadline) {
+            pthread_mutex_unlock(&g_exec_mu);
+            return false;
+        }
+    }
     if (g_keys[retrok] != (down ? 1 : 0)) {
         g_keys[retrok] = down ? 1 : 0;
         if (g_kbd_cb) g_kbd_cb(down, (unsigned)retrok, 0, 0);
     }
     pthread_mutex_unlock(&g_exec_mu);
+    return true;
+}
+
+void core_key(int retrok, bool down) {
+    (void)core_key_before_deadline(retrok, down, 0);
 }
 
 static void release_all_keys_unlocked(void) {

--- a/Sources/CoreHost/include/CoreHost.h
+++ b/Sources/CoreHost/include/CoreHost.h
@@ -20,6 +20,8 @@ void core_reset(void);
 
 /* Keyboard: retrok is a RETROK_* value. Routed to the core's keyboard callback. */
 void core_key(int retrok, bool down);
+/* CLOCK_MONOTONIC absolute seconds; zero disables the key-down deadline. */
+bool core_key_before_deadline(int retrok, bool down, double deadline);
 void core_release_all_keys(void);
 
 /* Mouse: relative motion in core pixels, buttons 0=left 1=right 2=middle. */

--- a/bench/broker.py
+++ b/bench/broker.py
@@ -211,6 +211,7 @@ async def start_session(agent, budget, publish=True):
                QUNXIA_GAME=str(game),
                QUNXIA_SAVES=str(saves),
                QUNXIA_HEALTH_DIR=str(WORK / sid / "health"),
+               QUNXIA_DIAGNOSTIC_DIR=str(RESULT_DIR / f"{sid}.diagnostics"),
                QUNXIA_RECORDING_DIR=str(RECORDING_DIR),
                QUNXIA_RECORDING_FILE=str(RECORDING_DIR / sid / "recording.jsonl"),
                QUNXIA_SEND_HZ="15",
@@ -230,7 +231,8 @@ async def start_session(agent, budget, publish=True):
     sessions[sid] = sess
 
     if not await wait_healthy(port):
-        proc.kill()
+        await asyncio.to_thread(stop_worker, proc)
+        await asyncio.to_thread(archive_health, sess, 'startup_failed')
         shutil.rmtree(WORK / sid, ignore_errors=True)
         raise web.HTTPBadGateway(
             text=json.dumps({"ok": False, "error": "session did not start"}),
@@ -260,11 +262,8 @@ async def start_session(agent, budget, publish=True):
     # handing the agent a broken game, which is what happened for an hour when
     # the bootstrap failed and every session silently started at the title.
     if not sess["spawned"]:
-        proc.terminate()
-        try:
-            proc.wait(timeout=10)
-        except Exception:
-            proc.kill()
+        await asyncio.to_thread(stop_worker, proc)
+        await asyncio.to_thread(archive_health, sess, 'spawn_failed')
         shutil.rmtree(WORK / sid, ignore_errors=True)
         sessions.pop(sid, None)
         print(f"session {sid} refused: start state would not load", flush=True)
@@ -526,9 +525,31 @@ def stop_worker(proc):
             proc.wait(timeout=3)
 
 
+def archive_health(sess, reason=None):
+    """Keep bounded evidence outside the work directory before reclaiming it.
+
+    A killed or unresponsive worker cannot write its own incident. The broker
+    retains the last heartbeat/fault and exit status in that case as well.
+    """
+    work = sess.get('work')
+    if not work or not (work / 'health').exists():
+        return
+    destination = RESULT_DIR / f"{sess['id']}.diagnostics"
+    try:
+        for name in ('heartbeat.json', 'failure.json'):
+            value = read_json(work / 'health' / name)
+            if value is not None:
+                write_json(destination / name, value)
+        write_json(destination / 'worker.json', dict(
+            pid=sess['proc'].pid, exit_code=sess['proc'].poll(), reason=reason))
+    except OSError as exc:
+        print(f"diagnostic archive {sess['id']}: {exc}", flush=True)
+
+
 async def fail_worker(sess, reason):
     # Reap before writing, so a dying worker cannot overwrite this result.
     await asyncio.to_thread(stop_worker, sess['proc'])
+    await asyncio.to_thread(archive_health, sess, reason)
     result = result_of(sess['id'])
     if result and result.get('valid') is True:
         result.update(complete=True, error=(result.get('error') or '') + f' artifact finalization failed: {reason}')
@@ -652,6 +673,7 @@ async def sweep(app):
         for s in list(sessions.values()):
             work = s.get("work")
             if work and s["proc"].poll() is not None and work.exists():
+                await loop.run_in_executor(None, archive_health, s)
                 await loop.run_in_executor(
                     None, lambda w=work: shutil.rmtree(w, ignore_errors=True))
                 # its thumbnail is nothing but storage cost once the run is over

--- a/bench/test_broker_health.py
+++ b/bench/test_broker_health.py
@@ -37,6 +37,25 @@ class WorkerFailureTests(unittest.IsolatedAsyncioTestCase):
                     if proc.poll() is None:proc.kill()
                     proc.wait()
 
+    async def test_diagnostics_survive_work_directory_reclamation(self):
+        import shutil
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            proc = mock.Mock(pid=12345)
+            proc.poll.return_value = 75
+            work = root / 'scratch'
+            sess = dict(id='run', agent='test', proc=proc, work=work)
+            fault = dict(broker.failure('input_frame_timeout'), source='input_wait')
+            broker.write_json(work / 'health/failure.json', fault)
+            broker.write_json(work / 'health/heartbeat.json', dict(pid=12345, core_ticks=42))
+            with mock.patch.object(broker, 'RESULT_DIR', root / 'results'):
+                await broker.fail_worker(sess, 'input_frame_timeout')
+                shutil.rmtree(work)
+            retained = root / 'results/run.diagnostics'
+            self.assertEqual(broker.read_json(retained / 'failure.json'), fault)
+            self.assertEqual(broker.read_json(retained / 'heartbeat.json')['core_ticks'], 42)
+            self.assertEqual(broker.read_json(retained / 'worker.json')['exit_code'], 75)
+
     async def test_missing_result_is_not_reported_as_success(self):
         result=broker.ended_payload({'id':'missing','agent':'test'},None)
         self.assertFalse(result['ok'])
@@ -49,11 +68,11 @@ class WorkerFailureTests(unittest.IsolatedAsyncioTestCase):
         async def stalled(_frames):
             raise RuntimeError('frame clock stalled')
         try:
-            warden.run.update(playable=__import__('time').time()-warden.BUDGET-1,done=None,credit=0)
+            warden.run.update(playable=__import__('time').time()-warden.BUDGET-1,done=None,credit=0,deadline=warden.clock()-1,last_clock=warden.clock())
             with mock.patch.object(warden,'write_result') as write:
                 await warden.warden({'events':[]},health,asyncio.Lock(),stalled)
                 write.assert_not_called()
-                health.fail.assert_called_once_with('core_stalled')
+                health.fail.assert_called_once_with('finalization_wait_failed', source='finalization', exception_type='RuntimeError')
         finally:
             warden.run.clear();warden.run.update(old)
 

--- a/server/README.md
+++ b/server/README.md
@@ -98,3 +98,34 @@ Measured on the target VM: at 77000 cycles the core runs 1.75x faster than the
 run out. At 26800 (486DX2-66, period-correct for a 1996 game) it runs 6.7x
 faster than needed, about 15% of a core, and an e2-micro holds a full 70.1 fps
 indefinitely. Override with `QUNXIA_CYCLES`.
+
+
+## Frame waits and failure evidence
+
+An input action keeps its original core-tick targets across hold, release, gap
+and settle phases. Its deadline is fixed at entry: requested wall-clock waits
+plus the larger of `QUNXIA_STALL_SECONDS + 0.5` (15.5 seconds by default) and
+`5 * total_requested_frames / nominal_fps + 0.5`. The frame total includes
+release fences and the maximum settle window. Progress never renews the
+deadline, and a key or sequence is never replayed to recover from a slow wait.
+
+A progressing core that exhausts this deadline reports `input_frame_timeout`.
+A core with no progress for the watchdog interval reports `core_stalled`;
+event-loop and finalization watchdog failures have separate sources. Pending
+keys are released on exceptions/cancellation when native calls can return. A
+native deadlock is terminated by the independent watchdog.
+
+The first fault freezes the current key, stage, target/actual ticks, elapsed
+times, up to 64 completed stages and up to 64 watchdog samples. The watchdog
+writes `incident.json` and Python thread stacks to `QUNXIA_DIAGNOSTIC_DIR`, or
+by default to a unique directory under `QUNXIA_HEALTH_DIR/incidents`. These
+records distinguish timeout paths; they do not establish why DOSBox slowed.
+
+Benchmark runs use a fixed monotonic deadline from the moment the opening
+state is playable. All waiting (including optional calibration) consumes that
+budget without credit. Deadline checks run before each key, while waiting and
+before reporting success; the native key gate checks again after acquiring its
+execution lock. A time-limit ending still validates core health before it can
+be scored as valid. Input/environment failures remain invalid. The broker
+stores diagnostics under `<result-dir>/<session-id>.diagnostics` and archives
+the last heartbeat, fault and exit status before reclaiming worker scratch.

--- a/server/health.py
+++ b/server/health.py
@@ -1,4 +1,6 @@
 """Detect an execution stall without waiting for the core mutex or HTTP loop."""
+from collections import deque
+import faulthandler
 import json
 import os
 from pathlib import Path
@@ -45,39 +47,77 @@ class Health:
         self.tick = int(ticks())
         self.phase, self.phase_at = 'starting', self.started
         self.fault = None
+        self.lock = threading.RLock()
+        self.history = deque(maxlen=64)
+        self.input = {}
+        self.incident = None
+        self.diagnostic_dir = Path(os.environ.get('QUNXIA_DIAGNOSTIC_DIR',
+            str(self.directory / 'incidents' / f'{os.getpid()}-{time.time_ns()}')))
         self.stop_event = threading.Event()
 
     def pulse(self):
-        self.loop_at = clock()
+        with self.lock:
+            self.loop_at = clock()
 
     def set_phase(self, phase):
-        self.phase, self.phase_at = phase, clock()
+        with self.lock:
+            self.phase, self.phase_at = phase, clock()
 
-    def fail(self, reason):
-        self.fault = self.fault or failure(reason)
+    def set_input(self, **details):
+        with self.lock:
+            self.input = details
+
+    def fail(self, reason, source='runtime', **details):
+        # Freeze the first failure before key cleanup or another sampler can
+        # overwrite its context. Disk I/O is left to the watchdog thread.
+        with self.lock:
+            if self.fault is None:
+                self.fault = dict(failure(reason), source=source)
+                self.incident = dict(self.snapshot(), input=dict(self.input),
+                                     details=details, samples=list(self.history))
 
     def check(self):
         if self.fault:
             raise EnvironmentFailure(self.fault['reason'])
 
     def sample(self):
+        with self.lock:
+            return self._sample()
+
+    def _sample(self):
         now, tick = clock(), int(self.ticks())  # atomic C load; no execution lock
         if tick != self.tick:
             self.tick, self.tick_at = tick, now
         if self.phase == 'starting':
             if now - self.started > 30:
-                self.fail('startup_stalled')
+                self.fail('startup_stalled', source='startup_watchdog')
         elif self.phase == 'finalizing':
             if now - self.phase_at > 300:
-                self.fail('finalization_stalled')
+                self.fail('finalization_stalled', source='finalization_watchdog')
         else:
             if now - self.loop_at > self.timeout:
-                self.fail('event_loop_stalled')
+                self.fail('event_loop_stalled', source='event_loop_watchdog')
             elif not self.paused() and now - self.tick_at > self.timeout:
-                self.fail('core_stalled')
-        return {'pid': os.getpid(), 'at': now, 'phase': self.phase, 'phase_at': self.phase_at,
+                self.fail('core_stalled', source='tick_watchdog')
+        state = self.snapshot()
+        self.history.append({k: v for k, v in state.items() if k != 'failure'})
+        return state
+
+    def snapshot(self):
+        """Read status without advancing the watchdog's samples or timers."""
+        with self.lock:
+            now, tick = clock(), int(self.ticks())
+            return {'pid': os.getpid(), 'at': now, 'phase': self.phase, 'phase_at': self.phase_at,
+                'last_tick_at': self.tick_at, 'last_loop_at': self.loop_at,
                 'core_ticks': tick, 'healthy': not self.fault and self.phase == 'running' and tick > 0 and not self.paused(),
                 'failure': self.fault}
+
+    def persist_incident(self):
+        if self.incident is None:
+            return
+        write_json(self.diagnostic_dir / 'incident.json', self.incident)
+        with (self.diagnostic_dir / 'threads.txt').open('w') as output:
+            faulthandler.dump_traceback(file=output, all_threads=True)
 
     def start(self):
         self.directory.mkdir(parents=True, exist_ok=True)
@@ -89,6 +129,7 @@ class Health:
                     write_json(self.directory / 'heartbeat.json', state)
                     if self.fault:
                         write_json(self.directory / 'failure.json', self.fault)
+                        self.persist_incident()
                         os._exit(75)
                 except OSError:
                     os._exit(75)

--- a/server/input_wait.py
+++ b/server/input_wait.py
@@ -1,0 +1,90 @@
+"""Progress-aware frame waits with one fixed deadline per input action."""
+import asyncio
+from collections import deque
+from contextvars import ContextVar
+
+from health import clock, EnvironmentFailure
+
+current_budget = ContextVar('input_budget', default=None)
+
+
+class InputBudget:
+    def __init__(self, frames, fps, health=None, wall_seconds=0,
+                 check_runtime=lambda: None, clock_fn=clock, sleep=asyncio.sleep):
+        self.clock, self.sleep = clock_fn, sleep
+        self.health, self.check_runtime = health, check_runtime
+        self.fps = max(1.0, fps)
+        self.stall_seconds = health.timeout if health else 15.0
+        self.started = self.clock()
+        # Allow a transient pause up to the existing no-progress watchdog,
+        # or sustained execution down to 1/5 nominal speed. Neither progress
+        # nor a new key/release/gap/settle phase extends this action deadline.
+        self.deadline = self.started + wall_seconds + max(
+            self.stall_seconds + .5, frames / self.fps * 5 + .5)
+        self.context = {}
+        self.step_index = self.action_seq = None
+        self.stages = deque(maxlen=64)
+        self.completed_stages = []
+        self.stage_at = self.started
+
+    def stage(self, stage, **details):
+        now = self.clock()
+        if self.context:
+            self.stages.append(dict(self.context, stage_elapsed=now - self.stage_at))
+            self.completed_stages = list(self.stages)
+        self.stage_at = now
+        self.step_index = details.pop('step_index', self.step_index)
+        self.context = dict(stage=stage, step_index=self.step_index,
+                            action_seq=self.action_seq, **details)
+        self.publish()
+
+    def publish(self):
+        if self.health:
+            self.health.set_input(action_started=self.started,
+                                  action_deadline=self.deadline, stage_started=self.stage_at,
+                                  completed_stages=self.completed_stages, **self.context)
+
+    def fail(self, reason, **details):
+        if self.health:
+            self.health.fail(reason, source='input_wait',
+                             action_elapsed=self.clock() - self.started, **details)
+        raise EnvironmentFailure(reason)
+
+    def check(self):
+        # Storage pauses and the benchmark's absolute budget take precedence;
+        # reaching a frame target after either boundary is not success.
+        self.check_runtime()
+        if self.health:
+            self.health.check()
+        if self.clock() >= self.deadline:
+            self.fail('input_frame_timeout')
+
+    async def wait(self, frames, ticks):
+        start = last = int(ticks())
+        target = start + max(1, int(frames))
+        wait_at = progressed_at = self.clock()
+        self.context.update(start_tick=start, target_tick=target, wait_started=wait_at)
+        self.publish()
+        while True:
+            # Record actual progress even when waking after the deadline.
+            now, actual = self.clock(), int(ticks())
+            self.context.update(actual_tick=actual, wait_elapsed=now - wait_at)
+            self.publish()
+            self.check()
+            if actual != last:
+                last, progressed_at = actual, now
+            if actual >= target:
+                return
+            if now - progressed_at >= self.stall_seconds:
+                self.fail('core_stalled', actual_tick=actual, target_tick=target,
+                          no_progress_seconds=now - progressed_at)
+            await self.sleep(min(.01, .5 / self.fps))
+
+    async def wait_seconds(self, seconds):
+        end = self.clock() + seconds
+        while True:
+            self.check()
+            remaining = end - self.clock()
+            if remaining <= 0:
+                return
+            await self.sleep(min(.1, remaining))

--- a/server/server.py
+++ b/server/server.py
@@ -1487,7 +1487,7 @@ async def status(_request):
         "width": LIB.core_width(), "height": LIB.core_height(),
         "fps": round(LIB.core_fps(), 3), "frame": LIB.core_frame_serial(),
         "clients": len(clients), "session": session_summary(), **stats,
-        **(health.sample() if health else {}),
+        **(health.snapshot() if health else {}),
         "recording": {"cache_bytes": 0, "pending_bytes": recording_store.pending_bytes if recording_store else 0,
                       "error": recording_store.error if recording_store else ""},
     })

--- a/server/server.py
+++ b/server/server.py
@@ -29,6 +29,7 @@ from state_reader import decode_inventory, inventory_gained
 
 from prompt import system_prompt
 from health import Health, EnvironmentFailure
+from input_wait import InputBudget, current_budget
 from peers import Peer
 from recording_store import RecordingStore
 from recording import RecordingAPI
@@ -46,6 +47,8 @@ LIB.core_set_option.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
 LIB.core_init.argtypes = [ctypes.c_char_p] * 3
 LIB.core_init.restype = ctypes.c_bool
 LIB.core_key.argtypes = [ctypes.c_int, ctypes.c_bool]
+LIB.core_key_before_deadline.argtypes = [ctypes.c_int, ctypes.c_bool, ctypes.c_double]
+LIB.core_key_before_deadline.restype = ctypes.c_bool
 LIB.core_fps.restype = ctypes.c_double
 LIB.core_frame_serial.restype = ctypes.c_uint64
 LIB.core_ticks.restype = ctypes.c_uint64
@@ -976,7 +979,8 @@ async def press_web_key(name, code, holding):
     """Press a browser key once and remember the core tick it reached."""
     if code in holding:
         return False
-    LIB.core_key(code, True)
+    input_stage("keydown", key=name)
+    send_key_down(code)
     holding[code] = (name, LIB.core_ticks())
     key_event(name, True)
     return True
@@ -996,38 +1000,70 @@ async def release_web_key(name, code, holding):
     pressed_name, pressed_at = pressed
     elapsed = max(0, LIB.core_ticks() - pressed_at)
     remaining = max(0, DEFAULT_TAP_FRAMES - elapsed)
+    budget = InputBudget(remaining + KEY_RELEASE_FRAMES, LIB.core_fps(), health,
+                         check_runtime=check_input_runtime)
+    token = current_budget.set(budget)
     try:
-        if remaining:
-            await wait_core_frames(remaining)
+        try:
+            if remaining:
+                input_stage("browser_hold", key=pressed_name or name)
+                await wait_core_frames(remaining)
+        finally:
+            # Cancellation or a dropped socket must never strand a movement key.
+            LIB.core_key(code, False)
+            holding.pop(code, None)
+            key_event(pressed_name or name, False)
+        input_stage("release", key=pressed_name or name)
+        await wait_core_frames(KEY_RELEASE_FRAMES)
+        budget.check()
+        return True
     finally:
-        # Cancellation or a dropped socket must never strand a movement key.
-        LIB.core_key(code, False)
-        holding.pop(code, None)
-        key_event(pressed_name or name, False)
-    await wait_core_frames(KEY_RELEASE_FRAMES)
-    return True
+        current_budget.reset(token)
+        if health:
+            health.set_input()
+
+
+def check_input_runtime(allow_finished=False):
+    if recording_blocked:
+        raise RecordingUnavailable(recording_store.error or "recording storage is paused")
+    if not allow_finished and warden.ON:
+        warden.check_time()
+        if warden.run["done"]:
+            raise web.HTTPGone(text=json.dumps(warden.ended_payload()), content_type="application/json")
+
+
+def input_stage(stage, **details):
+    budget = current_budget.get()
+    if budget:
+        budget.stage(stage, **details)
+    elif health:
+        health.set_input(stage=stage, **details)
+
+
+def send_key_down(code):
+    budget = current_budget.get()
+    check_input_runtime()
+    if budget:
+        budget.check()
+    deadline = budget.deadline if budget else 0
+    if warden.ON and warden.run["deadline"] is not None:
+        deadline = min(deadline, warden.run["deadline"]) if deadline else warden.run["deadline"]
+    if deadline:
+        if not LIB.core_key_before_deadline(code, True, deadline):
+            check_input_runtime()
+            if budget:
+                budget.fail("input_frame_timeout")
+            raise EnvironmentFailure("input_frame_timeout")
+    else:
+        LIB.core_key(code, True)
 
 
 async def wait_core_frames(frames, allow_finished=False):
-    """Wait until the emulator has actually completed ``frames`` frames."""
-    frames = max(1, int(frames))
-    fps = max(1.0, LIB.core_fps())
-    target = LIB.core_ticks() + frames
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + max(1.0, frames / fps * 5 + 0.5)
-    poll = min(0.01, 0.5 / fps)
-    while LIB.core_ticks() < target:
-        if recording_blocked:
-            raise RecordingUnavailable(recording_store.error or "recording storage is paused")
-        if not allow_finished and warden.ON and warden.run["done"]:
-            raise web.HTTPGone(text=json.dumps(warden.ended_payload()), content_type="application/json")
-        if loop.time() >= deadline:
-            if recording_blocked:
-                raise RecordingUnavailable(recording_store.error or "recording storage is paused")
-            if health:
-                health.fail("core_stalled")
-            raise EnvironmentFailure("emulator frame clock stalled during input")
-        await asyncio.sleep(poll)
+    """Keep the same absolute frame target while a slow core makes progress."""
+    budget = current_budget.get() or InputBudget(
+        max(1, int(frames)), LIB.core_fps(), health,
+        check_runtime=lambda: check_input_runtime(allow_finished))
+    await budget.wait(frames, LIB.core_ticks)
 
 
 def key_event(name, down):
@@ -1040,13 +1076,19 @@ def key_event(name, down):
 
 
 async def tap(code, hold_frames, name=None):
+    pressed = False
     try:
+        input_stage("keydown", key=name)
+        send_key_down(code)
+        pressed = True
         key_event(name, True)
-        LIB.core_key(code, True)
+        input_stage("hold", key=name)
         await wait_core_frames(hold_frames)
     finally:
-        LIB.core_key(code, False)
-        key_event(name, False)
+        if pressed:
+            LIB.core_key(code, False)
+            key_event(name, False)
+    input_stage("release", key=name)
     await wait_core_frames(KEY_RELEASE_FRAMES)
 
 
@@ -1070,6 +1112,7 @@ async def run_action(request, steps, note, verb="KEY",
     left to hang.
     """
     if warden.ON:
+        warden.check_time()
         done = warden.ended_payload()
         if done:
             return web.json_response(done, status=410)
@@ -1083,7 +1126,19 @@ async def run_action(request, steps, note, verb="KEY",
     finally:
         stats["queued"] -= 1
 
+    will_calibrate = CALIBRATE and not world["ok"] and not world["tried"]
+    calibration_frames = (280 + 4 * (DEFAULT_TAP_FRAMES + KEY_RELEASE_FRAMES
+                          + DEFAULT_SETTLE_MAX_FRAMES)) if will_calibrate else 0
+    budget = InputBudget(
+        sum(step[1] + (KEY_RELEASE_FRAMES if len(step) > 2 else 0)
+            for step in steps if step[0] != "wait")
+        + max(DEFAULT_SETTLE_MAX_FRAMES, 30 + stable) + calibration_frames,
+        LIB.core_fps(), health,
+        wall_seconds=sum(step[1] for step in steps if step[0] == "wait"),
+        check_runtime=check_input_runtime)
+    token = current_budget.set(budget)
     try:
+        budget.check()
         # Logged before the keys are sent, not after: the panel should show an
         # action starting, not report it once it is already over.
         if warden.ON and warden.run["done"]:
@@ -1109,35 +1164,26 @@ async def run_action(request, steps, note, verb="KEY",
             if len(_s) > 2:
                 _k = canon(_s[2])
                 keyhist[_k] = keyhist.get(_k, 0) + 1
-        if CALIBRATE and not world["ok"] and not world["tried"]:
+        if will_calibrate:
+            input_stage("calibration")
             world["tried"] = True
-            spent = time.time()
             await calibrate_lazily()
-            spent = time.time() - spent
-            # The agent did not spend this, so it should not pay for it: the
-            # run gets the time back at the far end, and the next gap is
-            # measured from now rather than from before the walk. The clock's
-            # origin is deliberately left alone - the first action was already
-            # timestamped against it, and moving it made time-to-first-action
-            # come out negative.
-            if warden.ON and warden.run["playable"] is not None:
-                warden.run["credit"] += spent
-                warden.run["last"] = time.time()
-                print(f"calibration took {spent:.1f}s; the run gets it back",
-                      flush=True)
+            # Calibration and input waits consume the same fixed run budget.
+        budget.action_seq = session["actions"]
         baseline = LIB.core_frame_hash()
-        for step in steps:
+        for index, step in enumerate(steps):
+            budget.check()
+            input_stage("step", step_index=index)
             kind, val = step[0], step[1]
             if kind == "wait":
-                end = asyncio.get_running_loop().time() + val
-                while asyncio.get_running_loop().time() < end:
-                    if warden.ON and warden.run["done"]:
-                        raise web.HTTPGone(text=json.dumps(warden.ended_payload()), content_type="application/json")
-                    await asyncio.sleep(min(.1, max(0, end - asyncio.get_running_loop().time())))
+                input_stage("wait")
+                await budget.wait_seconds(val)
             elif kind == "frames":
+                input_stage("gap", step_index=index)
                 await wait_core_frames(val)
             else:
                 await tap(kind, val, step[2] if len(step) > 2 else None)
+        input_stage("settle")
         waited, changed = await settle(baseline, stable=stable)
         note_move()
         note_screen()
@@ -1162,7 +1208,11 @@ async def run_action(request, steps, note, verb="KEY",
             warden.run["frontier"] = ((world["banked"] + world["far"])
                                       if world["ok"] else None)
             warden.run["curve"] = list(curve)
+        budget.check()
     finally:
+        current_budget.reset(token)
+        if health:
+            health.set_input()
         api_lock.release()
 
     return web.json_response({
@@ -1399,7 +1449,7 @@ async def calibrate():
     property of the build: the same coordinates were measured two bytes apart
     on two runs on the same machine, so the serialised layout shifts with
     whatever else the machine is doing. Within one session it holds, and the
-    walk is done and undone before the agent's clock starts.
+    walk is done and undone on the first action, within the fixed run budget.
     """
     cap = LIB.core_state_size()
     if not cap:

--- a/server/test_core_thread_safety.py
+++ b/server/test_core_thread_safety.py
@@ -40,6 +40,8 @@ class CoreThreadSafetyTests(unittest.TestCase):
             cls.lib.core_state_peek.argtypes = [ctypes.POINTER(ctypes.c_size_t), ctypes.c_int,
                                               ctypes.POINTER(ctypes.c_int16)]
         cls.lib.core_key.argtypes = [ctypes.c_int, ctypes.c_bool]
+        cls.lib.core_key_before_deadline.argtypes = [ctypes.c_int, ctypes.c_bool, ctypes.c_double]
+        cls.lib.core_key_before_deadline.restype = ctypes.c_bool
         cls.lib.core_ticks.restype = ctypes.c_uint64
         cls.lib.core_last_error.restype = ctypes.c_char_p
         if cls.has_state_access:
@@ -82,6 +84,18 @@ class CoreThreadSafetyTests(unittest.TestCase):
         self.assertFalse(reader.is_alive(), "core operation failed to release its lock")
         self.assertEqual(self.probe.probe_overlaps(), 0)
         return result[0]
+
+    def test_key_deadline_is_checked_after_native_lock_and_never_blocks_keyup(self):
+        from health import clock
+        accepted = self.assert_serialized(
+            lambda: self.lib.core_key_before_deadline(13, True, clock() + .02))
+        self.assertFalse(accepted)
+        self.assertEqual(self.probe.probe_keydowns(), 0)
+        self.assertTrue(self.lib.core_key_before_deadline(13, True, clock() + 1))
+        self.assertEqual(self.probe.probe_keydowns(), 1)
+        self.assertTrue(self.lib.core_key_before_deadline(13, False, clock() - 1))
+        self.assertTrue(self.lib.core_key_before_deadline(13, True, clock() + 1))
+        self.assertEqual(self.probe.probe_keydowns(), 2)
 
     def test_state_size_waits_for_frame(self):
         if not self.has_state_access:

--- a/server/test_fixtures/thread_probe_core.c
+++ b/server/test_fixtures/thread_probe_core.c
@@ -8,24 +8,27 @@
 static retro_environment_t environment;
 static retro_video_refresh_t video;
 static atomic_int running, release_run, overlaps, fail_serialize, state_size;
-static atomic_int game_loaded, unloads, premature_deinit;
+static atomic_int game_loaded, unloads, premature_deinit, keydowns;
 static void touch_core(void) {
     if (atomic_load(&running)) atomic_fetch_add(&overlaps, 1);
 }
 static void keyboard(bool down, unsigned key, uint32_t character, uint16_t mods) {
     (void)down; (void)key; (void)character; (void)mods;
     touch_core();
+    if (down) atomic_fetch_add(&keydowns, 1);
     if (down && getenv("PROBE_HANG_ON_KEY")) {
         for (;;) { struct timespec delay = {0, 1000000}; nanosleep(&delay, NULL); }
     }
 }
 void probe_reset(void) {
+    atomic_store(&keydowns, 0);
     atomic_store(&running, 0); atomic_store(&release_run, 0);
     atomic_store(&overlaps, 0); atomic_store(&fail_serialize, 0);
     atomic_store(&state_size, 16);
     atomic_store(&game_loaded, 0); atomic_store(&unloads, 0);
     atomic_store(&premature_deinit, 0);
 }
+int probe_keydowns(void) { return atomic_load(&keydowns); }
 int probe_running(void) { return atomic_load(&running); }
 int probe_overlaps(void) { return atomic_load(&overlaps); }
 void probe_release(void) { atomic_store(&release_run, 1); }
@@ -66,6 +69,12 @@ void retro_run(void) {
     atomic_store(&running, 1);
     while (!atomic_load(&release_run)) {
         struct timespec delay = { 0, 1000000 };
+        nanosleep(&delay, NULL);
+    }
+    const char *frame_delay = getenv("PROBE_FRAME_DELAY_MS");
+    if (frame_delay) {
+        long ms = atol(frame_delay);
+        struct timespec delay = { ms / 1000, (ms % 1000) * 1000000 };
         nanosleep(&delay, NULL);
     }
     uint32_t pixel = 0x00123456;

--- a/server/test_health_diagnostics.py
+++ b/server/test_health_diagnostics.py
@@ -1,0 +1,41 @@
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from health import Health
+
+
+class DiagnosticsTests(unittest.TestCase):
+    def test_first_fault_freezes_bounded_context_and_survives_cleanup(self):
+        with tempfile.TemporaryDirectory() as root:
+            root = Path(root)
+            with patch.dict('os.environ', {'QUNXIA_DIAGNOSTIC_DIR': str(root / 'retained')}):
+                health = Health(lambda: 42, lambda: False, root / 'scratch')
+            health.set_phase('running')
+            for _ in range(100):
+                health.sample()
+            health.set_input(stage='hold', key='kp7', target_tick=52)
+            health.fail('input_frame_timeout', source='input_wait', actual_tick=45)
+            health.set_input(stage='release')
+            health.fail('core_stalled', source='tick_watchdog')
+            health.persist_incident()
+            record = json.loads((root / 'retained/incident.json').read_text())
+            self.assertEqual(record['failure']['reason'], 'input_frame_timeout')
+            self.assertEqual(record['failure']['source'], 'input_wait')
+            self.assertEqual(record['input']['stage'], 'hold')
+            self.assertEqual(record['details']['actual_tick'], 45)
+            self.assertEqual(len(record['samples']), 64)
+            self.assertTrue((root / 'retained/threads.txt').read_text())
+
+    def test_http_snapshot_does_not_advance_watchdog(self):
+        with tempfile.TemporaryDirectory() as root:
+            tick = [0]
+            health = Health(lambda: tick[0], lambda: False, root)
+            tick[0] = 10
+            self.assertEqual(health.snapshot()['core_ticks'], 10)
+            self.assertEqual(health.tick, 0)
+            self.assertEqual(len(health.history), 0)
+            health.sample()
+            self.assertEqual(health.tick, 10)

--- a/server/test_input_timing.py
+++ b/server/test_input_timing.py
@@ -14,6 +14,9 @@ class FakeLib:
         self.tick = 0
         self.events = []
 
+    def core_fps(self):
+        return 60.0
+
     def core_ticks(self):
         return self.tick
 

--- a/server/test_input_wait.py
+++ b/server/test_input_wait.py
@@ -1,0 +1,127 @@
+import asyncio
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from health import Health, EnvironmentFailure
+from input_wait import InputBudget, current_budget
+
+
+class FakeClock:
+    def __init__(self, rate=60, pause=0, jump=0):
+        self.now, self.rate, self.pause, self.jump = 0.0, rate, pause, jump
+
+    def clock(self):
+        return self.now
+
+    def ticks(self):
+        return int(max(0, self.now - self.pause) * self.rate)
+
+    async def sleep(self, seconds):
+        self.now += self.jump or seconds
+
+
+class InputWaitTests(unittest.IsolatedAsyncioTestCase):
+    def budget(self, fake, frames=132, **kwargs):
+        return InputBudget(frames, 60, clock_fn=fake.clock, sleep=fake.sleep, **kwargs)
+
+    async def test_normal_slow_and_transient_pause_keep_original_target(self):
+        for rate, pause in ((60, 0), (16, 0), (16, 2), (60, 10)):
+            with self.subTest(rate=rate, pause=pause):
+                fake = FakeClock(rate, pause)
+                budget = self.budget(fake)
+                await budget.wait(10, fake.ticks)
+                self.assertEqual(budget.context['target_tick'], 10)
+                self.assertEqual(fake.ticks(), 10)
+                self.assertLess(fake.now, budget.deadline)
+
+    async def test_zero_ticks_are_a_stall_but_drip_feed_hits_fixed_action_cap(self):
+        for rate, reason in ((0, 'core_stalled'), (.1, 'input_frame_timeout')):
+            fake = FakeClock(rate)
+            budget = self.budget(fake)
+            with self.assertRaisesRegex(EnvironmentFailure, reason):
+                await budget.wait(10, fake.ticks)
+            self.assertLess(fake.now, 16)
+
+    async def test_hold_release_gap_and_settle_share_one_deadline(self):
+        fake = FakeClock(1)
+        budget = self.budget(fake)
+        deadline = budget.deadline
+        for stage, frames in (('hold', 10), ('release', 2), ('gap', 2)):
+            budget.stage(stage, step_index=0)
+            await budget.wait(frames, fake.ticks)
+            self.assertEqual(budget.deadline, deadline)
+        budget.stage('settle')
+        with self.assertRaisesRegex(EnvironmentFailure, 'input_frame_timeout'):
+            await budget.wait(2, fake.ticks)
+        self.assertLess(fake.now, 16)
+
+    async def test_target_reached_after_deadline_is_not_success(self):
+        fake = FakeClock(jump=20)
+        with self.assertRaisesRegex(EnvironmentFailure, 'input_frame_timeout'):
+            await self.budget(fake).wait(1, fake.ticks)
+
+    async def test_runtime_expiry_precedes_reached_target_and_frame_timeout(self):
+        fake = FakeClock(jump=20)
+        def check():
+            if fake.now >= 1:
+                raise TimeoutError('run ended')
+        with self.assertRaisesRegex(TimeoutError, 'run ended'):
+            await self.budget(fake, check_runtime=check).wait(1, fake.ticks)
+
+    async def test_explicit_wait_checks_deadline_even_after_late_wakeup(self):
+        fake = FakeClock(jump=20)
+        with self.assertRaisesRegex(EnvironmentFailure, 'input_frame_timeout'):
+            await self.budget(fake).wait_seconds(.1)
+
+    async def test_failure_captures_target_actual_key_and_source(self):
+        fake = FakeClock(.1)
+        with tempfile.TemporaryDirectory() as root:
+            health = Health(fake.ticks, lambda: False, root)
+            budget = self.budget(fake, health=health)
+            budget.stage('hold', key='kp7', step_index=2)
+            with self.assertRaises(EnvironmentFailure):
+                await budget.wait(10, fake.ticks)
+            health.set_input()
+            self.assertEqual(health.fault['source'], 'input_wait')
+            self.assertEqual(health.incident['input']['key'], 'kp7')
+            self.assertEqual(health.incident['input']['step_index'], 2)
+            self.assertEqual(health.incident['input']['target_tick'], 10)
+            self.assertEqual(health.incident['input']['actual_tick'], 1)
+
+
+with patch('ctypes.CDLL'):
+    import server
+
+
+class KeyCleanupTests(unittest.IsolatedAsyncioTestCase):
+    async def test_late_hold_releases_once_and_does_not_start_next_key(self):
+        fake = FakeClock(jump=20)
+        budget = InputBudget(144, 60, clock_fn=fake.clock, sleep=fake.sleep)
+        events = []
+        class Core:
+            core_ticks = staticmethod(fake.ticks)
+            def core_key_before_deadline(self, code, down, deadline):
+                events.append((code, down))
+                return True
+            def core_key(self, code, down):
+                events.append((code, down))
+        token = current_budget.set(budget)
+        try:
+            with patch.object(server, 'LIB', Core()), patch.object(server, 'key_event'):
+                with self.assertRaisesRegex(EnvironmentFailure, 'input_frame_timeout'):
+                    await server.tap(13, 10, 'enter')
+                    await server.tap(27, 10, 'escape')
+            self.assertEqual(events, [(13, True), (13, False)])
+        finally:
+            current_budget.reset(token)
+
+    async def test_cancellation_releases_rest_key(self):
+        from unittest.mock import Mock
+        core = Mock()
+        async def cancel(_frames):
+            raise asyncio.CancelledError
+        with patch.object(server, 'LIB', core), patch.object(server, 'key_event'), patch.object(server, 'wait_core_frames', cancel):
+            with self.assertRaises(asyncio.CancelledError):
+                await server.tap(13, 10, 'enter')
+        self.assertEqual(core.core_key.call_args_list, [((13, True),), ((13, False),)])

--- a/server/test_recording.py
+++ b/server/test_recording.py
@@ -177,6 +177,7 @@ server.KEYFRAME_EVERY = .05
 original_event = server.key_event
 original_write = server.RecordingStore._write
 original_key = server.LIB.core_key
+original_guarded_key = server.LIB.core_key_before_deadline
 armed = False
 fail_until = 0.0
 def key_event(name, down):
@@ -195,6 +196,13 @@ def core_key(code, down):
     with pathlib.Path(os.environ["KEY_LOG"]).open("a") as stream:
         stream.write(json.dumps([code, bool(down)]) + "\\n")
     return result
+def guarded_key(code, down, deadline):
+    result = original_guarded_key(code, down, deadline)
+    if result:
+        with pathlib.Path(os.environ["KEY_LOG"]).open("a") as stream:
+            stream.write(json.dumps([code, bool(down)]) + "\\n")
+    return result
+server.LIB.core_key_before_deadline = guarded_key
 server.key_event = key_event
 server.RecordingStore._write = fail_write
 server.LIB.core_key = core_key

--- a/server/test_warden_deadline.py
+++ b/server/test_warden_deadline.py
@@ -1,0 +1,68 @@
+import asyncio
+from copy import deepcopy
+import unittest
+from unittest.mock import Mock, patch
+
+import warden
+with patch('ctypes.CDLL'):
+    import server
+from input_wait import InputBudget, current_budget
+
+
+class DeadlineTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.old = deepcopy(warden.run)
+        self.addCleanup(lambda: (warden.run.clear(), warden.run.update(self.old)))
+        warden.run.update(playable=None, deadline=None, done=None, result=None)
+
+    async def test_wall_clock_jumps_and_credit_do_not_move_deadline(self):
+        with patch.object(warden, 'clock', return_value=100), patch.object(warden.time, 'time', return_value=1000):
+            warden.playable_now()
+        deadline = 100 + warden.BUDGET
+        self.assertEqual(warden.run['deadline'], deadline)
+        warden.run['credit'] = 10000
+        for wall in (-100000, 100000000):
+            with patch.object(warden, 'clock', return_value=deadline-.01), patch.object(warden.time, 'time', return_value=wall):
+                warden.check_time()
+                self.assertIsNone(warden.run['done'])
+        with patch.object(warden, 'clock', return_value=deadline):
+            warden.check_time()
+        self.assertEqual(warden.run['done'], 'time')
+        self.assertEqual(warden.run['deadline'], deadline)
+
+    async def test_budget_expiry_in_hold_releases_and_blocks_next_key(self):
+        now = [0.0]
+        events = []
+        async def sleep(_seconds):
+            now[0] = 1.1
+        class Core:
+            def core_ticks(self): return int(now[0] * 60)
+            def core_key_before_deadline(self, code, down, deadline):
+                events.append((code, down, deadline))
+                return True
+            def core_key(self, code, down): events.append((code, down, None))
+        warden.run.update(playable=1, deadline=1, last_clock=0)
+        budget = InputBudget(144, 60, check_runtime=server.check_input_runtime,
+                             clock_fn=lambda: now[0], sleep=sleep)
+        token = current_budget.set(budget)
+        try:
+            with patch.object(warden, 'ON', True), patch.object(warden, 'clock', lambda: now[0]), patch.object(server, 'LIB', Core()), patch.object(server, 'key_event'):
+                with self.assertRaises(server.web.HTTPGone):
+                    await server.tap(13, 10, 'enter')
+                    await server.tap(27, 10, 'escape')
+                with self.assertRaises(server.web.HTTPGone):
+                    server.send_key_down(27)
+            self.assertEqual(events, [(13, True, 1), (13, False, None)])
+            self.assertEqual(warden.run['done'], 'time')
+        finally:
+            current_budget.reset(token)
+
+    async def test_pre_marked_time_still_validates_finalization(self):
+        warden.run.update(playable=1, deadline=1, done='time')
+        health = Mock()
+        async def fail(_frames):
+            raise RuntimeError('validation failure')
+        with patch.object(warden, 'write_result') as write:
+            await warden.warden({}, health, asyncio.Lock(), fail)
+        write.assert_not_called()
+        health.fail.assert_called_once_with('finalization_wait_failed', source='finalization', exception_type='RuntimeError')

--- a/server/test_worker_health.py
+++ b/server/test_worker_health.py
@@ -123,6 +123,37 @@ class WorkerIntegrationTests(unittest.TestCase):
         after=self.healthy()
         self.assertGreater(after['core_ticks'],before['core_ticks'])
 
+    def test_slow_advancing_native_core_completes_one_key_without_retry(self):
+        self.launch(PROBE_FRAME_DELAY_MS='180', QUNXIA_STALL_SECONDS='15')
+        wait_for(self.healthy)
+        status, body = request(self.port, '/api/key?react=0&stable=1&maxsettle=6',
+                               {'key': 'right', 'hold': 10}, timeout=20)
+        self.assertEqual(status, 200, body)
+        events = json.loads(request(self.port, '/api/recording')[1])['events']
+        keys = [e['down'] for e in events if e.get('key') == 'right']
+        self.assertEqual(keys, [True, False])
+        self.assertTrue(self.healthy())
+
+    def test_benchmark_time_limit_releases_partial_key_and_validates_result(self):
+        result_dir = self.folder / 'results'
+        self.launch(PROBE_FRAME_DELAY_MS='180', QUNXIA_STALL_SECONDS='15',
+                    QUNXIA_BENCH='1', QUNXIA_BENCH_BUDGET='2',
+                    QUNXIA_BENCH_SID='deadline', QUNXIA_RESULT_DIR=str(result_dir),
+                    QUNXIA_RECORDING_FILE=str(self.folder / 'deadline.jsonl'),
+                    QUNXIA_VIDEO_DIR=str(self.folder / 'videos'), QUNXIA_PUBLISH='0')
+        wait_for(self.healthy)
+        status, body = request(self.port, '/api/reset?token=test', {}, timeout=10)
+        self.assertEqual(status, 200, body)
+        status, body = request(self.port, '/api/key', {'key': 'right', 'hold': 100}, timeout=8)
+        self.assertEqual(status, 410, body)
+        result = wait_for(lambda: read_json(result_dir / 'deadline.json'))
+        self.assertTrue(result['valid'])
+        self.assertEqual(result['reason'], 'time')
+        journal = self.folder / 'deadline.jsonl'
+        records = [json.loads(line) for line in journal.read_text().splitlines()]
+        downs = [e['down'] for e in records if e.get('key') == 'right']
+        self.assertEqual(downs, [True, False])
+
     def test_native_key_deadlock_becomes_environment_failure(self):
         p=self.launch(PROBE_HANG_ON_KEY='1')
         wait_for(self.healthy)

--- a/server/warden.py
+++ b/server/warden.py
@@ -14,7 +14,7 @@ import os
 import pathlib
 import sys
 import time
-from health import write_json
+from health import clock, write_json
 
 ROOT = pathlib.Path(__file__).resolve().parent
 sys.path.insert(0, str(ROOT.parent / "bench"))
@@ -46,6 +46,7 @@ CATALOG_OBJECT = "catalog.json"
 ALIAS = {"esc": "escape", "cancel": "escape", "return": "enter", "ok": "enter"}
 
 run = {"playable": None, "first": None, "last": None, "gaps": [], "keys": {},
+       "deadline": None, "last_clock": None,
        # Request errors have no counter; the historical zero was a placeholder.
        "reads": 0, "errors": None, "actions": 0, "key_events": 0,
        "input_frames": 0, "wait_calls": 0,
@@ -56,8 +57,7 @@ run = {"playable": None, "first": None, "last": None, "gaps": [], "keys": {},
        "level": None, "exp": None, "hp": None, "maxhp": None, "skills": None,
        "items": None, "reputation": None, "potential": None,
        "inventory_distinct": None, "picked_item": None,
-       # seconds spent on the benchmark's own housekeeping rather than by the
-       # agent, handed back at the end of the run
+       # Retained for metrics compatibility; the fixed deadline grants no credit.
        "credit": 0.0,
        "done": None, "result": None}
 
@@ -65,6 +65,14 @@ run = {"playable": None, "first": None, "last": None, "gaps": [], "keys": {},
 def playable_now():
     """Called once the savestate is in and the agent may act."""
     run["playable"] = time.time()
+    run["deadline"] = clock() + BUDGET
+    run["last_clock"] = clock()
+
+
+def check_time():
+    """End at the fixed monotonic deadline, also from inside an input action."""
+    if run["deadline"] is not None and clock() >= run["deadline"] and not run["done"]:
+        run["done"] = "time"
 
 
 def note_action(keys, label="", input_frames=0):
@@ -81,6 +89,7 @@ def note_action(keys, label="", input_frames=0):
     else:
         run["first"] = now
     run["last"] = now
+    run["last_clock"] = clock()
     run["actions"] += 1
     if not keys:
         run["wait_calls"] += 1
@@ -305,23 +314,23 @@ async def warden(rec, health, action_lock, wait_frames, recording_snapshot=None)
     then publishes it and takes the process down with it."""
     while run["playable"] is None:
         await asyncio.sleep(1)
-    while True:
-        deadline = run["playable"] + BUDGET + run["credit"]
-        now = time.time()
-        if now >= deadline:
-            run["done"] = "time"
+    while not run["done"]:
+        check_time()
+        if run["done"]:
             break
-        if now - (run["last"] or run["playable"]) >= IDLE:
+        now = clock()
+        if now - run["last_clock"] >= IDLE:
             run["done"] = "idle" if run["last"] else "never started"
             break
-        await asyncio.sleep(min(.25, max(.01, deadline - now)))
+        await asyncio.sleep(min(.25, max(.01, run["deadline"] - now)))
 
     async with action_lock:
         try:
             await wait_frames(2)
             health.check()
-        except Exception:
-            health.fail("core_stalled")
+        except Exception as exc:
+            health.fail("finalization_wait_failed", source="finalization",
+                        exception_type=type(exc).__name__)
             return
         health.set_phase("finalizing")
     res = dict(metrics(), valid=True, complete=False, why=why_text(), video_url=None, error=None)


### PR DESCRIPTION
A short per-wait deadline could classify delayed frame progress as `core_stalled` and abort the remaining key sequence. This change waits for the same absolute tick target under one fixed action deadline, reports `input_frame_timeout` separately from no-progress stalls, and preserves the first failure context before cleanup.

The two commits separately add bounded diagnostics and change input/deadline handling. Diagnostics include the key and phase, target/actual ticks, elapsed time, recent completed phases, watchdog samples and Python thread stacks. Hold/release/gap/settle phases share one non-renewing deadline; exceptions and cancellation release accepted keys. The native key gate checks the deadline again after taking the execution lock, so a delayed lock acquisition cannot admit a new key after expiry.

The benchmark deadline is monotonic and fixed once the opening state is playable. Waiting, including optional calibration, consumes the original budget without credit. Expiry blocks remaining keys and still validates core health during finalization; environment failures remain invalid. The broker retains diagnostics outside worker scratch before reaping/reclamation.

Validation: 73 server tests and 9 broker/renderer tests passed. Controlled-clock cases cover 60/16 fps, transient pauses, zero progress, slow drip-feed, cancellation and late wakeups. Native worker cases cover slow progress, deadlocks, key release and the post-lock deadline gate. An isolated DOSBox run restored the opening state and executed a seven-key sequence once, with all 14 down/up transitions and a healthy advancing core afterward.

In the renderer test fixture, assertions passed, but local FFmpeg 9.0.1 logged an MJPEG color-range error and did not produce a poster. This is an existing artifact limitation outside the input/deadline change.

Baseline comparison with the same injected 180 ms frame delay: both upstream bases returned HTTP 503 / `core_stalled` and exited 75 for a 10-frame key; both fixed revisions completed the key once with one down/up pair and remained healthy.

A fresh 3,600-second Astra Max run on this benchmark revision ended with `valid: true`, `complete: true`, `reason: time` and no artifact error. It completed 166 actions and 324 tool calls from the formal four-tool surface, with zero tool failures, 1,189 healthy samples and 1,126 balanced key down/up pairs. The model stopped at the fixed one-hour limit; the H.264 replay decoded fully, its poster was produced, and owned processes were reaped. This single run is a regression witness, not a controlled causal comparison with the earlier run. This change addresses premature termination, classification and missing evidence. The underlying cause of the earlier DOSBox slowdown remains unproven.
