### PR TITLE
bench-automation: restore Pi tool calls and benchmark end responses

### DIFF
--- a/Scripts/test-pi-launch.mjs
+++ b/Scripts/test-pi-launch.mjs
@@ -75,3 +75,76 @@ test("isolated launcher preserves Gemini High through the real Pi CLI and HTTP a
   assert.equal(manifest.model.mappedThinkingLevel, "high");
   assert.equal(manifest.model.api, "google-generative-ai");
 });
+
+test("extension game tools execute against the game API through the real Pi CLI", { timeout: 60000 }, async t => {
+  const directory = await mkdtemp(join(tmpdir(), "qunxia-tool-call-"));
+  const requests = [];
+  let base;
+  const server = createServer(async (req, res) => {
+    let text = "";
+    for await (const chunk of req) text += chunk;
+    requests.push({ path: req.url, body: text ? JSON.parse(text) : null, xAgent: req.headers["x-agent"] });
+    if (req.url.startsWith("/api/help")) {
+      res.end(["# Fixture game brief", ...["screen", "key", "keys", "wait"].map(
+        name => `${name === "screen" ? "GET" : "POST"} ${base}/api/${name}`,
+      )].join("\n"));
+    } else if (req.url.startsWith("/api/screen")) {
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ ok: true, image: pixel, width: 1, height: 1 }));
+    } else if (req.url.includes(":streamGenerateContent")) {
+      // First turn: the model calls the look tool. Second turn: it finishes.
+      const turn = requests.filter(r => r.path.includes(":streamGenerateContent")).length;
+      const parts = turn === 1
+        ? [{ functionCall: { name: "game_look", args: {} } }]
+        : [{ text: "Fixture finished." }];
+      res.setHeader("Content-Type", "text/event-stream");
+      res.end(`data: ${JSON.stringify({ candidates: [{ content: { role: "model", parts }, finishReason: "STOP" }] })}\n\n`);
+    } else {
+      res.writeHead(404).end();
+    }
+  });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  base = `http://127.0.0.1:${server.address().port}`;
+  t.after(() => { server.closeAllConnections(); server.close(); });
+  const definition = join(directory, "gemini.json");
+  await writeFile(definition, JSON.stringify({
+    id: "gemini-3.8-flash", api: "google-generative-ai", reasoning: true,
+    input: ["text", "image"], contextWindow: 1048576, maxTokens: 65536,
+    thinkingLevelMap: { off: null, minimal: null, low: "low", medium: "medium", high: "high", xhigh: null, max: null },
+  }));
+  const env = {
+    ...Object.fromEntries(Object.entries(process.env).filter(([name]) => !name.startsWith("QUNXIA_"))),
+    PATH: `${dirname(process.execPath)}:${process.env.PATH}`,
+    QUNXIA_LLM_MODEL: "fixture-google/gemini-3.8-flash", QUNXIA_LLM_BASE_URL: `${base}/v1beta`,
+    QUNXIA_LLM_API_KEY: "fake-test-key", QUNXIA_MODEL_CONFIG: definition,
+    QUNXIA_THINKING: "high", QUNXIA_PI_PROFILE: "benchmark", QUNXIA_API: `${base}/api`,
+    QUNXIA_RUNS_DIR: directory, QUNXIA_RUN_ID: "tool-call-run",
+  };
+  const child = spawn("zsh", [join(root, "Scripts", "play-agent.sh"), "-p", "Look at the screen."], {
+    env, cwd: root, stdio: ["ignore", "pipe", "pipe"],
+  });
+  t.after(() => { if (child.exitCode === null) child.kill(); });
+  let output = "";
+  child.stdout.on("data", data => { output += data; });
+  child.stderr.on("data", data => { output += data; });
+  const status = await new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("exit", resolve);
+  });
+  assert.equal(status, 0, output);
+
+  // The extension names the run in the activity log, like every other harness.
+  const toolScreens = requests.filter(req => req.path.startsWith("/api/screen") && req.xAgent);
+  assert.equal(toolScreens.length, 1, output);
+  assert.equal(toolScreens[0].xAgent, "pi");
+
+  // The model's tool call executed against the game API and came back as a
+  // clean result: the status line and the frame, not a harness error.
+  const calls = requests.filter(req => req.path.includes(":streamGenerateContent"));
+  assert.equal(calls.length, 2, output);
+  const parts = calls[1].body.contents.flatMap(content => content.parts ?? []);
+  const result = parts.find(part => part.functionResponse?.name === "game_look");
+  assert.ok(result, output);
+  assert.equal(result.functionResponse.response.error, undefined);
+  assert.match(JSON.stringify(result.functionResponse.response), /look \\| 1x1/);
+});

