### PR TITLE
server: add opt-in checkpoints and resume for long-lived play

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -75,6 +75,26 @@ on-demand PNG/WebP observations and activity thumbnails.
 
 ## Several agents on one session
 
+For long-lived interactive play, set `QUNXIA_RESUME_STATE` to a checkpoint on
+persistent storage. The server waits for 1500 emulated frames and a nonempty
+framebuffer before loading it, then verifies that frames continue advancing.
+`QUNXIA_RESUME_WARMUP_FRAMES` can tune that initial warmup for another core.
+`/status.checkpoint.state` is `warming`, `restoring`, `ready` or `failed`;
+input is refused until ready. An unreadable checkpoint remains untouched and
+blocks input instead of silently starting a new game.
+
+`QUNXIA_AUTOSAVE_SECONDS` defaults to 30; zero disables periodic saves. A clean
+shutdown also saves. Serialization and its before/after frame checks share the
+action lock. Cancellation and failures discard only the staged new checkpoint,
+so the previous one remains available. Abrupt process termination can lose
+progress since the last successful checkpoint. Recordings continue through the
+existing RecordingStore and are not scanned for replay during startup.
+
+This mode disables the game's automatic menu-save macro and optional position
+calibration, whose reload of the opening state would undo resumed progress.
+`QUNXIA_BENCH=1` ignores all resume/autosave settings and keeps the normal
+benchmark startup, action limits and save/load restrictions.
+
 REST actions and browser key holds share one single-player lease, so a browser
 release cannot cancel an API press (or another browser's hold). The queue is
 FIFO. Measured against the deployed e2-micro, each

--- a/server/README.md
+++ b/server/README.md
@@ -89,6 +89,9 @@ action lock. Cancellation and failures discard only the staged new checkpoint,
 so the previous one remains available. Abrupt process termination can lose
 progress since the last successful checkpoint. Recordings continue through the
 existing RecordingStore and are not scanned for replay during startup.
+This guarantee requires the atomic CoreHost saver and a rebuilt native bridge:
+an older saver that reports success despite a failed buffered close can pass a
+partial staged file to the checkpoint layer.
 
 This mode disables the game's automatic menu-save macro and optional position
 calibration, whose reload of the opening state would undo resumed progress.

--- a/server/server.py
+++ b/server/server.py
@@ -1911,8 +1911,8 @@ async def api_save(request):
 
 async def checkpoint_core(path, *, saving):
     """Drain native work before releasing the pause, including cancellation."""
-    await pause_emulator()
     try:
+        await pause_emulator()
         def operation():
             LIB.core_release_all_keys()
             if saving:

--- a/server/server.py
+++ b/server/server.py
@@ -22,6 +22,7 @@ import sys
 import threading
 import time
 import traceback
+import uuid
 import zlib
 
 from aiohttp import WSMsgType, web
@@ -197,6 +198,13 @@ SCREEN_FORMATS = ("", "png", "webp", "jpeg")
 # 注音 IME, which is a puzzle about input methods and not about the game.
 START_STATE = os.environ.get("QUNXIA_START_STATE", str(ROOT.parent / "saves" / "start.state"))
 STATE_DIR = os.environ.get("QUNXIA_STATE_DIR", str(ROOT.parent / "saves" / "states"))
+# Long-lived play is opt-in. A scored run must never read or update a previous
+# interactive checkpoint, even if its launcher inherited these variables.
+RESUME_STATE = "" if warden.ON else os.environ.get("QUNXIA_RESUME_STATE", "")
+AUTOSAVE_SECONDS = float(os.environ.get("QUNXIA_AUTOSAVE_SECONDS", "30")) if RESUME_STATE else 0
+RESUME_WARMUP_FRAMES = int(os.environ.get("QUNXIA_RESUME_WARMUP_FRAMES", "1500")) if RESUME_STATE else 0
+checkpoint = {"enabled": bool(RESUME_STATE), "state": "warming" if RESUME_STATE else "disabled",
+              "restored": False, "saves": 0, "last_saved": None, "error": None}
 
 # Everything anyone does to this session, so the page can show who is doing
 # what. The game is shared, so this doubles as "why did the screen just move".
@@ -564,7 +572,7 @@ def read_stats():
 # back showing DOSBox Pure's "DOS Crashed" menu and stopped responding to keys
 # - which is far too high a price for one column. Distance then reports as
 # unmeasured, which the page already draws as a dash rather than a nought.
-CALIBRATE = os.environ.get("QUNXIA_CALIBRATE") == "1"
+CALIBRATE = os.environ.get("QUNXIA_CALIBRATE") == "1" and not RESUME_STATE
 
 world = {"scenes": 1, "banked": 0, "origin": None, "far": 0, "ok": False,
          "dark": False, "miss": 0, "tried": False,
@@ -1071,6 +1079,8 @@ async def ws_handler(request):
             if not isinstance(d, dict):
                 continue
             t = d.get("t")
+            if checkpoint["enabled"] and checkpoint["state"] != "ready" and t in ("key", "tap"):
+                continue
             if recording_blocked and not (t == "key" and not d.get("down")):
                 continue
             if warden.ON and t in ("key", "tap"):
@@ -1899,6 +1909,85 @@ async def api_save(request):
     return web.json_response(result, status=200 if result.get("ok") else 500)
 
 
+async def checkpoint_core(path, *, saving):
+    """Drain native work before releasing the pause, including cancellation."""
+    await pause_emulator()
+    try:
+        def operation():
+            LIB.core_release_all_keys()
+            if saving:
+                return bool(LIB.core_save_state(str(path).encode()))
+            ok = bool(LIB.core_load_state(str(path).encode()))
+            if ok:
+                LIB.fb_reset()
+            return ok
+
+        task = asyncio.create_task(asyncio.to_thread(operation))
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            # A cancelled await cannot stop ctypes. Keep the lease and pause
+            # until that call has actually returned.
+            await task
+            raise
+    finally:
+        resume_emulator()
+
+
+async def save_checkpoint():
+    if warden.ON or not RESUME_STATE or checkpoint["state"] != "ready":
+        return False
+    async with action_lock():
+        # Keep the old checkpoint until execution is healthy on both sides
+        # of serialization; the file itself is staged in its own directory.
+        await wait_core_frames(2)
+        path = pathlib.Path(RESUME_STATE)
+        pending = path.with_name(path.name + "." + uuid.uuid4().hex + ".pending")
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if not await checkpoint_core(pending, saving=True):
+                raise RuntimeError(core_error("checkpoint save failed"))
+            await wait_core_frames(2)
+            os.replace(pending, path)
+            checkpoint.update(saves=checkpoint["saves"] + 1, last_saved=time.time(), error=None)
+            return True
+        finally:
+            pending.unlink(missing_ok=True)
+
+
+async def resume_and_autosave():
+    if warden.ON or not RESUME_STATE:
+        return
+    try:
+        async with action_lock():
+            checkpoint["state"] = "warming"
+            await wait_core_frames(RESUME_WARMUP_FRAMES)
+            if LIB.core_width() <= 0 or LIB.core_height() <= 0:
+                raise RuntimeError("the core has not produced a frame")
+            path = pathlib.Path(RESUME_STATE)
+            if path.exists():
+                checkpoint["state"] = "restoring"
+                if not await checkpoint_core(path, saving=False):
+                    raise RuntimeError(core_error("checkpoint restore failed"))
+                await wait_core_frames(2)
+                checkpoint["restored"] = True
+                await send_keyframe(None)
+            checkpoint.update(state="ready", error=None)
+    except Exception as exc:
+        # Do not accept input or overwrite an unreadable previous session
+        # with the newly booted machine. An operator must resolve the file.
+        checkpoint.update(state="failed", error=str(exc))
+        stats["last_error"] = "resume: " + str(exc)
+        return
+    while AUTOSAVE_SECONDS > 0:
+        await asyncio.sleep(AUTOSAVE_SECONDS)
+        try:
+            await save_checkpoint()
+        except Exception as exc:
+            checkpoint["error"] = str(exc)
+            stats["last_error"] = "autosave: " + str(exc)
+
+
 async def api_load(request):
     if warden.ON:
         # A scored run has no out-of-band rewind. Hidden, like reset.
@@ -2194,6 +2283,7 @@ async def status(_request):
         **(health.snapshot() if health else {}),
         "recording": {"cache_bytes": 0, "pending_bytes": recording_store.pending_bytes if recording_store else 0,
                       "error": recording_store.error if recording_store else ""},
+        "checkpoint": dict(checkpoint),
     })
 
 
