### PR TITLE
bench: the sweep keeps unarchived journals and partially published runs

### DIFF
--- a/bench/broker.py
+++ b/bench/broker.py
@@ -61,7 +61,7 @@ MAX_SESSIONS = int(os.environ.get("QUNXIA_MAX_SESSIONS", "24"))
 # that merges it. None of those outlives this, so the entry - a dict, a Popen
 # handle and a cached result - can go. Without it both grow for the life of
 # the container. (The heavier per-run residue - the published run's staging
-# copies - is dropped separately, as soon as the result names the video:
+# copies - is dropped separately, once all rendered artifacts are uploaded:
 # drop_published_artifacts.)
 REAP_GRACE = float(os.environ.get("QUNXIA_REAP_GRACE", "600"))
 # Every session gets its own copy of the game directory and its own libretro
@@ -156,22 +156,16 @@ def drop(name):
 
 
 def drop_published_artifacts(sess):
-    """The staging copies of what the bucket already holds.
+    """Drop rendered copies after the warden confirms all their uploads.
 
-    The run rendered its video, poster and timeline into the instance's
-    video directory, and journaled its input stream beside its game copy.
-    Once the result names the published video, the bucket is the copy of
-    record and these local files are only bytes the instance keeps paying
-    for - on a memory-backed container, against the very limit that bounds
-    the pool. A publish that never succeeds leaves video_url unset and the
-    files standing: they are the only copy of a run that did not reach the
-    bucket.
+    A video URL alone may point at the local server, or precede a failed
+    poster/timeline upload. The caller requires explicit upload completion.
+    Raw recording journals have no remote copy and must remain available.
     """
     for name in (f"{sess['agent']}-{sess['id']}.mp4",
                  f"{sess['agent']}-{sess['id']}.timeline.json",
                  f"{sess['agent']}-{sess['id']}.jpg"):
         (VIDEO_DIR / name).unlink(missing_ok=True)
-    shutil.rmtree(RECORDING_DIR / sess["id"], ignore_errors=True)
 
 
 CATALOG_OBJECT = "catalog.json"
@@ -1139,12 +1133,13 @@ async def sweep(app):
                     # its thumbnail is nothing but storage cost once the run is over
                     await loop.run_in_executor(None, drop, f"live/{s['id']}.jpg")
                     print(f"reclaimed {work}", flush=True)
-                # The run's disk footprint does not end with the game copy:
-                # the video, poster, timeline and journal that made it are
-                # staging copies of what the bucket holds now
+                # Local and partially published runs retain their artifacts.
+                # Older results have no upload confirmation, so retain those
+                # too; a nonempty video URL is not evidence of remote copies.
                 if not s.get("artifacts_dropped"):
                     res = result_of(s["id"])
-                    if res and res.get("complete") and res.get("video_url"):
+                    if (res and res.get("complete")
+                            and res.get("rendered_artifacts_uploaded") is True):
                         await loop.run_in_executor(
                             None, drop_published_artifacts, s)
                         s["artifacts_dropped"] = True

--- a/bench/test_artifact_retention.py
+++ b/bench/test_artifact_retention.py
@@ -1,0 +1,180 @@
+"""Run real publication and broker cleanup against isolated marker files."""
+import asyncio
+from copy import deepcopy
+import json
+import pathlib
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import broker
+import render
+import warden
+
+
+class ArtifactRetentionTests(unittest.IsolatedAsyncioTestCase):
+    SID, AGENT = "retention-test", "probe"
+
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory(prefix="qunxia-retention-")
+        self.addCleanup(temporary.cleanup)
+        self.root = pathlib.Path(temporary.name)
+        self.videos, self.results = self.root / "videos", self.root / "results"
+        self.recordings = self.root / "recordings"
+        self.videos.mkdir()
+        self.rendered = [self.videos / f"{self.AGENT}-{self.SID}.{suffix}"
+                         for suffix in ("mp4", "jpg", "timeline.json")]
+        self.journals = [self.recordings / self.SID / name
+                         for name in ("recording.jsonl", "recordings/old.jsonl")]
+        for path in self.journals:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"original recording marker")
+        self.session = {"id": self.SID, "agent": self.AGENT, "work": None,
+                        "proc": types.SimpleNamespace(poll=lambda: 0)}
+        old_run = deepcopy(warden.run)
+        self.addCleanup(lambda: (warden.run.clear(), warden.run.update(old_run)))
+        patches = [
+            mock.patch.object(warden, "RESULTS", self.results),
+            mock.patch.object(warden, "VIDEOS", self.videos),
+            mock.patch.object(warden, "SID", self.SID),
+            mock.patch.object(warden, "AGENT", self.AGENT),
+            mock.patch.object(warden, "PUBLIC_BASE", "http://127.0.0.1:12345"),
+            mock.patch.object(broker, "RESULT_DIR", self.results),
+            mock.patch.object(broker, "VIDEO_DIR", self.videos),
+            mock.patch.object(broker, "RECORDING_DIR", self.recordings),
+            mock.patch.object(broker, "sessions", {self.SID: self.session}),
+            mock.patch.object(broker, "_results", {}),
+            mock.patch.object(broker, "put"),
+            mock.patch.object(broker, "live_payload", return_value={}),
+            mock.patch.dict("os.environ", {"QUNXIA_LOCAL_PUBLIC": str(self.root / "public")}),
+        ]
+        for patch in patches:
+            patch.start()
+            self.addCleanup(patch.stop)
+
+    def render(self, _snap, out, _agent, timeline_extra=None):
+        for path in self.rendered:
+            path.write_bytes(b"rendered marker")
+        return {"path": str(out), "frames": 1,
+                "poster": str(self.rendered[1]), "timeline": str(self.rendered[2])}
+
+    async def finalize(self, *, publish=True, bucket="test-bucket", fail=None,
+                       catalog_error=False):
+        remote = {}
+
+        class Blob:
+            def __init__(self, name):
+                self.name = name
+
+            def upload_from_filename(self, filename, content_type=None):
+                if self.name == fail:
+                    raise IOError("fixture upload failed")
+                remote[self.name] = pathlib.Path(filename).read_bytes()
+
+        storage = types.ModuleType("google.cloud.storage")
+        storage.Client = lambda: types.SimpleNamespace(
+            bucket=lambda _name: types.SimpleNamespace(blob=Blob))
+        cloud = types.ModuleType("google.cloud")
+        cloud.storage = storage
+        google = types.ModuleType("google")
+        google.cloud = cloud
+        warden.run.update(playable=1, done="time", result=None)
+        with mock.patch.dict(sys.modules, {"google": google, "google.cloud": cloud,
+                                           "google.cloud.storage": storage}), \
+                mock.patch.object(warden, "PUBLISH", publish), \
+                mock.patch.object(warden, "BUCKET", bucket), \
+                mock.patch.object(render, "render", side_effect=self.render), \
+                mock.patch.object(warden, "append_catalog",
+                                  side_effect=IOError("catalogue unavailable") if catalog_error else None), \
+                mock.patch.object(warden.os, "_exit"), \
+                mock.patch.object(warden.asyncio, "sleep", new=mock.AsyncMock()):
+            await warden.warden({"events": []}, mock.Mock(), asyncio.Lock(), mock.AsyncMock())
+        result = json.loads((self.results / f"{self.SID}.json").read_text())
+        self.assertTrue(result["complete"])
+        return result, remote
+
+    async def sweep(self, result):
+        warden.write_result(result)
+        ticks = 0
+
+        async def bounded_sleep(_seconds):
+            nonlocal ticks
+            ticks += 1
+            if ticks > 30:
+                raise asyncio.CancelledError
+
+        with mock.patch.object(broker.asyncio, "sleep", bounded_sleep):
+            with self.assertRaises(asyncio.CancelledError):
+                await broker.sweep({})
+        self.assertEqual(ticks, 31)
+        for journal in self.journals:
+            self.assertEqual(journal.read_bytes(), b"original recording marker")
+
+    async def assert_retained(self, result):
+        await self.sweep(result)
+        for path in self.rendered:
+            self.assertEqual(path.read_bytes(), b"rendered marker")
+        self.assertFalse(self.session.get("artifacts_dropped", False))
+
+    async def test_disabled_publication_keeps_local_files_even_with_a_bucket(self):
+        result, remote = await self.finalize(publish=False)
+        self.assertTrue(result["video_url"].startswith("http://127.0.0.1:12345/videos/"))
+        self.assertEqual(remote, {})
+        await self.assert_retained(result)
+
+    async def test_missing_bucket_keeps_local_files(self):
+        result, remote = await self.finalize(bucket="")
+        self.assertTrue(result["video_url"])
+        self.assertEqual(remote, {})
+        await self.assert_retained(result)
+
+    async def test_failed_video_upload_keeps_every_file(self):
+        result, remote = await self.finalize(fail=self.rendered[0].name)
+        self.assertIsNone(result["video_url"])
+        self.assertEqual(remote, {})
+        await self.assert_retained(result)
+
+    async def test_failed_poster_after_video_upload_keeps_every_file(self):
+        result, remote = await self.finalize(fail=self.rendered[1].name)
+        self.assertTrue(result["video_url"])
+        self.assertEqual(set(remote), {self.rendered[0].name})
+        await self.assert_retained(result)
+
+    async def test_failed_timeline_after_video_upload_keeps_every_file(self):
+        result, remote = await self.finalize(fail=f"runs/{self.SID}.json")
+        self.assertTrue(result["video_url"])
+        self.assertEqual(set(remote), {path.name for path in self.rendered[:2]})
+        await self.assert_retained(result)
+
+    async def test_successful_upload_drops_only_rendered_copies(self):
+        result, remote = await self.finalize()
+        self.assertIsNone(result["error"])
+        self.assertEqual(set(remote), {self.rendered[0].name, self.rendered[1].name,
+                                       f"runs/{self.SID}.json"})
+        await self.sweep(result)
+        self.assertTrue(self.session.get("artifacts_dropped"))
+        self.assertFalse(any(path.exists() for path in self.rendered))
+
+    async def test_catalogue_failure_does_not_undo_successful_artifact_uploads(self):
+        result, remote = await self.finalize(catalog_error=True)
+        self.assertIn("catalogue unavailable", result["error"])
+        self.assertEqual(len(remote), 3)
+        await self.sweep(result)
+        self.assertFalse(any(path.exists() for path in self.rendered))
+
+    async def test_legacy_result_without_upload_confirmation_keeps_local_files(self):
+        result, _remote = await self.finalize()
+        result.pop("rendered_artifacts_uploaded", None)
+        await self.assert_retained(result)
+
+    async def test_incomplete_result_keeps_local_files(self):
+        result, _remote = await self.finalize()
+        result["complete"] = False
+        await self.assert_retained(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/test_broker_contract.py
+++ b/bench/test_broker_contract.py
@@ -466,12 +466,8 @@ class StartStateTests(aiohttp.test_utils.AioHTTPTestCase):
 
 
 class PublishedArtifactsTests(unittest.TestCase):
-    # A published run's staging copies - the rendered video, poster and
-    # timeline in the instance's video directory, and the input journal
-    # beside its game copy - count against the container's memory on Cloud
-    # Run for the rest of its life. The sweep drops them as soon as the
-    # result names the published video; a publish that never succeeds
-    # leaves video_url unset and the files standing, as the only copy.
+    # Only the rendered copies are eligible for cleanup. The raw journal
+    # and rotated recordings have no uploaded counterpart.
 
     SID = "a" * 12
     AGENT = "probe"
@@ -506,11 +502,12 @@ class PublishedArtifactsTests(unittest.TestCase):
         archived.mkdir()
         (archived / "old.jsonl").write_bytes(b"x")
 
-    def test_the_staging_copies_go(self):
+    def test_rendered_copies_go_but_original_recordings_stay(self):
         self._staging_files()
         broker.drop_published_artifacts(self._sess())
         self.assertEqual(list(broker.VIDEO_DIR.iterdir()), [])
-        self.assertFalse((broker.RECORDING_DIR / self.SID).exists())
+        self.assertEqual((broker.RECORDING_DIR / self.SID / "recording.jsonl").read_bytes(), b"x")
+        self.assertEqual((broker.RECORDING_DIR / self.SID / "recordings" / "old.jsonl").read_bytes(), b"x")
 
     def test_missing_artifacts_are_a_noop(self):
         broker.drop_published_artifacts(self._sess())

--- a/server/warden.py
+++ b/server/warden.py
@@ -368,7 +368,8 @@ async def warden(rec, health, action_lock, wait_frames, recording_snapshot=None)
                         exception_type=type(exc).__name__)
             return
         health.set_phase("finalizing")
-    res = dict(metrics(), valid=True, complete=False, why=why_text(), video_url=None, error=None)
+    res = dict(metrics(), valid=True, complete=False, why=why_text(), video_url=None,
+               rendered_artifacts_uploaded=False, error=None)
     run["result"] = res
     write_result(res)                      # answer late callers straight away
     events = None
@@ -398,6 +399,10 @@ async def warden(rec, health, action_lock, wait_frames, recording_snapshot=None)
             await loop.run_in_executor(None, publish_bytes, f"runs/{SID}.json",
                                        pathlib.Path(timeline), "application/json")
             res["timeline_url"] = f"runs/{SID}.json"
+        # Only successful uploads of every rendered artifact permit cleanup.
+        # With no bucket or publication disabled, publish() returns a local
+        # URL instead. The raw recording journal is never uploaded here.
+        res["rendered_artifacts_uploaded"] = bool(PUBLISH and BUCKET)
     except Exception as exc:
         res["error"] = f"{type(exc).__name__}: {exc}"
     finally:


### PR DESCRIPTION
Ports the work from the orphaned fork PR #29 (LYMDLUT), whose bench-automation base fell six commits behind main; every hunk applied cleanly to main's current context.

## The bug

`drop_published_artifacts` deleted the session's recording directory as soon as the result named a video. Two problems:

1. **The journal never has a remote copy.** The bucket holds the rendered video, poster, timeline and the result entry - not the input stream. The sweep deleted the only copy of what the run played.
2. **A video URL is not proof of a complete publish.** The poster, timeline or result upload could fail after `video_url` was set, leaving the board pointing at files whose local copies had already gone.

## The fix

- `server/warden.py`: the result carries `rendered_artifacts_uploaded`, set to `True` only after every upload succeeds (stays `False` when publishing is disabled, when there is no bucket, or when any upload raises).
- `bench/broker.py`: the sweep drops the rendered copies only when that flag is strictly `True`; it no longer touches the recording directory, so journals live until the session's normal reap (`REAP_GRACE`) instead of being destroyed mid-life.
- `bench/test_artifact_retention.py` (new): nine tests driving the real warden finalization and broker sweep against marker files - disabled publication, missing bucket, each individual upload failure, full success, catalogue failure after successful uploads, legacy results without the flag, incomplete results.
- `bench/test_broker_contract.py`: the published-artifacts contract test now asserts the journal and rotated recordings survive the drop.

## Verification

- New suite: 9/9 against main, first attempt.
- Full bench suite: 77 OK (was 68).
- Full server suite: 104 OK.