--- a/Scripts/test-pi-launch.mjs
+++ b/Scripts/test-pi-launch.mjs
@@ -146,5 +146,7 @@ test("extension game tools execute against the game API through the real Pi CLI"
   const result = parts.find(part => part.functionResponse?.name === "game_look");
   assert.ok(result, output);
   assert.equal(result.functionResponse.response.error, undefined);
-  assert.match(JSON.stringify(result.functionResponse.response), /look \\| 1x1/);
+  assert.match(JSON.stringify(result.functionResponse.response), /look \| 1x1/);
+  assert.ok(JSON.stringify(calls[1].body).includes(pixel.split(",")[1]),
+    "the fixture model receives the screen image");
 });

--- a/Scripts/test-pi-run.mjs
+++ b/Scripts/test-pi-run.mjs
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 // Exercise the exact compatibility code bundled with the pinned Pi package.
 import {
   clampThinkingLevel,
@@ -349,4 +349,67 @@ test("the manifest preserves an explicit off mapping without claiming a wire cap
   assert.equal(manifest.model.thinkingLevel, "off");
   assert.equal(manifest.model.mappedThinkingLevel, "none");
   assert.equal("providerThinkingLevel" in manifest.model, false);
+});
+
+test("a benchmark end is an answer on every tool, not a tool failure", async () => {
+  // Load the real extension source verbatim under Node's type stripping and
+  // drive the registered tools against a fake game server, so the error
+  // handling is tested as code instead of as a regex over the file.
+  const stage = await mkdtemp(join(tmpdir(), "qunxia-pi-ext-"));
+  await mkdir(join(stage, "node_modules"), { recursive: true });
+  await writeFile(join(stage, "package.json"), JSON.stringify({ type: "module" }));
+  await writeFile(
+    join(stage, "index.ts"),
+    await readFile(join(root, "pi-agent", "extensions", "qunxia", "index.ts"), "utf8"),
+  );
+  await symlink(
+    join(root, "node_modules", "@earendil-works", "pi-coding-agent",
+         "node_modules", "typebox"),
+    join(stage, "node_modules", "typebox"),
+  );
+
+  const tools = {};
+  const mod = await import(pathToFileURL(join(stage, "index.ts")).href);
+  mod.default({ registerTool: (tool) => { tools[tool.name] = tool; } });
+  assert.ok(tools.game_look, "game_look is registered");
+  assert.ok(tools.game_press, "game_press is registered");
+
+  const realFetch = globalThis.fetch;
+  try {
+    // A 410 with the end payload is the run summary. It must reach the model
+    // as the answer the brief promised, not as "game is not reachable".
+    globalThis.fetch = async () => new Response(
+      JSON.stringify({
+        ok: true, ended: true, reason: "time",
+        why: "benchmark deadline reached", actions: 3, played: 42,
+        video_url: "http://broker.invalid/videos/a.mp4",
+      }),
+      { status: 410, headers: { "content-type": "application/json" } },
+    );
+    const ended = await tools.game_look.execute("call-1", {}, undefined);
+    assert.equal(ended.isError, undefined);
+    assert.match(ended.content[0].text, /^BENCHMARK ENDED \| /);
+    assert.match(ended.content[0].text, /"actions":3/);
+    assert.match(ended.content[0].text, /"played_seconds":42/);
+    assert.match(ended.content[0].text, /"video_url":"http:\/\/broker\.invalid\/videos\/a\.mp4"/);
+
+    // A server rejection is a rejection, reported with its status code and
+    // not disguised as a network problem.
+    globalThis.fetch = async () => new Response(
+      JSON.stringify({ ok: false, error: "unknown key" }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    );
+    const rejected = await tools.game_press.execute("call-2", { key: "nope" }, undefined);
+    assert.equal(rejected.isError, true);
+    assert.match(rejected.content[0].text, /The game rejected the request: unknown key \(HTTP 400\)/);
+    assert.doesNotMatch(rejected.content[0].text, /not reachable/);
+
+    // A dead server is still reported as unreachable.
+    globalThis.fetch = async () => { throw new Error("ECONNREFUSED"); };
+    const down = await tools.game_look.execute("call-3", {}, undefined);
+    assert.equal(down.isError, true);
+    assert.match(down.content[0].text, /not reachable/);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
 });

--- a/Scripts/test-pi-run.mjs
+++ b/Scripts/test-pi-run.mjs
@@ -386,12 +386,18 @@ test("a benchmark end is an answer on every tool, not a tool failure", async () 
       }),
       { status: 410, headers: { "content-type": "application/json" } },
     );
