### PR TITLE
server: a failed catalogue download no longer wipes the public board

### DIFF
--- a/server/test_action_accounting.py
+++ b/server/test_action_accounting.py
@@ -36,6 +36,12 @@ class ActionAccountingTests(unittest.TestCase):
         self.assertEqual(warden.run["input_frames"], 30)
         self.assertEqual(warden.run["keys"], {"kp3": 2, "enter": 1})
 
+    def test_same_scancode_spellings_share_one_histogram_row(self):
+        # ne and upright drive the same scancode as up (273), so the three
+        # spellings are one key; kp9 drives its own 265 and keeps its row.
+        warden.note_action(["ne", "upright", "up", "kp9"])
+        self.assertEqual(warden.run["keys"], {"up": 3, "kp9": 1})
+
     def test_final_metrics_keep_the_end_reason(self):
         warden.run["done"] = "idle"
         self.assertEqual(warden.metrics()["reason"], "idle")

--- a/server/test_warden_finalization.py
+++ b/server/test_warden_finalization.py
@@ -161,3 +161,64 @@ class SharedAppendPreconditionTests(unittest.TestCase):
         # to read the fresh generation back from the object, not reuse 5.
         self.assertEqual(store["uploads"], [5, 6])
         self.assertEqual(store["generation"], 7)
+
+    def test_failed_download_retries_instead_of_wiping_the_catalogue(self):
+        class PreconditionFailed(Exception):
+            pass
+
+        store = {"runs": [{"id": "a"}, {"id": "b"}], "generation": 5,
+                 "uploads": [], "fail_download_times": 1}
+
+        class FakeBlob:
+            cache_control = None
+
+            def download_as_bytes(self):
+                if store["fail_download_times"] > 0:
+                    store["fail_download_times"] -= 1
+                    raise IOError("transient download blip")
+                return json.dumps(store["runs"]).encode()
+
+            def upload_from_string(self, data, content_type=None,
+                                   if_generation_match=None):
+                store["uploads"].append(if_generation_match)
+                if if_generation_match != store["generation"]:
+                    raise PreconditionFailed
+                store["generation"] += 1
+                store["runs"] = json.loads(data)
+
+        class FakeBucket:
+            def get_blob(self, name):
+                blob = FakeBlob()
+                blob.generation = store["generation"]
+                return blob
+
+            def blob(self, name):
+                return self.get_blob(name)
+
+        conf = types.ModuleType("google.api_core.exceptions")
+        conf.PreconditionFailed = PreconditionFailed
+        api_core = types.ModuleType("google.api_core")
+        api_core.exceptions = conf
+        storage = types.ModuleType("google.cloud.storage")
+        storage.Client = lambda: types.SimpleNamespace(
+            bucket=lambda name: FakeBucket())
+        cloud = types.ModuleType("google.cloud")
+        cloud.storage = storage
+        google = types.ModuleType("google")
+        google.cloud = cloud
+        google.api_core = api_core
+        with mock.patch.dict(sys.modules, {
+                "google": google, "google.api_core": api_core,
+                "google.api_core.exceptions": conf,
+                "google.cloud": cloud, "google.cloud.storage": storage}), \
+                mock.patch.object(warden, "BUCKET", "bench-test"), \
+                mock.patch.object(warden, "PUBLISH", True):
+            warden.append_catalog({"id": "c", "complete": True})
+
+        # The transient download failure must not have been read as an empty
+        # catalogue: the retry re-read the object and appended to it, so the
+        # pre-existing entries survive alongside the new one.
+        self.assertEqual([r["id"] for r in store["runs"]], ["c", "a", "b"])
+        # The failed attempt wrote nothing; only the retry's upload landed,
+        # against the generation it re-read.
+        self.assertEqual(store["uploads"], [5])

--- a/server/warden.py
+++ b/server/warden.py
@@ -45,12 +45,19 @@ CATALOG_OBJECT = "catalog.json"
 # emulator in.
 # Spelling -> the key it names. Two spellings are one key only when they
 # drive the same scancode: lshift and shift are both 304, but rshift is its