@@ -2206,6 +2296,10 @@ async def json_errors(request, handler):
     bad request.
     """
     try:
+        if (checkpoint["enabled"] and checkpoint["state"] != "ready"
+                and request.method == "POST" and request.path.startswith("/api/")):
+            return web.json_response({"ok": False, "error": "session_not_ready",
+                                      "checkpoint": dict(checkpoint)}, status=503)
         if recording_blocked and request.method == "POST" and request.path.startswith("/api/"):
             raise RecordingUnavailable(recording_store.error)
         if health:
@@ -2237,7 +2331,10 @@ async def startup(app):
     api_lock = asyncio.Lock()
     app["pump"] = asyncio.create_task(pump())
     app["reaper"] = asyncio.create_task(reap())
-    app["snapshotter"] = asyncio.create_task(snapshotter())
+    if RESUME_STATE:
+        app["checkpoint"] = asyncio.create_task(resume_and_autosave())
+    else:
+        app["snapshotter"] = asyncio.create_task(snapshotter())
     if health:
         app["heartbeat"] = asyncio.create_task(pulse_health())
         health.set_phase("running")
@@ -2286,6 +2383,14 @@ async def pulse_health():
 
 
 async def cleanup(app):
+    saving = app.get("checkpoint")
+    if saving:
+        saving.cancel()
+        await asyncio.gather(saving, return_exceptions=True)
+        try:
+            await asyncio.wait_for(save_checkpoint(), timeout=10)
+        except Exception as exc:
+            stats["last_error"] = "shutdown checkpoint: " + str(exc)
     for task in app.values():
         if isinstance(task, asyncio.Task):
             task.cancel()
@@ -2303,6 +2408,9 @@ async def cleanup(app):
 
 def main():
     global health, recording_store, recording_api
+    if RESUME_STATE and (not math.isfinite(AUTOSAVE_SECONDS) or AUTOSAVE_SECONDS < 0
+                         or RESUME_WARMUP_FRAMES < 1):
+        raise SystemExit("checkpoint interval must be finite and non-negative; warmup frames must be positive")
     directory = os.environ.get("QUNXIA_RECORDING_DIR", str(ROOT.parent / "recordings"))
     validate_recording_directory(directory)
     path = pathlib.Path(os.environ.get("QUNXIA_RECORDING_FILE", str(pathlib.Path(directory) / f"{PORT}.jsonl")))

--- a/server/test_checkpoint_worker.py
+++ b/server/test_checkpoint_worker.py
@@ -1,0 +1,93 @@
+"""Real worker restart and native progress restoration, using the probe core."""
+import json
+import shutil
+import struct
+import unittest
+
+import test_worker_health as worker
+from test_worker_health import request, stop_process, wait_for
+
+
+@unittest.skipUnless(shutil.which("cc"), "C compiler required")
+class CheckpointWorkerTests(unittest.TestCase):
+    setUpClass = classmethod(worker.WorkerIntegrationTests.setUpClass.__func__)
+    setUp = worker.WorkerIntegrationTests.setUp
+    launch = worker.WorkerIntegrationTests.launch
+    healthy = worker.WorkerIntegrationTests.healthy
+
+    def checkpoint(self):
+        return self.folder / "live.state"
+
+    def launch_checkpoint(self, **extra):
+        return self.launch(**dict({
+            "QUNXIA_RESUME_STATE": str(self.checkpoint()),
+            "QUNXIA_AUTOSAVE_SECONDS": "0.15",
+            "QUNXIA_RESUME_WARMUP_FRAMES": "6",
+            "QUNXIA_SNAPSHOT_EVERY": "0",
+            "PROBE_STATEFUL": "1",
+        }, **extra))
+
+    def phase(self, phase):
+        value = self.healthy()
+        return value if value and value["checkpoint"]["state"] == phase else None
+
+    def count(self, path=None):
+        return struct.unpack_from("=i", (path or self.checkpoint()).read_bytes(), 4)[0]
+
+    def seed(self, count):
+        self.checkpoint().write_bytes(b"{" + bytes(3) + struct.pack("=i", count) + bytes(8))
+
+    def test_restore_autosave_restart_and_shutdown_keep_native_progress(self):
+        self.seed(7)
+        first = self.launch_checkpoint()
+        ready = wait_for(lambda: self.phase("ready"))
+        self.assertTrue(ready["checkpoint"]["restored"])
+        self.assertEqual(request(self.port, "/api/key", {"key": "enter"})[0], 200)
+        wait_for(lambda: self.count() == 8)
+        stop_process(first, timeout=5)
+        self.assertEqual(first.returncode, 0)
+        second = self.launch_checkpoint(QUNXIA_AUTOSAVE_SECONDS="0")
+        wait_for(lambda: self.phase("ready"))
+        self.assertEqual(request(self.port, "/api/key", {"key": "enter"})[0], 200)
+        self.assertEqual(request(self.port, "/api/save", {"name": "witness"})[0], 200)
+        self.assertEqual(self.count(self.folder / "slots/witness.state"), 9)
+        stop_process(second, timeout=5)
+        self.assertEqual(second.returncode, 0)
+        self.assertEqual(self.count(), 9)
+        self.assertEqual(list(self.folder.glob("live.state.*.pending")), [])
+
+    def test_failed_restore_preserves_file_and_refuses_actions(self):
+        original = b"unreadable checkpoint"
+        self.checkpoint().write_bytes(original)
+        process = self.launch_checkpoint()
+        wait_for(lambda: self.phase("failed"))
+        code, body = request(self.port, "/api/key", {"key": "enter"})
+        self.assertEqual(code, 503)
+        self.assertEqual(json.loads(body)["error"], "session_not_ready")
+        stop_process(process, timeout=5)
+        self.assertEqual(self.checkpoint().read_bytes(), original)
+
+    def test_input_is_blocked_during_warmup_and_exit_preserves_checkpoint(self):
+        self.seed(7)
+        original = self.checkpoint().read_bytes()
+        process = self.launch_checkpoint(QUNXIA_RESUME_WARMUP_FRAMES="600")
+        wait_for(lambda: self.phase("warming"))
+        self.assertEqual(request(self.port, "/api/key", {"key": "enter"})[0], 503)
+        stop_process(process, timeout=5)
+        self.assertEqual(self.checkpoint().read_bytes(), original)
+
+    def test_benchmark_ignores_even_invalid_autosave_configuration(self):
+        self.seed(7)
+        original = self.checkpoint().read_bytes()
+        process = self.launch_checkpoint(QUNXIA_BENCH="1", QUNXIA_AUTOSAVE_SECONDS="invalid",
+                                         QUNXIA_RESUME_WARMUP_FRAMES="invalid")
+        ready = wait_for(self.healthy)
+        self.assertEqual(ready["checkpoint"]["state"], "disabled")
+        self.assertFalse(ready["checkpoint"]["enabled"])
+        self.assertEqual(request(self.port, "/api/load", {"name": "live"})[0], 404)
+        stop_process(process, timeout=5)
+        self.assertEqual(self.checkpoint().read_bytes(), original)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/test_checkpoints.py
+++ b/server/test_checkpoints.py
@@ -1,0 +1,138 @@
+"""Checkpoint lifecycle tests; every path belongs to a temporary session."""
+import asyncio
+import pathlib
+import tempfile
+import threading
+import unittest
+from unittest import mock
+
+with mock.patch("ctypes.CDLL", return_value=mock.MagicMock()):
+    import server
+
+
+class CheckpointTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory(prefix="qunxia-checkpoint-")
+        self.addCleanup(temporary.cleanup)
+        self.path = pathlib.Path(temporary.name) / "live.state"
+        self.path.write_bytes(b"previous checkpoint")
+        self.lib = mock.Mock()
+        self.lib.core_width.return_value = self.lib.core_height.return_value = 1
+        self.lib.core_load_state.return_value = True
+        self.paused = False
+        self.wait = mock.AsyncMock()
+
+        def save(path):
+            self.assertTrue(self.paused)
+            self.assertEqual(self.path.read_bytes(), b"previous checkpoint")
+            pathlib.Path(path.decode()).write_bytes(b"new checkpoint")
+            return True
+
+        self.lib.core_save_state.side_effect = save
+
+        async def pause():
+            self.paused = True
+
+        def resume():
+            self.paused = False
+
+        patches = [
+            mock.patch.object(server, "RESUME_STATE", str(self.path)),
+            mock.patch.object(server, "AUTOSAVE_SECONDS", 0),
+            mock.patch.object(server, "RESUME_WARMUP_FRAMES", 1500),
+            mock.patch.object(server.warden, "ON", False),
+            mock.patch.object(server, "api_lock", asyncio.Lock()),
+            mock.patch.object(server, "LIB", self.lib),
+            mock.patch.object(server, "wait_core_frames", self.wait),
+            mock.patch.object(server, "pause_emulator", pause),
+            mock.patch.object(server, "resume_emulator", resume),
+            mock.patch.object(server, "send_keyframe", mock.AsyncMock()),
+            mock.patch.dict(server.checkpoint, enabled=True, state="ready", restored=False,
+                            saves=0, last_saved=None, error=None),
+        ]
+        for patch in patches:
+            patch.start()
+            self.addCleanup(patch.stop)
+
+    def assert_preserved(self):
+        self.assertEqual(self.path.read_bytes(), b"previous checkpoint")
+        self.assertEqual(list(self.path.parent.iterdir()), [self.path])
+        self.assertFalse(self.paused)
+        self.assertFalse(server.api_lock.locked())
+
+    async def test_success_commits_only_after_execution_resumes(self):
+        self.assertTrue(await server.save_checkpoint())
+        self.assertEqual(self.path.read_bytes(), b"new checkpoint")
+        self.assertEqual(self.wait.await_args_list, [mock.call(2), mock.call(2)])
+        self.assertFalse(self.paused)
+        self.assertEqual(server.checkpoint["saves"], 1)
+
+    async def test_failed_save_preserves_old_checkpoint(self):
+        self.lib.core_save_state.side_effect = lambda _path: False
+        with self.assertRaises(RuntimeError):
+            await server.save_checkpoint()
+        self.assert_preserved()
+
+    async def test_stalled_frames_before_or_after_save_preserve_old_checkpoint(self):
+        for sequence in ([RuntimeError("stalled")], [None, RuntimeError("stalled")]):
+            with self.subTest(waits=len(sequence)):
+                self.wait.side_effect = sequence
+                with self.assertRaisesRegex(RuntimeError, "stalled"):
+                    await server.save_checkpoint()
+                self.assert_preserved()
+
+    async def test_cancelled_native_save_finishes_before_unpausing_and_discards_stage(self):
+        started, release = threading.Event(), threading.Event()
+
+        def save(path):
+            started.set()
+            release.wait(2)
+            pathlib.Path(path.decode()).write_bytes(b"cancelled checkpoint")
+            return True
+
+        self.lib.core_save_state.side_effect = save
+        task = asyncio.create_task(server.save_checkpoint())
+        try:
+            self.assertTrue(await asyncio.to_thread(started.wait, 1))
+            task.cancel()
+            await asyncio.sleep(.01)
+            self.assertTrue(self.paused)
+            self.assertFalse(task.done())
+        finally:
+            release.set()
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+        self.assert_preserved()
+
+    async def test_restore_waits_for_warmup_then_checks_execution(self):
+        await server.resume_and_autosave()
+        self.assertEqual(self.wait.await_args_list, [mock.call(1500), mock.call(2)])
+        self.lib.core_load_state.assert_called_once_with(str(self.path).encode())
+        server.send_keyframe.assert_awaited_once()
+        self.assertEqual(server.checkpoint["state"], "ready")
+        self.assertTrue(server.checkpoint["restored"])
+        self.assert_preserved()
+
+    async def test_failed_restore_blocks_input_and_never_autosaves(self):
+        self.lib.core_load_state.return_value = False
+        await server.resume_and_autosave()
+        self.assertEqual(server.checkpoint["state"], "failed")
+        self.assertFalse(await server.save_checkpoint())
+        handler = mock.AsyncMock()
+        response = await server.json_errors(
+            mock.Mock(method="POST", path="/api/key"), handler)
+        self.assertEqual(response.status, 503)
+        handler.assert_not_awaited()
+        self.assert_preserved()
+
+    async def test_benchmark_never_reads_or_saves_a_checkpoint(self):
+        with mock.patch.object(server.warden, "ON", True):
+            await server.resume_and_autosave()
+            self.assertFalse(await server.save_checkpoint())
+        self.lib.core_load_state.assert_not_called()
+        self.lib.core_save_state.assert_not_called()
+        self.assert_preserved()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/test_checkpoints.py
+++ b/server/test_checkpoints.py
@@ -21,6 +21,8 @@ class CheckpointTests(unittest.IsolatedAsyncioTestCase):
         self.lib.core_load_state.return_value = True
         self.paused = False
         self.wait = mock.AsyncMock()
+        self.real_pause_emulator = server.pause_emulator
+        self.real_resume_emulator = server.resume_emulator
 
         def save(path):
             self.assertTrue(self.paused)
@@ -103,6 +105,25 @@ class CheckpointTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(asyncio.CancelledError):
             await task
         self.assert_preserved()
+
+    async def test_cancelled_pause_ack_wait_unpauses_before_releasing_the_lease(self):
+        paused, acknowledged = threading.Event(), threading.Event()
+        with mock.patch.object(server, "paused", paused), \
+                mock.patch.object(server, "paused_ack", acknowledged), \
+                mock.patch.object(server, "recording_blocked", False), \
+                mock.patch.object(server, "pause_emulator", self.real_pause_emulator), \
+                mock.patch.object(server, "resume_emulator", self.real_resume_emulator):
+            task = asyncio.create_task(server.save_checkpoint())
+            try:
+                self.assertTrue(await asyncio.to_thread(paused.wait, 1))
+            finally:
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+            self.assertTrue(task.cancelled())
+            self.assertFalse(paused.is_set())
+            self.assertFalse(acknowledged.is_set())
+            self.lib.core_save_state.assert_not_called()
+            self.assert_preserved()
 
     async def test_restore_waits_for_warmup_then_checks_execution(self):
         await server.resume_and_autosave()

--- a/server/test_fixtures/thread_probe_core.c
+++ b/server/test_fixtures/thread_probe_core.c
@@ -88,10 +88,21 @@ bool retro_serialize(void *data, size_t size) {
     if (size < 16 || atomic_load(&fail_serialize)) return false;
     memset(data, 0, size);
     ((unsigned char *)data)[0] = 123;
+    if (getenv("PROBE_STATEFUL")) {
+        int value = atomic_load(&keydowns);
+        memcpy((unsigned char *)data + 4, &value, sizeof(value));
+    }
     return true;
 }
 bool retro_unserialize(const void *data, size_t size) {
-    (void)data; touch_core(); return size == 16;
+    touch_core();
+    if (size != 16) return false;
+    if (getenv("PROBE_STATEFUL")) {
+        int value;
+        memcpy(&value, (const unsigned char *)data + 4, sizeof(value));
+        atomic_store(&keydowns, value);
+    }
+    return true;
 }
 size_t retro_get_memory_size(unsigned id) { (void)id; touch_core(); return 16; }
 void *retro_get_memory_data(unsigned id) {


### PR DESCRIPTION
Long-lived interactive play can opt into automatic checkpoints and startup resume with QUNXIA_RESUME_STATE and QUNXIA_AUTOSAVE_SECONDS. Restore waits for warmup and a nonempty framebuffer, then checks continued execution. Input stays blocked until ready; an unreadable checkpoint is preserved instead of starting a new game. Benchmark mode keeps its existing startup and scoring behavior.

Save/load share the action lease and always release the emulator pause, including cancellation while waiting for pause acknowledgement. Periodic and clean-shutdown saves stage a new checkpoint and keep the last valid file on failure. This depends on the atomic native saver in #34 and a rebuilt bridge for its file-write guarantees.

Validation: 12 checkpoint and worker lifecycle tests passed, including a regression that fails on the prior implementation when cancellation lands between pause request and acknowledgement. The combined local release also passed its full server suite and restored a copied real game without changing original user data.