### PR TITLE
core: the host refuses to initialize a second core over a live one

### DIFF
--- a/Sources/CoreHost/CoreHost.c
+++ b/Sources/CoreHost/CoreHost.c
@@ -361,6 +361,14 @@ static void *sym(const char *name, bool required) {
 
 bool core_init(const char *core_path, const char *game_path, const char *save_dir) {
     g_err[0] = 0;
+    if (g_run) {
+        /* The libretro contract is one initialization per process: a second
+           retro_init over a live core is what took DOSBox Pure down - it
+           accepted the init, logged "core loaded", and died on the next frame.
+           Refuse cleanly instead of corrupting the live core. */
+        set_err("a core is already initialized in this process; call core_shutdown() first");
+        return false;
+    }
     snprintf(g_save_dir, sizeof(g_save_dir), "%s", save_dir ? save_dir : ".");
     snprintf(g_sys_dir, sizeof(g_sys_dir), "%s", save_dir ? save_dir : ".");
 

--- a/Sources/CoreHost/include/CoreHost.h
+++ b/Sources/CoreHost/include/CoreHost.h
@@ -13,6 +13,9 @@ typedef void (*core_log_fn)(const char *line);
 void core_set_option(const char *key, const char *value);
 const char *core_get_option(const char *key);
 
+/* One initialization per process: a second call over a live core fails.
+   Re-initializing after core_shutdown() is not guaranteed by the libretro
+   contract; for a fresh origin, start a new process. */
 bool core_init(const char *core_path, const char *game_path, const char *save_dir);
 void core_shutdown(void);
 void core_run_frame(void);

--- a/bench/test_repro.py
+++ b/bench/test_repro.py
@@ -13,8 +13,9 @@ the claim:
   been running when it arrived - the start state is a well-defined
   origin, not a moving target.
 
-Each case runs the driver in a subprocess: the core cannot be
-re-initialised inside an already-running process, and a fresh process
+Each case runs the driver in a subprocess: the core's lifecycle is one
+per process - the host refuses a second initialization over a live core
+and the libretro contract guarantees no second one - and a fresh process
 is the stronger claim anyway.  Where the core, game, or start state is
 absent the driver exits 3 and the case is skipped, as on a CI runner
 that builds no game.

--- a/server/test_core_thread_safety.py
+++ b/server/test_core_thread_safety.py
@@ -58,6 +58,11 @@ class CoreThreadSafetyTests(unittest.TestCase):
         self.assertTrue(self.lib.core_init(str(self.core_path).encode(), b"unused", str(self.directory).encode()))
         self.lib.core_release_all_keys()
 
+    def tearDown(self):
+        # One lifecycle per test: the host refuses to initialize over a live
+        # core, so the next setUp's core_init is a clean post-shutdown init.
+        self.lib.core_shutdown()
+
     def assert_serialized(self, operation):
         runner = threading.Thread(target=self.lib.core_run_frame, daemon=True)
         runner.start()
@@ -96,6 +101,18 @@ class CoreThreadSafetyTests(unittest.TestCase):
         self.assertTrue(self.lib.core_key_before_deadline(13, False, clock() - 1))
         self.assertTrue(self.lib.core_key_before_deadline(13, True, clock() + 1))
         self.assertEqual(self.probe.probe_keydowns(), 2)
+
+    def test_init_over_a_live_core_is_refused(self):
+        # The libretro contract is one initialization per process; a second
+        # retro_init over a live core is what took DOSBox Pure down (it
+        # accepted the init, logged "core loaded" and died on the next frame).
+        # The host must refuse the second call cleanly, leaving the live core
+        # untouched.
+        self.assertFalse(
+            self.lib.core_init(str(self.core_path).encode(), b"unused", str(self.directory).encode()))
+        self.assertIn(b"already initialized", self.lib.core_last_error())
+        self.assert_serialized(lambda: self.lib.core_key(13, True))
+        self.assertEqual(self.probe.probe_keydowns(), 1)
 
     def test_state_size_waits_for_frame(self):
         if not self.has_state_access:


### PR DESCRIPTION
The libretro contract is one initialization per process. A second
retro_init over a live core is undefined, and DOSBox Pure does not
honour it: it accepted the second init, logged "core loaded", and
segfaulted on the next frame. The bench driver works around this by
running one origin per subprocess; the host itself offered no guard,
so any caller that double-initialised took the process down with it.

core_init now fails cleanly - "a core is already initialized in this
process; call core_shutdown() first" - instead of calling retro_init
a second time. Re-initialising after core_shutdown() is still left to
the core's discretion (the probe fixture honours it, the production
core does not, and the host cannot tell); the header now says so.

The thread-safety suite re-initialised in setUp while the previous
test's core was still live - the probe tolerated it, the guard does
not - so the class now owns one lifecycle per test (tearDown shuts
down) and a new case pins the refusal: a second init over a live core
fails with the error, and the live core keeps running and taking keys.

Verified against the real core: 120 frames paced, second init
refused, frames advancing after the refusal, clean shutdown.