-# own 303 (as in the native table), so it keeps its own row.
+# own 303 (as in the native table), so it keeps its own row. The on-screen
+# diagonal aliases are the arrow scancodes under second names (ne and
+# upright both drive 273, the same as up), so they merge into the arrow's
+# row the way lshift merges into shift's; kp9 keeps its own 265.
 ALIAS = {
     "esc": "escape", "cancel": "escape", "back": "escape",
     "return": "enter", "ok": "enter", "confirm": "enter",
     "yes": "y", "no": "n",
     "lshift": "shift", "lctrl": "ctrl", "lalt": "alt",
+    "upright": "up", "ne": "up",
+    "downleft": "down", "sw": "down",
+    "downright": "right", "se": "right",
+    "upleft": "left", "nw": "left",
     "quote": "'", "comma": ",", "minus": "-", "period": ".", "slash": "/",
     "semicolon": ";", "equals": "=", "leftbracket": "[", "backslash": "\\",
     "rightbracket": "]", "backquote": "`",

--- a/server/warden.py
+++ b/server/warden.py
@@ -308,14 +308,22 @@ def append_catalog(entry):
             try:
                 runs = json.loads(blob.download_as_bytes())
             except Exception:
-                runs = []
+                # A failed or corrupt download is not an empty catalogue:
+                # reading it as one would replace the public leaderboard
+                # with this single entry, since the generation precondition
+                # still passes. Retry like a write conflict; the broker's
+                # usage merge makes the same distinction.
+                time.sleep(0.3 * (attempt + 1))
+                continue
         runs = [entry] + [r for r in runs if r.get("id") != entry["id"]]
+        # Carry the hint into the write, as the broker's merge does: one
+        # API call, and no window in which the catalogue sits public under
+        # default cache hints.
+        blob.cache_control = "public, max-age=15"
         try:
             blob.upload_from_string(json.dumps(runs[:500]),
                                     content_type="application/json",
                                     if_generation_match=gen)
-            blob.cache_control = "public, max-age=15"
-            blob.patch()
             return
         except PreconditionFailed:
             time.sleep(0.3 * (attempt + 1))


### PR DESCRIPTION
## What

Two fixes to the warden's public-catalogue path, each with a pinning test.

**1. A failed catalogue download wiped the leaderboard (the important one).**
append_catalog read the shared catalogue and, on *any* exception from the
download (network blip, corrupt bytes), fell back to runs = []. The
upload's generation precondition still passed — nobody had written in
between — so the public leaderboard at
storage.googleapis.com/jy-crpg-bench-runs/catalog.json was replaced with
the single new entry. The broker's usage merge (same object) already made
this distinction ("a transient download failure is not 'the entry does
not exist'"); the warden, which appends on *every* run end, now does too:
back off and re-read like a write conflict, and fail loudly after the
retries (the caller records catalogue: … on the run result) instead of
destroying data.

While in the function: the cache hint is now carried into the write, as
the broker's merge does (one API call, and no window in which the
catalogue sits public under default cache hints between the upload and
the out-of-band patch it replaced). The live object already serves
cache-control: public, max-age=15 via the broker's pattern.

**2. The diagonal aliases keep their own histogram rows.**
The ALIAS table says two spellings are one key only when they drive the
same scancode (lshift+shift → 304; rshift keeps its 303). ne, upright,
sw, downleft, se, downright, nw, upleft drive 273–276 — the arrow
scancodes — so by that rule they count under the arrows. They had kept
their own rows, which would inflate distinct_keys for a spelling of the
key the model actually pressed. kp9 and friends drive their own numpad
scancodes (265 etc.) and keep their rows. No published run uses the
diagonal names, so only future histograms are affected.

## Tests

- test_failed_download_retries_instead_of_wiping_the_catalogue: a
  transient download failure must leave the pre-existing entries intact
  and land exactly one (retry) upload. Its fake blob has no .patch(), so
  a regression to the out-of-band patch fails it too.
- test_same_scancode_spellings_share_one_histogram_row:
  note_action([ne, upright, up, kp9]) → {up: 3, kp9: 1}.
- Full suite: 103 server + 65 bench tests green.