### PR TITLE
core: preserve existing savestates when a write fails

### DIFF
--- a/Sources/CoreHost/CoreHost.c
+++ b/Sources/CoreHost/CoreHost.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 200809L
 #include "CoreHost.h"
 
 #include <dlfcn.h>
@@ -8,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "libretro.h"
 
@@ -604,6 +606,7 @@ bool core_mem_read(unsigned id, size_t off, void *dst, size_t n) {
 }
 
 bool core_save_state(const char *path) {
+    if (!path || !*path) { set_err("savestate path is empty"); return false; }
     pthread_mutex_lock(&g_exec_mu);
     if (!g_ser_size || !g_ser) {
         pthread_mutex_unlock(&g_exec_mu);
@@ -620,10 +623,31 @@ bool core_save_state(const char *path) {
     bool ok = g_ser(buf, n);
     pthread_mutex_unlock(&g_exec_mu);
     if (ok) {
-        FILE *f = fopen(path, "wb");
-        if (!f) { free(buf); set_err("cannot open savestate for write"); return false; }
-        ok = fwrite(buf, 1, n, f) == n;
-        fclose(f);
+        /* A failed write must never truncate the previous checkpoint. Stage
+           beside it so rename is atomic, including for native-app callers. */
+        size_t length = strlen(path) + sizeof(".tmp.XXXXXX");
+        char *temporary = malloc(length);
+        if (!temporary) { free(buf); set_err("cannot allocate savestate path"); return false; }
+        snprintf(temporary, length, "%s.tmp.XXXXXX", path);
+        int fd = mkstemp(temporary);
+        FILE *f = fd < 0 ? NULL : fdopen(fd, "wb");
+        if (!f) {
+            if (fd >= 0) { close(fd); unlink(temporary); }
+            ok = false;
+            set_err("cannot open temporary savestate for write");
+        } else {
+            ok = fwrite(buf, 1, n, f) == n;
+            if (ok) ok = fflush(f) == 0;
+            if (ok) ok = fsync(fileno(f)) == 0;
+            if (fclose(f) != 0) ok = false;
+            if (!ok) set_err("cannot finish writing savestate");
+            else if (rename(temporary, path) != 0) {
+                ok = false;
+                set_err("cannot replace savestate");
+            }
+            if (!ok) unlink(temporary);
+        }
+        free(temporary);
     } else {
         set_err("retro_serialize failed");
     }

--- a/server/test_atomic_save.py
+++ b/server/test_atomic_save.py
@@ -1,0 +1,104 @@
+"""Real native serialization and filesystem failures, without game assets."""
+import ctypes
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+@unittest.skipUnless(shutil.which("cc"), "C compiler required")
+class AtomicSaveTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.temp = tempfile.TemporaryDirectory(prefix="qunxia-atomic-save-")
+        cls.addClassCleanup(cls.temp.cleanup)
+        cls.directory = pathlib.Path(cls.temp.name)
+        shared = "-dynamiclib" if sys.platform == "darwin" else "-shared"
+        common = ["cc", "-std=c11", "-O2", "-fPIC", "-pthread",
+                  "-I" + str(ROOT / "Sources/CoreHost/include")]
+        cls.core = cls.directory / "core.so"
+        cls.host = cls.directory / "host.so"
+        subprocess.run(common + [shared, str(ROOT / "server/test_fixtures/thread_probe_core.c"),
+                                 "-o", str(cls.core)], check=True)
+        obj = cls.directory / "host.o"
+        hooks = [f"-D{name}=save_test_{name}" for name in
+                 ("fwrite", "fflush", "fsync", "fclose", "rename")]
+        subprocess.run(common + hooks + ["-c", str(ROOT / "Sources/CoreHost/CoreHost.c"),
+                                        "-o", str(obj)], check=True)
+        subprocess.run(common + [shared, str(obj),
+                                 str(ROOT / "server/test_fixtures/save_io_faults.c"),
+                                 "-o", str(cls.host)]
+                       + ([] if sys.platform == "darwin" else ["-ldl"]), check=True)
+        cls.lib = ctypes.CDLL(str(cls.host))
+        cls.probe = ctypes.CDLL(str(cls.core))
+        cls.lib.core_init.argtypes = [ctypes.c_char_p] * 3
+        cls.lib.core_init.restype = ctypes.c_bool
+        for name in ("core_save_state", "core_load_state"):
+            getattr(cls.lib, name).argtypes = [ctypes.c_char_p]
+            getattr(cls.lib, name).restype = ctypes.c_bool
+
+    def setUp(self):
+        self.folder = tempfile.TemporaryDirectory(dir=self.directory)
+        self.addCleanup(self.folder.cleanup)
+        self.path = pathlib.Path(self.folder.name) / "live.state"
+        self.path.write_bytes(b"previous checkpoint")
+        self.lib.save_io_failure(0)
+        self.probe.probe_reset()
+        self.assertTrue(self.lib.core_init(str(self.core).encode(), b"unused",
+                                          self.folder.name.encode()))
+        self.addCleanup(self.lib.core_shutdown)
+
+    def assert_unchanged(self):
+        self.assertEqual(self.path.read_bytes(), b"previous checkpoint")
+        self.assertEqual(list(self.path.parent.iterdir()), [self.path])
+
+    def test_write_flush_sync_close_and_rename_failures_preserve_old_save(self):
+        for mode in range(1, 6):
+            with self.subTest(failure=mode):
+                self.lib.save_io_failure(mode)
+                self.assertFalse(self.lib.core_save_state(str(self.path).encode()))
+                self.assert_unchanged()
+
+    def test_failed_serialization_preserves_old_save(self):
+        self.probe.probe_fail_serialize(1)
+        self.assertFalse(self.lib.core_save_state(str(self.path).encode()))
+        self.assert_unchanged()
+
+    def test_success_replaces_the_file_and_can_be_loaded(self):
+        self.assertTrue(self.lib.core_save_state(str(self.path).encode()))
+        self.assertEqual(self.path.read_bytes(), b"{" + bytes(15))
+        self.assertTrue(self.lib.core_load_state(str(self.path).encode()))
+        self.assertEqual(list(self.path.parent.iterdir()), [self.path])
+
+    def test_filesize_limit_leaves_previous_save_intact(self):
+        # The limit and SIGXFSZ disposition belong only to this child. This
+        # exercises an actual failed OS write/flush, not a mocked C return.
+        child = subprocess.run([sys.executable, "-c", """
+import ctypes, json, resource, signal, sys
+host, core, path = sys.argv[1:]
+lib = ctypes.CDLL(host)
+probe = ctypes.CDLL(core)
+lib.core_init.argtypes = [ctypes.c_char_p] * 3
+lib.core_init.restype = ctypes.c_bool
+lib.core_save_state.argtypes = [ctypes.c_char_p]
+lib.core_save_state.restype = ctypes.c_bool
+probe.probe_reset()
+assert lib.core_init(core.encode(), b'unused', b'/tmp')
+signal.signal(signal.SIGXFSZ, signal.SIG_IGN)
+resource.setrlimit(resource.RLIMIT_FSIZE, (8, 8))
+print(json.dumps({'saved': bool(lib.core_save_state(path.encode()))}))
+lib.core_shutdown()
+""", str(self.host), str(self.core), str(self.path)],
+            capture_output=True, text=True, timeout=10)
+        self.assertEqual(child.returncode, 0, child.stderr)
+        self.assertFalse(json.loads(child.stdout)["saved"])
+        self.assert_unchanged()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/test_fixtures/save_io_faults.c
+++ b/server/test_fixtures/save_io_faults.c
@@ -1,0 +1,39 @@
+/* Link only into the save test host; production has no fault-injection hooks. */
+#define _POSIX_C_SOURCE 200809L
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+
+static int failure;
+void save_io_failure(int mode) { failure = mode; }
+
+size_t save_test_fwrite(const void *data, size_t size, size_t count, FILE *stream) {
+    if (failure == 1) {
+        size_t written = fwrite(data, size, count / 2, stream);
+        errno = ENOSPC;
+        return written;
+    }
+    return fwrite(data, size, count, stream);
+}
+
+int save_test_fflush(FILE *stream) {
+    int result = fflush(stream);
+    if (failure == 2) { errno = EIO; return EOF; }
+    return result;
+}
+
+int save_test_fsync(int fd) {
+    if (failure == 3) { errno = EIO; return -1; }
+    return fsync(fd);
+}
+
+int save_test_fclose(FILE *stream) {
+    int result = fclose(stream);
+    if (failure == 4) { errno = EIO; return EOF; }
+    return result;
+}
+
+int save_test_rename(const char *source, const char *destination) {
+    if (failure == 5) { errno = EACCES; return -1; }
+    return rename(source, destination);
+}


### PR DESCRIPTION
`core_save_state()` opens the destination with `wb`, so a short write can destroy the previous checkpoint. It also ignores `fclose()` errors and can report success after the buffered write fails.

Serialize under the existing native execution lock, write to a unique temporary file beside the destination, and rename only after write, flush, file sync and close all succeed. Every reported failure removes the temporary file and leaves the previous checkpoint intact. This protects both the HTTP server and native app callers without replacing the server implementation.

Validation: 4 native save tests and 23 native concurrency/lifecycle tests passed. The save tests link the real CoreHost implementation with the existing libretro fixture. They cover real `RLIMIT_FSIZE` failure in a child process, controlled short-write/flush/fsync/close/rename failures, serialization failure, successful replacement and subsequent load. The old implementation fails the filesystem-limit and injected-failure checks. No game assets, user saves or provider requests are involved.

This change guarantees atomic replacement on successful rename; it does not add a directory-sync protocol for power-loss durability.