-    const ended = await tools.game_look.execute("call-1", {}, undefined);
-    assert.equal(ended.isError, undefined);
-    assert.match(ended.content[0].text, /^BENCHMARK ENDED \| /);
-    assert.match(ended.content[0].text, /"actions":3/);
-    assert.match(ended.content[0].text, /"played_seconds":42/);
-    assert.match(ended.content[0].text, /"video_url":"http:\/\/broker\.invalid\/videos\/a\.mp4"/);
+    for (const [name, args] of [
+      ["game_look", {}], ["game_press", { key: "enter" }],
+      ["game_press_sequence", { keys: ["enter", "down"] }],
+      ["game_wait", { ms: 100 }],
+    ]) {
+      const ended = await tools[name].execute(`end-${name}`, args, undefined);
+      assert.equal(ended.isError, undefined, name);
+      assert.match(ended.content[0].text, /^BENCHMARK ENDED \| /);
+      assert.match(ended.content[0].text, /"actions":3/);
+      assert.match(ended.content[0].text, /"played_seconds":42/);
+      assert.match(ended.content[0].text, /"video_url":"http:\/\/broker\.invalid\/videos\/a\.mp4"/);
+    }
 
     // A server rejection is a rejection, reported with its status code and
     // not disguised as a network problem.

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -132,7 +132,8 @@ def _result(res, note=""):
     """Turn an API response into MCP content: a short status line plus the screen."""
     if res.get("ended"):
         summary = {key: res.get(key) for key in
-                   ("reason", "why", "actions", "video_url", "video_pending")}
+                   ("reason", "why", "message", "actions", "video_url",
+                    "video_pending")}
         summary["played_seconds"] = res.get("played_seconds", res.get("played"))
         return [TextContent(type="text", text="BENCHMARK ENDED | "
                             + json.dumps(summary, ensure_ascii=False))]

--- a/mcp-server/test_server.py
+++ b/mcp-server/test_server.py
@@ -202,18 +202,23 @@ class MCPHTTPContractTests(unittest.TestCase):
     def test_http_410_retains_broker_and_warden_timing(self):
         for timing in ({"played": 42}, {"played_seconds": 42}):
             ended = {"ok": True, "ended": True, "reason": "budget",
+                     "message": "The benchmark deadline has been reached.",
                      "actions": 7, "video_url": "https://example.invalid/run.mp4", **timing}
-            with self.subTest(timing=timing), http_fixture([
-                    (410, "application/json", json.dumps(ended).encode())]) as (origin, _requests):
-                server = load_server("benchmark", QUNXIA_API=origin + "/api")
-                result = self.call_tool(server, "wait", {"ms": 1500})
-            self.assertEqual(len(result.content), 1)
-            prefix, summary = result.content[0].text.split(" | ", 1)
-            self.assertEqual(prefix, "BENCHMARK ENDED")
-            summary = json.loads(summary)
-            self.assertEqual(summary["played_seconds"], 42)
-            self.assertEqual(summary["actions"], 7)
-            self.assertEqual(summary["video_url"], ended["video_url"])
+            for name, arguments in (("look", {}), ("press", {"key": "enter"}),
+                                    ("press_sequence", {"keys": ["enter", "down"]}),
+                                    ("wait", {"ms": 1500})):
+                with self.subTest(timing=timing, tool=name), http_fixture([
+                        (410, "application/json", json.dumps(ended).encode())]) as (origin, _requests):
+                    server = load_server("benchmark", QUNXIA_API=origin + "/api")
+                    result = self.call_tool(server, name, arguments)
+                self.assertEqual(len(result.content), 1)
+                prefix, summary = result.content[0].text.split(" | ", 1)
+                self.assertEqual(prefix, "BENCHMARK ENDED")
+                summary = json.loads(summary)
+                self.assertEqual(summary["played_seconds"], 42)
+                self.assertEqual(summary["actions"], 7)
+                self.assertEqual(summary["message"], ended["message"])
+                self.assertEqual(summary["video_url"], ended["video_url"])
 
 
 if __name__ == "__main__":

