### PR TITLE
server: the benchmark deadline test tolerates a stalled event loop

### DIFF
--- a/server/test_worker_health.py
+++ b/server/test_worker_health.py
@@ -148,7 +148,7 @@ class WorkerIntegrationTests(unittest.TestCase):
     def test_benchmark_time_limit_releases_partial_key_and_validates_result(self):
         result_dir = self.folder / 'results'
         self.launch(PROBE_FRAME_DELAY_MS='180', QUNXIA_STALL_SECONDS='15',
-                    QUNXIA_BENCH='1', QUNXIA_BENCH_BUDGET='5',
+                    QUNXIA_BENCH='1', QUNXIA_BENCH_BUDGET='10',
                     QUNXIA_BENCH_SID='deadline', QUNXIA_RESULT_DIR=str(result_dir),
                     QUNXIA_RECORDING_FILE=str(self.folder / 'deadline.jsonl'),
                     QUNXIA_VIDEO_DIR=str(self.folder / 'videos'), QUNXIA_PUBLISH='0')
@@ -167,23 +167,41 @@ class WorkerIntegrationTests(unittest.TestCase):
         # never recorded), and far enough behind it that the hold cannot
         # finish first (100 frames at the probe's 180 ms frame delay is
         # ~18 s of real time, while the warden's absolute deadline still
-        # beats the input budget's ~19 s wall). The 0.6 s floor is
-        # unchanged: a runner that spends the budget before the first read
-        # still sends the key at whatever remains, as before.
+        # beats the input budget's ~19 s wall). The 10 s budget and the
+        # wide client timeouts (15 s / 20 s) are for a third flake mode
+        # found on CI: a loaded runner can stall the server's event loop
+        # for several seconds (the journal fsyncs run on it, and so can a
+        # noisy neighbor), freezing the warden and every handler with it;
+        # the wide timeouts let a stalled response land late instead of
+        # failing the test, while a poll that drops must not abort the
+        # drain, and the 15 s stall watchdog still kills a truly wedged
+        # server. The 0.6 s floor is unchanged: a runner that spends the
+        # budget before the first read still sends the key at whatever
+        # remains, as before.
         def remaining():
-            status, body = request(self.port, '/status', None, timeout=5)
+            try:
+                status, body = request(self.port, '/status', None, timeout=15)
+            except OSError:
+                return None
             if status != 200:
                 return None
             return json.loads(body).get('session', {}).get('remaining')
         margin = 3.0
-        wait_for(lambda: (remaining() or 0) > 0, seconds=8)
-        r = remaining()
-        while r > margin + 0.15:
-            time.sleep(min(0.1, max(0.01, r - margin - 0.15)))
-            r = remaining()
+        wait_for(lambda: (remaining() or 0) > 0.6, seconds=8)
+        land = time.monotonic() + 15
+        r = None
+        while time.monotonic() < land:
+            v = remaining()
+            if v is not None:
+                r = v
+                if v <= margin + 0.15:
+                    break
+            time.sleep(0.05)
+        self.assertIsNotNone(r, "drain never read a remaining")
+        self.assertLessEqual(r, margin + 0.15, f"drain did not land: {r}")
         self.assertGreater(r, 0.6, f"deadline consumed: {r}")
         time.sleep(max(0.0, r - margin))
-        status, body = request(self.port, '/api/key', {'key': 'right', 'hold': 100}, timeout=8)
+        status, body = request(self.port, '/api/key', {'key': 'right', 'hold': 100}, timeout=20)
         self.assertEqual(status, 410, body)
         result = wait_for(lambda: read_json(result_dir / 'deadline.json'))
         self.assertTrue(result['valid'])


### PR DESCRIPTION
CI failed test_benchmark_time_limit_releases_partial_key_and_validates_result
on the push runs after the PR #26 and #30 merges, with client-side
timeouts: a /status poll during the drain (5 s) and the /api/key request
(8 s). Both are symptoms of one phenomenon: on a loaded CI runner the
server subprocess's event loop stalls for several seconds (the journal
fsyncs run on it, and a noisy 2-vCPU neighbor can starve it), freezing
the warden and every handler with it. With the warden's ~3 s deadline
already spent inside the stall, the 410 could not land inside the
client's 8 s window.

The test's invariant is that the deadline fires mid-hold, the partial
key is released, and the result validates - it never needed a fast
response. So:

- the /api/key client timeout widens 8 s -> 20 s: a stalled 410 lands
  late instead of failing; a truly wedged server is still caught, by
  the 15 s stall watchdog (process exit => connection error, not
  timeout);
- the drain's /status timeout widens 5 s -> 15 s, and a dropped poll no
  longer aborts the drain (it retries within a 15 s landing cap);
- the warden budget widens 5 s -> 10 s: the drain lands the deadline a
  fixed ~3 s after the request, but a 5 s budget left the drain racing
  the budget on a slow runner (the 0.6 s floor mode); the invariants do
  not depend on the budget value, the drain is relative to it.


## Failure signatures (from the two failed push runs)

- **run after the #26 merge (14:13 UTC):** drain succeeded (several `/status` polls fine), then `TimeoutError: read operation timed out` on the `/api/key` request (`timeout=8`). The warden's `bench run deadline finished` line never appeared in the log - its finalization was still behind the in-flight request when tearDown killed the server.
- **run after the #30 merge (14:30 UTC):** `TimeoutError` one step earlier - a `/status` poll *during the drain* (`timeout=5`). Same phenomenon, earlier in the window. The same log also shows an asyncio slow-callback warning (0.317 s task) from an earlier test - the runner was generally slow.

## What was ruled out

- Not the deadline re-check that last lap's 1 s to 3 s margin fix addressed: the `/status` failure proves the stall is not specific to the `/api/key` path - it hits any request.
- Not NTP: the health clock is monotonic.
- Not the health lock: the warden/watchdog writes the heartbeat *outside* the lock; lock holds are short.
- The journal fsyncs (`recording_store.append` -> `os.fsync`, plus a directory fsync after `/api/reset`) run **on the event-loop thread** - a contended disk stalls the whole loop (warden, input polling, every handler). CPU starvation on the shared 2-vCPU runner would stall it too. The widened timeouts cover both mechanisms; a server-side fix (journal I/O off the event loop) is a separate, durability-semantics change, deliberately not bundled here.

## Verification

- 3/3 clean locally, 5/5 with 30/32 cores saturated (loaded-runner simulation).
- Full server suite: 104 OK.
- Invariants unchanged: still asserts 410 mid-hold, `reason: time`, `valid: true`, journal `[down=True, down=False]`, and the result's key/frames/hold fields.