--- a/pi-agent/extensions/qunxia/index.ts
+++ b/pi-agent/extensions/qunxia/index.ts
@@ -8,6 +8,7 @@ import { Type } from "typebox";
 const API = (process.env.QUNXIA_API ?? "http://127.0.0.1:8765").replace(/\/+$/, "");
 const rawScale = Number(process.env.QUNXIA_SCALE ?? "1");
 const SCALE = Number.isFinite(rawScale) ? Math.min(6, Math.max(1, Math.trunc(rawScale))) : 1;
+const AGENT = (process.env.QUNXIA_AGENT ?? "pi").replace(/[^a-zA-Z0-9_.-]/g, "").slice(0, 16) || "pi";
 const OBSERVE_AFTER_ACTION = process.env.QUNXIA_OBSERVE_AFTER_ACTION !== "0";
 const ACTION_RESULT = OBSERVE_AFTER_ACTION
   ? "The resulting visible frame is returned."
@@ -47,7 +48,7 @@ async function call(method: string, path: string, body?: unknown, signal?: Abort
   return payload;
 }
 
-function offline(err: unknown) {
+function toolFailure(err: unknown, _signal?: AbortSignal) {
   return {
     content: [{
       type: "text" as const,

--- a/pi-agent/extensions/qunxia/index.ts
+++ b/pi-agent/extensions/qunxia/index.ts
@@ -16,7 +16,15 @@ const ACTION_RESULT = OBSERVE_AFTER_ACTION
 
 type Content = { type: "text"; text: string } | { type: "image"; data: string; mimeType: string };
 
-class GameApiError extends Error {}
+class GameApiError extends Error {
+  status: number | undefined;
+  hint: string | undefined;
+  constructor(message: string, status?: number, hint?: string) {
+    super(message);
+    this.status = status;
+    this.hint = hint;
+  }
+}
 
 async function call(method: string, path: string, body?: unknown, signal?: AbortSignal) {
   const res = await fetch(API + path, {
@@ -38,17 +46,36 @@ async function call(method: string, path: string, body?: unknown, signal?: Abort
       error: `game API returned HTTP ${res.status} with a non-JSON response`,
     };
   }
+  // The end of a benchmark run is an answer, not a request failure: its 410
+  // body is the summary the brief tells the model to wait for, so it passes
+  // through even though the status code is not 2xx.
+  if (payload.ended) return payload;
   if (!res.ok) {
     payload.ok = false;
     payload.error ??= `game API returned HTTP ${res.status}`;
   }
   if (payload.ok === false) {
-    throw new GameApiError(String(payload.error ?? `game API returned HTTP ${res.status}`));
+    throw new GameApiError(
+      String(payload.error ?? `game API returned HTTP ${res.status}`),
+      res.status,
+      typeof payload.hint === "string" && payload.hint ? payload.hint : undefined);
   }
   return payload;
 }
 
 function toolFailure(err: unknown, _signal?: AbortSignal) {
+  if (err instanceof GameApiError) {
+    const status = err.status !== undefined ? ` (HTTP ${err.status})` : "";
+    const hint = err.hint ? ` ${err.hint}` : "";
+    return {
+      content: [{
+        type: "text" as const,
+        text: `The game rejected the request: ${err.message}${status}.${hint}`,
+      }],
+      details: { error: String(err.message), status: err.status, hint: err.hint },
+      isError: true,
+    };
+  }
   return {
     content: [{
       type: "text" as const,
@@ -70,6 +97,7 @@ function frame(res: Record<string, any>, note: string) {
         text: `BENCHMARK ENDED | ${JSON.stringify({
           reason: res.reason,
           why: res.why,
+          message: res.message,
           actions: res.actions,
           played_seconds: res.played_seconds ?? res.played,
           video_url: res.video_url,

--- a/server/server.py
+++ b/server/server.py
@@ -1453,6 +1453,12 @@ async def api_screen(request):
     fmt = request.query.get("format", "")
     watching = request.query.get("spectate") == "1"
     if warden.ON and not watching:
+        ended = warden.ended_payload()
+        if ended:
+            # A look after the run is over is answered the way an action is:
+            # the end signal rides on every tool the agent can still call, not
+            # only the ones that send keys.
+            return web.json_response(ended, status=410)
         warden.note_read()
     if not watching:
         log_action(actor(request), "GET", "screen", thumb=True)

--- a/server/test_api.py
+++ b/server/test_api.py
@@ -171,5 +171,53 @@ class AtomicObservationTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(base64.b64decode(result["image"].split(",", 1)[1]), b"png")
 
 
+class ScreenWardenTest(unittest.IsolatedAsyncioTestCase):
+    """The end of a benchmark run must be visible on /api/screen.
+
+    The agent's brief is "wait for a tool to report BENCHMARK ENDED", and look
+    is the tool it calls most often. If only key-sending tools answered with
+    410, an agent that finishes by watching would stare at a finished run
+    until its own deadline.
+    """
+
+    def setUp(self):
+        import warden
+        self._warden = warden
+        self.old_on = warden.ON
+        self.addCleanup(setattr, warden, "ON", self.old_on)
+        warden.ON = True
+
+    async def test_ended_run_answers_looks_with_410(self):
+        payload = {"ended": True, "reason": "time", "actions": 3}
+        with mock.patch.object(self._warden, "ended_payload", return_value=payload):
+            response = await server.api_screen(FakeRequest())
+        self.assertEqual(response.status, 410)
+        self.assertEqual(response_json(response), payload)
+
+    async def test_spectating_looks_are_not_wardened(self):
+        payload = {"ended": True, "reason": "time"}
+        with mock.patch.object(self._warden, "ended_payload", return_value=payload), \
+                mock.patch.object(server, "snapshot",
+                                  lambda _fmt: (b"x", 2, 2, "image/png")):
+            response = await server.api_screen(
+                FakeRequest(query={"format": "png", "spectate": "1"}))
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.body, b"x")
+
+    async def test_live_run_still_serves_frames_and_counts_the_read(self):
+        reads = []
+        with mock.patch.object(self._warden, "ended_payload", return_value=None), \
+                mock.patch.object(self._warden, "note_read",
+                                  lambda: reads.append(1)), \
+                mock.patch.object(server, "snapshot",
+                                  lambda _fmt: (b"x", 2, 2, "image/png")), \
+                mock.patch.object(server, "log_action", lambda *_a, **_k: None):
+            response = await server.api_screen(
+                FakeRequest(query={"format": "png"}))
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.body, b"x")
+        self.assertEqual(reads, [1])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
On `bench-automation`, Pi game-tool calls reference the missing `AGENT` constant and `toolFailure` helper. After a benchmark ends, `/api/screen` also continues returning frames while Pi treats the HTTP 410 end payload as a request failure.

Restore the missing definitions, return the benchmark end payload on warded screen reads, and carry the end summary through Pi and MCP. Spectator reads still return frames. Genuine API rejections retain their status and hint; network failures remain distinguishable.

This is the Pi/tool-lifecycle portion of the closed #24, targeting `bench-automation`. The two production commits are cherry-picked from Han Xiao's `b3611e15` and `202e973c` in #22 with their authorship and source hashes preserved. A separate test commit checks the returned image and all four formal tools. These fixes are already in `main`.

Validation on Node 24.15.0, Pi 0.84.4 and Python 3.12:

- `node --test Scripts/test-pi-run.mjs Scripts/test-pi-launch.mjs`: 19 passed. A local fake provider drives the real Pi CLI through `game_look` and receives its status text and image.
- `python -m unittest discover -s server -p test_api.py -v`: 13 passed, including ended/live/spectator screen reads.
- `python -m unittest discover -s mcp-server -p test_server.py -v`: 11 passed, including HTTP 410 responses through look, press, press_sequence and wait.
- Both the real-CLI tool-call fixture and the extension end-response fixture fail against the original `bench-automation` extension. No paid model, live game or cloud-storage requests were used.
