### PR TITLE
server: add persistent users with owned loopback sessions

### DIFF
--- a/server/MULTIUSER.md
+++ b/server/MULTIUSER.md
@@ -1,0 +1,44 @@
+# Persistent interactive sessions
+
+This gateway preserves `user.json` identities and `/u/<id>/` addresses across
+restarts. Workers start on demand and use independent `game/` and `saves/`
+directories. It requires the server's opt-in persistent checkpoint support;
+it refuses a worker that cannot report a ready checkpoint lifecycle.
+
+Run with the same Python environment as the headless server:
+
+```sh
+python server/multiuser.py serve \
+  --users-dir /srv/qunxia/users \
+  --core /srv/qunxia/cores/dosbox_pure_libretro.so \
+  --game-dir /srv/qunxia/game-template \
+  --host 127.0.0.1 --port 8084
+```
+
+`--game-dir` is needed only to create new users and must contain `PLAY.BAT`.
+Existing user directories keep their metadata, game, `saves/live.state`,
+manual slots and `saves/recording.jsonl`. The existing RecordingStore opens
+that JSONL directly; no log conversion or startup replay indexing occurs.
+`QUNXIA_USERS_DIR`, `QUNXIA_CORE`, `QUNXIA_GAME_DIR`,
+`QUNXIA_MULTIUSER_HOST` and `PORT` provide the corresponding defaults.
+`QUNXIA_MAX_USERS=0` leaves user count uncapped. This is a local/shared gateway,
+not an account authentication system; the lobby lists the available sessions.
+
+Workers always bind to loopback and use the opt-in checkpoint path. The normal
+checkpoint interval and warmup settings apply. Benchmark mode, calibration and
+the menu-save macro are disabled for these persistent interactive workers.
+The gateway waits for `checkpoint.state=ready`; a failed resume is reported
+instead of accepting input into a fresh game. Asset, help, WebSocket and
+recording requests resolve relative to the session URL. For a reverse proxy,
+`QUNXIA_PUBLIC_BASE` can supply the public origin used in copied API help.
+
+A directory lease prevents two gateways using the same root; an inherited
+per-user lease prevents duplicate workers. A parent pipe makes an orphaned
+worker exit cleanly. Shutdown waits up to 15 seconds for each owned worker's
+checkpoint before terminating a stuck worker. Unknown live legacy PIDs are
+refused, never killed based solely on a stale marker.
+
+The existing browser replay and MediaRecorder export remain available. This
+gateway does not add the separate legacy cached/cancellable export service or
+its job endpoints. A local migration that depends on those endpoints needs an
+explicit compatibility adapter before replacing its old entry point.

--- a/server/MULTIUSER.md
+++ b/server/MULTIUSER.md
@@ -27,6 +27,10 @@ not an account authentication system; the lobby lists the available sessions.
 Workers always bind to loopback and use the opt-in checkpoint path. The normal
 checkpoint interval and warmup settings apply. Benchmark mode, calibration and
 the menu-save macro are disabled for these persistent interactive workers.
+Each worker's watchdog state is kept under its own `saves/.health/` directory,
+with diagnostics under `saves/.health/incidents/`; gateway-level
+`QUNXIA_HEALTH_DIR` and `QUNXIA_DIAGNOSTIC_DIR` values cannot make workers
+share these files.
 The gateway waits for `checkpoint.state=ready`; a failed resume is reported
 instead of accepting input into a fresh game. Asset, help, WebSocket and
 recording requests resolve relative to the session URL. For a reverse proxy,

--- a/server/README.md
+++ b/server/README.md
@@ -183,3 +183,9 @@ execution lock. A time-limit ending still validates core health before it can
 be scored as valid. Input/environment failures remain invalid. The broker
 stores diagnostics under `<result-dir>/<session-id>.diagnostics` and archives
 the last heartbeat, fault and exit status before reclaiming worker scratch.
+
+The multiuser lobby lists games by their latest `live.state` save time and offers
+name search, creation-time/name sorting, and a new-game dialog. Reading the lobby
+only inspects user metadata and save-file timestamps; it does not start game
+workers or read recordings. The displayed time is explicitly a save time, since
+a running game may autosave without player input.

--- a/server/index.html
+++ b/server/index.html
@@ -343,7 +343,7 @@
 </aside>
 </div>
 
-<script src="/recording.js"></script>
+<script src="recording.js"></script>
 <script>
 const cv = document.getElementById("screen");
 const ctx = cv.getContext("2d", { alpha: false });
@@ -633,7 +633,9 @@ playBtn.onclick = async () => {
 };
 
 function connect() {
-  sock = new WebSocket((location.protocol === "https:" ? "wss://" : "ws://") + location.host + "/ws");
+  const socketUrl = new URL("ws", location.href);
+  socketUrl.protocol = location.protocol === "https:" ? "wss:" : "ws:";
+  sock = new WebSocket(socketUrl);
   sock.binaryType = "arraybuffer";
   sock.onmessage = e => {
     if (typeof e.data === "string") {
@@ -916,7 +918,7 @@ async function openSlot() {
   const body = document.getElementById("slotbody");
   body.replaceChildren(el("div", "kind", "reading the slot…"));
   try {
-    const r = await fetch("/progress" + location.search);
+    const r = await fetch("progress" + location.search);
     slotData = r.ok ? await r.json() : {why: "hidden while the run is scored"};
   } catch (e) {
     slotData = {why: "could not read the slot"};
@@ -1095,7 +1097,7 @@ cv.addEventListener("click", () => cv.focus());
 const promptEl = document.getElementById("prompt");
 let lang = "en";
 function loadSkill() {
-  fetch("/api/help?lang=" + lang).then(r => r.text()).then(t => promptEl.value = t)
+  fetch("api/help?lang=" + lang).then(r => r.text()).then(t => promptEl.value = t)
     .catch(() => promptEl.value = "could not load /api/help");
 }
 for (const b of document.querySelectorAll(".lang button")) {
@@ -1118,7 +1120,7 @@ document.getElementById("copy").onclick = async () => {
   c.classList.add("on");
   setTimeout(() => c.classList.remove("on"), 1400);
 };
-document.getElementById("open").onclick = () => window.open("/api/help?lang=" + lang, "_blank");
+document.getElementById("open").onclick = () => window.open("api/help?lang=" + lang, "_blank");
 
 fit();
 connect();

--- a/server/lobby.html
+++ b/server/lobby.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="icon" href="data:,">
+<title>金庸群侠传 · 游戏大厅</title>
+<style>
+:root{color-scheme:dark;--bg:#0c0e10;--panel:#14171a;--line:#292d30;--text:#e9e8e1;--muted:#92968f;--accent:#d4b883;--green:#9bb89b}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--text);font:14px/1.6 -apple-system,BlinkMacSystemFont,"PingFang SC","Microsoft YaHei",sans-serif}
+button,input,select{font:inherit}button,a,input,select{-webkit-tap-highlight-color:transparent}
+a{color:inherit;text-decoration:none}button{cursor:pointer}button:disabled{cursor:wait;opacity:.55}
+button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{outline:2px solid var(--accent);outline-offset:4px}
+button{border:0}main{max-width:1080px;padding:0 34px 44px;margin:auto}
+.topbar{height:82px;display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid var(--line);gap:20px}
+.brand{display:flex;align-items:center;gap:11px}.seal{display:grid;place-items:center;width:34px;height:38px;border:1px solid #7c6b4c;color:var(--accent);font:23px "Songti SC","STSong",serif;border-radius:3px}
+.brand-name{font-weight:600;letter-spacing:.14em}.brand-sub{font-size:11px;letter-spacing:.16em;color:var(--muted)}
+.top-note{color:var(--muted);font-size:12px;display:flex;gap:8px;align-items:center}.dot{width:6px;height:6px;background:var(--green);border-radius:50%;display:inline-block}
+.intro{display:flex;justify-content:space-between;align-items:center;gap:28px;padding:42px 0 32px}
+.eyebrow{margin:0 0 10px;color:var(--accent);font-size:11px;letter-spacing:.2em}
+h1{font-family:"Songti SC","STSong",serif;font-weight:600;font-size:36px;line-height:1.3;letter-spacing:.08em;margin:0 0 12px}
+.subtitle{color:var(--muted);margin:0;font-size:13px}.primary{background:var(--accent);color:#232219;padding:11px 19px;border-radius:5px;font-weight:600;white-space:nowrap;transition:background .15s}.primary:hover{background:#e3c995}
+.plus{font-size:18px;margin-right:8px;font-weight:400;vertical-align:-1px}
+.toolbar{display:flex;justify-content:space-between;align-items:center;gap:16px;padding:0 0 18px}
+.section-label{font-size:14px;font-weight:600;white-space:nowrap}.count{font-size:12px;font-weight:400;color:var(--muted);margin-left:9px}
+.filters{display:flex;align-items:center;gap:10px}.search-wrap{position:relative}.search-wrap svg{position:absolute;left:11px;top:12px;width:14px;height:14px;color:var(--muted);pointer-events:none}
+#search{height:38px;width:200px;border:1px solid var(--line);background:#121517;color:var(--text);padding:8px 12px 8px 33px;border-radius:5px;font-size:12px}#search::placeholder{color:#93958e}
+select{height:38px;color:#c7c9c2;background:#121517;border:1px solid var(--line);border-radius:5px;padding:0 10px;font-size:12px}
+.games{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:14px}
+.game-card{position:relative;min-width:0;padding:17px 19px 0;background:var(--panel);border:1px solid var(--line);border-radius:7px;transition:border-color .15s,background .15s}
+.game-card:hover{border-color:#605842;background:#181b1d}.card-top{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px}
+.slot-number{font:11px ui-monospace,SFMono-Regular,monospace;letter-spacing:.05em;color:#9b937e}.state{font-size:10px;color:#a3a79f;letter-spacing:.05em}.state.is-active{color:#b6d2ab;display:flex;align-items:center;gap:5px}.state.is-active:before{content:"";width:5px;height:5px;background:#b6d2ab;border-radius:50%}
+.game-card h2{font-size:15px;line-height:1.5;font-weight:550;margin:0 0 10px;min-height:23px;overflow-wrap:anywhere}.game-card h2 a:hover{color:var(--accent)}
+.saved-at{display:flex;align-items:center;justify-content:space-between;gap:10px;font-size:11px;color:var(--muted);margin-bottom:17px}.saved-at time{color:#b2b4ac}
+.card-actions{border-top:1px solid var(--line);display:flex;justify-content:space-between;align-items:center;gap:10px;min-height:44px}.continue{display:flex;align-items:center;gap:14px;color:var(--accent);font-size:12px;font-weight:550;padding:10px 0}.continue span{font-size:15px}.continue:hover{color:#efd3a0}
+.session-tools a{font-size:11px;color:var(--muted);padding:10px 0;display:inline-block}.session-tools a:hover{color:var(--text)}
+#empty{padding:65px 20px;text-align:center;color:var(--muted);border:1px dashed var(--line);border-radius:7px}#empty strong{display:block;color:var(--text);font-size:17px;font-weight:500;margin-bottom:8px}
+footer{border-top:1px solid var(--line);margin-top:28px;padding-top:17px;display:flex;justify-content:space-between;gap:20px;color:var(--muted);font-size:11px}.footer-mark{color:#b4a37f;letter-spacing:.14em}
+dialog{background:#171a1d;color:var(--text);width:min(430px,calc(100% - 32px));border:1px solid #42443d;border-radius:10px;padding:27px;box-shadow:0 25px 100px #0008}dialog::backdrop{background:#0009;backdrop-filter:blur(3px)}.dialog-head{display:flex;justify-content:space-between;align-items:center;gap:15px}dialog h2{margin:0;font-size:21px;font-weight:550}.close{background:transparent;color:var(--muted);font-size:25px;width:30px;height:36px}dialog p{color:var(--muted);font-size:13px;margin:10px 0 23px}label{display:block;color:#bfc2b8;font-size:12px;margin-bottom:8px}#name{background:#101315;border:1px solid #42473e;border-radius:5px;width:100%;padding:11px 12px;color:var(--text)}#message{font-size:12px;color:#ebba94;min-height:20px;margin:10px 0}.dialog-actions{display:flex;justify-content:flex-end;gap:10px}.cancel{background:transparent;color:var(--muted);padding:10px 13px}
+[hidden]{display:none!important}
+@media(min-width:1300px){main{max-width:1160px}.games{gap:16px}.game-card{padding:18px 21px 0}}
+@media(max-width:780px){main{padding:0 22px 30px}.games{grid-template-columns:repeat(2,minmax(0,1fr))}.intro{padding:32px 0 27px}h1{font-size:30px}.topbar{height:70px}.top-note{font-size:11px}.filters{gap:7px}#search{width:164px}.toolbar{gap:10px}}
+@media(max-width:520px){main{padding:0 16px 25px}.brand-sub{display:none}.top-note{font-size:10px}.intro{align-items:flex-start;gap:14px;padding:27px 0 25px}h1{font-size:26px}.subtitle{font-size:12px;max-width:210px}.eyebrow{font-size:10px}.intro>.primary{padding:9px 11px;font-size:12px;margin-top:23px}.plus{margin-right:3px}.toolbar{flex-wrap:wrap;gap:11px}.filters{width:100%}.search-wrap{flex:1}#search{width:100%}.games{grid-template-columns:1fr;gap:11px}.game-card{padding:15px 17px 0}.card-top{margin-bottom:8px}.saved-at{margin-bottom:12px}.game-card h2{margin-bottom:8px}footer{align-items:flex-start;gap:16px}footer>span:first-child{max-width:220px}}
+@media(prefers-reduced-motion:reduce){*{transition:none!important}}
+</style>
+</head>
+<body>
+<main>
+<header class="topbar"><div class="brand"><span class="seal" aria-hidden="true">侠</span><div><div class="brand-name">金庸群侠传</div><div class="brand-sub">群侠 · 游戏大厅</div></div></div><span class="top-note"><span class="dot" aria-hidden="true"></span>__RUNNING_COUNT__ 个游戏运行中</span></header>
+<section class="intro"><div><p class="eyebrow">每一段江湖，都值得继续</p><h1>再入江湖</h1><p class="subtitle">选择你的游戏，接着上次的故事。</p></div><button class="primary" id="new-game"><span class="plus" aria-hidden="true">＋</span>新建游戏</button></section>
+<section aria-label="游戏存档">
+<div class="toolbar"><div class="section-label">我的游戏<span class="count" id="count">__SESSION_COUNT__ 个</span></div><div class="filters"><div class="search-wrap"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><circle cx="10" cy="10" r="6.5"/><path d="m15 15 5 5"/></svg><input id="search" type="search" aria-label="搜索游戏名称" placeholder="搜索游戏名称"></div><select id="sort" aria-label="游戏排序"><option value="saved">最近保存</option><option value="created">最近创建</option><option value="name">名称排序</option></select></div></div>
+<div class="games" id="games"><!-- SESSION_CARDS --></div>
+<div id="empty" hidden><strong>没有找到游戏</strong><span>试试其他名称，或开始一段新的江湖。</span></div>
+</section>
+<footer><span>每个游戏的进度、存档与活动记录分别保存。</span><span class="footer-mark">江湖未远 · 故事未完</span></footer>
+</main>
+<dialog id="create-dialog" aria-labelledby="create-title"><div class="dialog-head"><h2 id="create-title">开启一段新江湖</h2><button class="close" id="close-dialog" aria-label="关闭">×</button></div><p>取个便于辨认的名字，以后从这里继续。</p><form id="create"><label for="name">游戏名称</label><input id="name" name="name" maxlength="40" required placeholder="例如：我的江湖 / 模型实验" autocomplete="off"><div id="message" role="alert"></div><div class="dialog-actions"><button type="button" class="cancel" id="cancel">取消</button><button class="primary" id="create-submit" type="submit">创建并进入</button></div></form></dialog>
+<script>
+const games=document.getElementById('games'), cards=Array.from(games.children), search=document.getElementById('search'), sort=document.getElementById('sort'), count=document.getElementById('count'), empty=document.getElementById('empty');
+const dates=new Intl.DateTimeFormat('zh-CN',{month:'numeric',day:'numeric',hour:'2-digit',minute:'2-digit',hour12:false});
+for(const time of document.querySelectorAll('time[data-time]')){const date=new Date(Number(time.dataset.time)*1000);time.textContent=dates.format(date);time.title=date.toLocaleString('zh-CN');}
+function update(){const query=search.value.trim().toLocaleLowerCase();let shown=0;const key=sort.value;
+ cards.sort((a,b)=>key==='name'?a.dataset.name.localeCompare(b.dataset.name,'zh-CN'):Number(b.dataset[key])-Number(a.dataset[key]));
+ for(const card of cards){card.hidden=!card.dataset.name.toLocaleLowerCase().includes(query);if(!card.hidden)shown++;games.append(card);}
+ count.textContent=query?`${shown} / ${cards.length} 个`:`${cards.length} 个`;empty.hidden=shown>0;
+}
+search.addEventListener('input',update);sort.addEventListener('change',update);update();
+const dialog=document.getElementById('create-dialog'), form=document.getElementById('create'), message=document.getElementById('message'), submit=document.getElementById('create-submit');
+document.getElementById('new-game').onclick=()=>{message.textContent='';dialog.showModal();document.getElementById('name').focus();};
+for(const id of ['close-dialog','cancel'])document.getElementById(id).onclick=()=>dialog.close();
+form.onsubmit=async event=>{event.preventDefault();submit.disabled=true;message.textContent='正在创建游戏…';try{
+ const response=await fetch('/api/users',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name:new FormData(form).get('name')})});
+ const result=await response.json();if(!response.ok)throw Error(result.error||'创建失败，请稍后再试。');location.href=result.url;
+}catch(error){message.textContent=error.message||'暂时无法连接，请稍后再试。';submit.disabled=false;}};
+</script>
+</body></html>

--- a/server/lobby.py
+++ b/server/lobby.py
@@ -1,0 +1,37 @@
+"""Read-only save metadata and the session lobby presentation."""
+from datetime import datetime, timezone
+import html
+from pathlib import Path
+
+TEMPLATE = Path(__file__).with_name('lobby.html')
+
+
+def lobby_page(store, running=()):
+    players = []
+    for number, user in enumerate(store.all(), 1):
+        saved = None
+        try:
+            state = store.paths(user['id'])[2] / 'live.state'
+            if not state.is_symlink() and state.is_file():
+                saved = state.stat().st_mtime
+        except (OSError, ValueError):
+            pass
+        players.append(dict(user, number=number, saved=saved))
+    players.sort(key=lambda u: (u['saved'] or 0, u['created_at']), reverse=True)
+    cards = []
+    for user in players:
+        identity, name = html.escape(user['id'], quote=True), html.escape(user['name'], quote=True)
+        active = user['id'] in running
+        stamp = user['saved']
+        date = datetime.fromtimestamp(stamp, timezone.utc).isoformat() if stamp else ''
+        saved = (f'<time datetime="{date}" data-time="{stamp}">已保存</time>' if stamp
+                 else '<span>尚未保存</span>')
+        cards.append(f'''<article class="game-card" data-name="{name}" data-saved="{stamp or 0}" data-created="{user['created_at']}">
+<div class="card-top"><span class="slot-number">{user['number']:02d}</span><span class="state {'is-active' if active else ''}">{'运行中' if active else '已存档' if stamp else '新游戏'}</span></div>
+<h2><a href="/u/{identity}/">{name}</a></h2>
+<div class="saved-at"><span>{'最近保存' if stamp else '准备启程'}</span>{saved}</div>
+<div class="card-actions"><a class="continue" href="/u/{identity}/">继续游戏 <span aria-hidden="true">↗</span></a><span class="session-tools" data-session-tools="{identity}"></span></div>
+</article>''')
+    return (TEMPLATE.read_text().replace('<!-- SESSION_CARDS -->', ''.join(cards))
+            .replace('__SESSION_COUNT__', str(len(players)))
+            .replace('__RUNNING_COUNT__', str(sum(u['id'] in running for u in players))))

--- a/server/multiuser.py
+++ b/server/multiuser.py
@@ -187,6 +187,12 @@ class BackendManager:
                     QUNXIA_SAVES=str(saves), QUNXIA_STATE_DIR=str(saves / "states"),
                     QUNXIA_START_STATE=str(saves / "start.state"),
                     QUNXIA_RESUME_STATE=str(saves / "live.state"),
+                    # Health and diagnostic files are worker-local state.  Do
+                    # not let a gateway-level environment override these
+                    # paths: multiple users may otherwise overwrite one
+                    # another's heartbeat or incident while running together.
+                    QUNXIA_HEALTH_DIR=str(saves / ".health"),
+                    QUNXIA_DIAGNOSTIC_DIR=str(saves / ".health" / "incidents"),
                     QUNXIA_RECORDING_DIR=str(saves), QUNXIA_RECORDING_FILE=str(saves / "recording.jsonl"),
                     QUNXIA_BENCH="0", QUNXIA_CALIBRATE="0", QUNXIA_SNAPSHOT_EVERY="0",
                     QUNXIA_PARENT_FD=str(read_fd))

--- a/server/multiuser.py
+++ b/server/multiuser.py
@@ -208,7 +208,8 @@ class BackendManager:
             try:
                 atomic_json(marker, {"pid": process.pid, "port": port, "started_at": time.time()})
                 deadline = asyncio.get_running_loop().time() + self.startup_timeout
-                while process.poll() is None and asyncio.get_running_loop().time() < deadline:
+                while (not self.closing and process.poll() is None
+                       and asyncio.get_running_loop().time() < deadline):
                     try:
                         async with self.client.get(f"http://127.0.0.1:{port}/status", timeout=1) as response:
                             status = await response.json()

--- a/server/multiuser.py
+++ b/server/multiuser.py
@@ -20,6 +20,8 @@ import sys
 import time
 from urllib.parse import urlsplit
 
+from lobby import lobby_page
+
 from aiohttp import ClientSession, ClientTimeout, WSMsgType, web
 
 HERE = Path(__file__).resolve().parent
@@ -269,18 +271,11 @@ def build_app(store, manager, public_origin=None):
     connections = set()
 
     async def lobby(_request):
-        rows = "".join(f'<li><a href="/u/{u["id"]}/">{html.escape(u["name"])}</a></li>' for u in store.all())
-        return web.Response(content_type="text/html", text='''<!doctype html><meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1"><title>Persistent sessions</title>
-<style>body{max-width:38rem;margin:3rem auto;padding:1rem;font:18px system-ui;line-height:1.6}
-input,button{font:inherit;padding:.4rem}li{margin:.5rem 0}</style><h1>Persistent sessions</h1>
-<p>Each player has a separate game, saves and recording. Opening a session can take a moment.</p>
-<ul>''' + rows + '''</ul><form><input name="name" maxlength="40" required placeholder="Player name">
-<button>Create session</button></form><p id="message"></p><script>
-document.querySelector('form').onsubmit=async e=>{e.preventDefault();
-const r=await fetch('api/users',{method:'POST',headers:{'Content-Type':'application/json'},
-body:JSON.stringify({name:new FormData(e.target).get('name')})});const d=await r.json();
-if(r.ok)location.href=d.url;else document.querySelector('#message').textContent=d.error;};</script>''')
+        running = {identity for identity, backend in manager.backends.items()
+                   if backend.process.poll() is None}
+        page = await asyncio.to_thread(lobby_page, store, running)
+        return web.Response(content_type="text/html", text=page,
+                            headers={"Cache-Control": "no-store"})
 
     async def users(_request):
         entries = store.all()

--- a/server/multiuser.py
+++ b/server/multiuser.py
@@ -1,0 +1,390 @@
+"""Persistent, process-isolated interactive sessions under /u/<id>/.
+
+The users directory is explicit. Each existing user.json, game and saves tree
+keeps its identity across gateway restarts. No benchmark session is resumed.
+"""
+import argparse
+import asyncio
+from dataclasses import dataclass
+import fcntl
+import html
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from urllib.parse import urlsplit
+
+from aiohttp import ClientSession, ClientTimeout, WSMsgType, web
+
+HERE = Path(__file__).resolve().parent
+USER_ID = re.compile(r"[A-Za-z0-9_-]{20,64}")
+HOP = {"connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
+       "te", "trailer", "trailers", "transfer-encoding", "upgrade", "content-length"}
+
+
+def atomic_json(path, value):
+    temporary = path.with_name(path.name + "." + secrets.token_hex(8) + ".tmp")
+    try:
+        with temporary.open("x", encoding="utf-8") as stream:
+            json.dump(value, stream, ensure_ascii=False)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+class UserStore:
+    def __init__(self, root, game=None, max_users=0):
+        self.root = Path(root).resolve()
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.game = Path(game).resolve() if game else None
+        self.max_users = max(0, max_users)
+
+    def paths(self, identity):
+        if not USER_ID.fullmatch(identity):
+            raise ValueError("invalid user id")
+        base = self.root / identity
+        for path in (base, base / "game", base / "saves"):
+            if path.is_symlink() or not path.resolve().is_relative_to(self.root):
+                raise ValueError("session paths must stay inside the users directory")
+        return base, base / "game", base / "saves"
+
+    def get(self, identity):
+        try:
+            path = self.paths(identity)[0] / "user.json"
+            if path.is_symlink() or path.stat().st_size > 65536:
+                return None
+            user = json.loads(path.read_text())
+            if (user.get("id") == identity and isinstance(user.get("name"), str)
+                    and isinstance(user.get("created_at"), (float, int))):
+                return user
+        except (OSError, ValueError, TypeError, AttributeError):
+            pass
+        return None
+
+    def all(self):
+        users = [self.get(path.name) for path in self.root.iterdir()
+                 if USER_ID.fullmatch(path.name)]
+        return sorted((u for u in users if u), key=lambda u: u["created_at"])
+
+    def create(self, name):
+        name = " ".join(str(name).split())
+        if not 1 <= len(name) <= 40:
+            raise ValueError("name must contain 1-40 characters")
+        if self.max_users and len(self.all()) >= self.max_users:
+            raise ValueError("user limit reached")
+        if not self.game or not (self.game / "PLAY.BAT").is_file():
+            raise ValueError("configure a game template directory containing PLAY.BAT")
+        identity = secrets.token_urlsafe(18)
+        base, game, saves = self.paths(identity)
+        base.mkdir(mode=0o700)
+        try:
+            shutil.copytree(self.game, game)
+            saves.mkdir()
+            user = {"id": identity, "name": name, "created_at": time.time(), "default": False}
+            atomic_json(base / "user.json", user)
+            return user
+        except BaseException:
+            shutil.rmtree(base)
+            raise
+
+
+@dataclass
+class Backend:
+    process: subprocess.Popen
+    port: int
+    log: object
+    parent_pipe: int
+    marker: Path
+
+
+class BackendManager:
+    def __init__(self, store, core, *, python=sys.executable, server=HERE / "server.py",
+                 startup_timeout=90, shutdown_timeout=15, environment=None):
+        self.store, self.core = store, str(core)
+        self.python, self.server = python, Path(server)
+        self.startup_timeout, self.shutdown_timeout = startup_timeout, shutdown_timeout
+        self.environment = environment or {}
+        self.backends, self.locks = {}, {}
+        self.client = None
+        self.lease = None
+        self.closing = False
+
+    async def start(self):
+        self.lease = os.open(self.store.root / ".gateway.lock", os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fcntl.flock(self.lease, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            os.close(self.lease)
+            self.lease = None
+            raise RuntimeError("another gateway owns this users directory")
+        self.client = ClientSession(timeout=ClientTimeout(total=120), auto_decompress=False)
+
+    async def stop(self, backend):
+        if backend.process.poll() is None:
+            backend.process.terminate()
+            try:
+                await asyncio.to_thread(backend.process.wait, timeout=self.shutdown_timeout)
+            except subprocess.TimeoutExpired:
+                backend.process.kill()
+                await asyncio.to_thread(backend.process.wait)
+        if backend.parent_pipe is not None:
+            os.close(backend.parent_pipe)
+            backend.parent_pipe = None
+        backend.log.close()
+        backend.marker.unlink(missing_ok=True)
+
+    async def ensure(self, user):
+        identity = user["id"]
+        async with self.locks.setdefault(identity, asyncio.Lock()):
+            if self.closing:
+                raise RuntimeError("gateway is shutting down")
+            old = self.backends.get(identity)
+            if old and old.process.poll() is None:
+                return old
+            if old:
+                await self.stop(old)
+                self.backends.pop(identity, None)
+            base, game, saves = self.store.paths(identity)
+            marker = base / "backend.json"
+            lease = os.open(base / ".backend.lock", os.O_CREAT | os.O_RDWR, 0o600)
+            try:
+                fcntl.flock(lease, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                # A legacy marker is not proof that we own its PID. Refuse a
+                # live unknown owner instead of signalling an unrelated process.
+                if marker.exists():
+                    try:
+                        pid = int(json.loads(marker.read_text())["pid"])
+                    except (OSError, ValueError, KeyError, TypeError):
+                        pid = 0
+                    if pid > 0:
+                        try:
+                            os.kill(pid, 0)
+                        except ProcessLookupError:
+                            pass
+                        else:
+                            raise RuntimeError("a previous backend may still own this session")
+                with socket.socket() as sock:
+                    sock.bind(("127.0.0.1", 0))
+                    port = sock.getsockname()[1]
+                read_fd, write_fd = os.pipe()
+                log = (base / "server.log").open("ab", buffering=0)
+                environment = dict(os.environ, **self.environment)
+                for name in ("QUNXIA_RESET_TOKEN", "QUNXIA_PARENT_PID", "QUNXIA_RUNTIME_DIR",
+                             "QUNXIA_SESSION_DIR", "QUNXIA_BENCH_SID"):
+                    environment.pop(name, None)
+                environment.update(PORT=str(port), QUNXIA_HOST="127.0.0.1",
+                    QUNXIA_CORE=self.core, QUNXIA_GAME=str(game / "PLAY.BAT"),
+                    QUNXIA_SAVES=str(saves), QUNXIA_STATE_DIR=str(saves / "states"),
+                    QUNXIA_START_STATE=str(saves / "start.state"),
+                    QUNXIA_RESUME_STATE=str(saves / "live.state"),
+                    QUNXIA_RECORDING_DIR=str(saves), QUNXIA_RECORDING_FILE=str(saves / "recording.jsonl"),
+                    QUNXIA_BENCH="0", QUNXIA_CALIBRATE="0", QUNXIA_SNAPSHOT_EVERY="0",
+                    QUNXIA_PARENT_FD=str(read_fd))
+                try:
+                    process = subprocess.Popen([self.python, "-u", str(HERE / "session_worker.py"),
+                                                str(self.server)], cwd=self.server.parent,
+                        env=environment, stdout=log, stderr=log, pass_fds=(read_fd, lease),
+                        start_new_session=True)
+                except BaseException:
+                    os.close(write_fd)
+                    log.close()
+                    raise
+                finally:
+                    os.close(read_fd)
+                backend = Backend(process, port, log, write_fd, marker)
+                self.backends[identity] = backend
+            finally:
+                # The inherited descriptor keeps the per-user lease until
+                # the worker exits, even if the gateway is killed.
+                os.close(lease)
+            try:
+                atomic_json(marker, {"pid": process.pid, "port": port, "started_at": time.time()})
+                deadline = asyncio.get_running_loop().time() + self.startup_timeout
+                while process.poll() is None and asyncio.get_running_loop().time() < deadline:
+                    try:
+                        async with self.client.get(f"http://127.0.0.1:{port}/status", timeout=1) as response:
+                            status = await response.json()
+                        checkpoint = status.get("checkpoint", {})
+                        if checkpoint.get("state") == "failed":
+                            raise RuntimeError("session restore failed: " + str(checkpoint.get("error")))
+                        if response.status == 200 and status.get("healthy"):
+                            if not checkpoint.get("enabled"):
+                                raise RuntimeError("the worker needs persistent checkpoint support")
+                            if checkpoint.get("state") == "ready":
+                                return backend
+                    except (OSError, asyncio.TimeoutError):
+                        pass
+                    await asyncio.sleep(.1)
+                raise RuntimeError("backend did not become ready; inspect its server.log")
+            except BaseException:
+                await asyncio.shield(self.stop(backend))
+                self.backends.pop(identity, None)
+                raise
+
+    async def close(self):
+        self.closing = True
+        await asyncio.gather(*(self.stop(b) for b in self.backends.values()))
+        self.backends.clear()
+        if self.client:
+            await self.client.close()
+        if self.lease is not None:
+            os.close(self.lease)
+            self.lease = None
+
+
+def forwarded_headers(request, identity, public_origin=None):
+    excluded = HOP | {s.strip().lower() for s in request.headers.get("Connection", "").split(",")}
+    headers = {k: v for k, v in request.headers.items() if k.lower() not in excluded
+               and k.lower() != "host" and not k.lower().startswith(("x-forwarded-", "sec-websocket-"))}
+    origin = urlsplit(public_origin) if public_origin else None
+    headers.update({"Host": request.host,
+                    "X-Forwarded-Host": origin.netloc if origin else request.host,
+                    "X-Forwarded-Proto": origin.scheme if origin else request.scheme,
+                    "X-Forwarded-Prefix": f"/u/{identity}"})
+    return headers
+
+
+async def relay(source, destination):
+    async for message in source:
+        if message.type == WSMsgType.TEXT:
+            await destination.send_str(message.data)
+        elif message.type == WSMsgType.BINARY:
+            await destination.send_bytes(message.data)
+        else:
+            break
+
+
+def build_app(store, manager, public_origin=None):
+    app = web.Application(client_max_size=4 << 20)
+    create_lock = asyncio.Lock()
+
+    async def lobby(_request):
+        rows = "".join(f'<li><a href="/u/{u["id"]}/">{html.escape(u["name"])}</a></li>' for u in store.all())
+        return web.Response(content_type="text/html", text='''<!doctype html><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>Persistent sessions</title>
+<style>body{max-width:38rem;margin:3rem auto;padding:1rem;font:18px system-ui;line-height:1.6}
+input,button{font:inherit;padding:.4rem}li{margin:.5rem 0}</style><h1>Persistent sessions</h1>
+<p>Each player has a separate game, saves and recording. Opening a session can take a moment.</p>
+<ul>''' + rows + '''</ul><form><input name="name" maxlength="40" required placeholder="Player name">
+<button>Create session</button></form><p id="message"></p><script>
+document.querySelector('form').onsubmit=async e=>{e.preventDefault();
+const r=await fetch('api/users',{method:'POST',headers:{'Content-Type':'application/json'},
+body:JSON.stringify({name:new FormData(e.target).get('name')})});const d=await r.json();
+if(r.ok)location.href=d.url;else document.querySelector('#message').textContent=d.error;};</script>''')
+
+    async def users(_request):
+        entries = store.all()
+        return web.json_response({"users": len(entries), "max_users": store.max_users or None,
+                                  "items": entries, "active": len(manager.backends)})
+
+    async def create(request):
+        try:
+            body = await request.json()
+            if not isinstance(body, dict):
+                raise ValueError("JSON object required")
+            async with create_lock:
+                user = await asyncio.to_thread(store.create, body.get("name", ""))
+            return web.json_response({"ok": True, "id": user["id"], "url": f'/u/{user["id"]}/'}, status=201)
+        except (ValueError, OSError) as exc:
+            return web.json_response({"error": str(exc)}, status=400)
+
+    async def proxy(request):
+        identity = request.match_info["identity"]
+        user = store.get(identity)
+        if not user:
+            raise web.HTTPNotFound()
+        if "tail" not in request.match_info:
+            raise web.HTTPFound(f"/u/{identity}/")
+        try:
+            backend = await manager.ensure(user)
+        except (OSError, RuntimeError) as exc:
+            return web.json_response({"error": str(exc)}, status=503)
+        target = f'http://127.0.0.1:{backend.port}/{request.match_info["tail"]}'
+        if request.query_string:
+            target += "?" + request.rel_url.raw_query_string
+        headers = forwarded_headers(request, identity, public_origin)
+        if request.headers.get("Upgrade", "").lower() == "websocket":
+            upstream = await manager.client.ws_connect(target, headers=headers, max_msg_size=4 << 20,
+                                                        compress=0)
+            downstream = web.WebSocketResponse(max_msg_size=4096, compress=False)
+            await downstream.prepare(request)
+            tasks = [asyncio.create_task(relay(a, b)) for a, b in
+                     ((downstream, upstream), (upstream, downstream))]
+            try:
+                await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            finally:
+                for task in tasks:
+                    task.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
+                await upstream.close()
+                await downstream.close()
+            return downstream
+        async with manager.client.request(request.method, target, headers=headers,
+                data=request.content.iter_chunked(64 << 10), allow_redirects=False) as upstream:
+            headers = {k: v for k, v in upstream.headers.items() if k.lower() not in HOP}
+            if headers.get("Location", "").startswith("/"):
+                headers["Location"] = f"/u/{identity}" + headers["Location"]
+            downstream = web.StreamResponse(status=upstream.status, headers=headers)
+            if upstream.content_length is not None:
+                downstream.content_length = upstream.content_length
+            await downstream.prepare(request)
+            try:
+                async for chunk in upstream.content.iter_chunked(64 << 10):
+                    await downstream.write(chunk)
+                await downstream.write_eof()
+            except ConnectionError:
+                pass
+            return downstream
+
+    async def start(_app):
+        await manager.start()
+
+    async def close(_app):
+        await manager.close()
+
+    app.router.add_get("/", lobby)
+    app.router.add_get("/health", users)
+    app.router.add_get("/api/users", users)
+    app.router.add_post("/api/users", create)
+    app.router.add_get("/u/{identity}", proxy)
+    app.router.add_route("*", "/u/{identity}/{tail:.*}", proxy)
+    app.on_startup.append(start)
+    app.on_cleanup.append(close)
+    return app
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", nargs="?", default="serve", choices=("serve", "list", "create"))
+    parser.add_argument("--users-dir", default=os.environ.get("QUNXIA_USERS_DIR"))
+    parser.add_argument("--game-dir", default=os.environ.get("QUNXIA_GAME_DIR"))
+    parser.add_argument("--core", default=os.environ.get("QUNXIA_CORE"))
+    parser.add_argument("--name")
+    parser.add_argument("--host", default=os.environ.get("QUNXIA_MULTIUSER_HOST", "127.0.0.1"))
+    parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", "8084")))
+    args = parser.parse_args()
+    if not args.users_dir:
+        parser.error("set --users-dir or QUNXIA_USERS_DIR")
+    store = UserStore(args.users_dir, args.game_dir, int(os.environ.get("QUNXIA_MAX_USERS", "0")))
+    if args.command == "list":
+        print(json.dumps(store.all(), ensure_ascii=False, indent=2))
+    elif args.command == "create":
+        print(json.dumps(store.create(args.name or ""), ensure_ascii=False))
+    else:
+        if not args.core:
+            parser.error("set --core or QUNXIA_CORE")
+        manager = BackendManager(store, args.core)
+        web.run_app(build_app(store, manager, os.environ.get("QUNXIA_PUBLIC_BASE")),
+                    host=args.host, port=args.port, access_log=None)
+
+
+if __name__ == "__main__":
+    main()

--- a/server/multiuser.py
+++ b/server/multiuser.py
@@ -265,6 +265,7 @@ async def relay(source, destination):
 def build_app(store, manager, public_origin=None):
     app = web.Application(client_max_size=4 << 20)
     create_lock = asyncio.Lock()
+    connections = set()
 
     async def lobby(_request):
         rows = "".join(f'<li><a href="/u/{u["id"]}/">{html.escape(u["name"])}</a></li>' for u in store.all())
@@ -315,12 +316,18 @@ if(r.ok)location.href=d.url;else document.querySelector('#message').textContent=
             upstream = await manager.client.ws_connect(target, headers=headers, max_msg_size=4 << 20,
                                                         compress=0)
             downstream = web.WebSocketResponse(max_msg_size=4096, compress=False)
-            await downstream.prepare(request)
-            tasks = [asyncio.create_task(relay(a, b)) for a, b in
-                     ((downstream, upstream), (upstream, downstream))]
+            pair = (downstream, upstream, request.transport)
+            connections.add(pair)
+            tasks = []
             try:
+                if manager.closing:
+                    raise web.HTTPServiceUnavailable()
+                await downstream.prepare(request)
+                tasks = [asyncio.create_task(relay(a, b)) for a, b in
+                         ((downstream, upstream), (upstream, downstream))]
                 await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
             finally:
+                connections.discard(pair)
                 for task in tasks:
                     task.cancel()
                 await asyncio.gather(*tasks, return_exceptions=True)
@@ -350,6 +357,22 @@ if(r.ok)location.href=d.url;else document.querySelector('#message').textContent=
     async def close(_app):
         await manager.close()
 
+    async def shutdown(_app):
+        # on_cleanup is too late: aiohttp first waits for open request handlers,
+        # including these long-lived WebSockets. End both halves before drain.
+        manager.closing = True
+        active = list(connections)
+        try:
+            await asyncio.wait_for(asyncio.gather(
+                *(socket.close() for pair in active for socket in pair[:2]),
+                return_exceptions=True), timeout=2)
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            for _downstream, _upstream, transport in active:
+                if transport:
+                    transport.close()
+
     app.router.add_get("/", lobby)
     app.router.add_get("/health", users)
     app.router.add_get("/api/users", users)
@@ -357,6 +380,7 @@ if(r.ok)location.href=d.url;else document.querySelector('#message').textContent=
     app.router.add_get("/u/{identity}", proxy)
     app.router.add_route("*", "/u/{identity}/{tail:.*}", proxy)
     app.on_startup.append(start)
+    app.on_shutdown.append(shutdown)
     app.on_cleanup.append(close)
     return app
 

--- a/server/multiuser.py
+++ b/server/multiuser.py
@@ -110,8 +110,8 @@ class Backend:
 class BackendManager:
     def __init__(self, store, core, *, python=sys.executable, server=HERE / "server.py",
                  startup_timeout=90, shutdown_timeout=15, environment=None):
-        self.store, self.core = store, str(core)
-        self.python, self.server = python, Path(server)
+        self.store, self.core = store, str(Path(core).expanduser().resolve())
+        self.python, self.server = python, Path(server).expanduser().resolve()
         self.startup_timeout, self.shutdown_timeout = startup_timeout, shutdown_timeout
         self.environment = environment or {}
         self.backends, self.locks = {}, {}

--- a/server/recording.js
+++ b/server/recording.js
@@ -8,7 +8,7 @@ class ReplayRecording {
   }
   async request(extra) {
     const query = new URLSearchParams({view:'paged', ...(this.token ? {token:this.token} : {}), ...extra});
-    const response = await fetch('/api/recording?' + query);
+    const response = await fetch('api/recording?' + query);
     const page = await response.json();
     if (!response.ok) throw new Error(page.error || 'Recording unavailable');
     return page;

--- a/server/server.py
+++ b/server/server.py
@@ -45,6 +45,7 @@ CORE = os.environ.get("QUNXIA_CORE", str(ROOT.parent / "cores" / "dosbox_pure_li
 GAME = os.environ.get("QUNXIA_GAME", str(ROOT.parent / "game" / "PLAY.BAT"))
 SAVES = os.environ.get("QUNXIA_SAVES", str(ROOT.parent / "saves"))
 PORT = int(os.environ.get("PORT", "8080"))
+HOST = os.environ.get("QUNXIA_HOST", "0.0.0.0")
 SEND_HZ = float(os.environ.get("QUNXIA_SEND_HZ", "20"))
 
 LIB.core_set_option.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
@@ -1831,6 +1832,9 @@ def base_url(request):
             scheme = value
             break
     base = f"{scheme}://{host}"
+    prefix = request.headers.get("X-Forwarded-Prefix", "").rstrip("/")
+    if re.fullmatch(r"/u/[A-Za-z0-9_-]{20,64}", prefix):
+        return base + prefix
     sid = os.environ.get("QUNXIA_BENCH_SID", "")
     if os.environ.get("QUNXIA_BENCH") == "1" and sid:
         base = f"{base.rstrip('/')}/s/{sid}"
@@ -2352,7 +2356,7 @@ def main():
     # than returned, or startup would block on loops that never end.
     app.on_startup.append(startup)
     app.on_cleanup.append(cleanup)
-    web.run_app(app, host="0.0.0.0", port=PORT, access_log=None)
+    web.run_app(app, host=HOST, port=PORT, access_log=None)
 
 
 if __name__ == "__main__":

--- a/server/session_worker.py
+++ b/server/session_worker.py
@@ -1,0 +1,22 @@
+"""Run one gateway-owned server, exiting cleanly when its parent disappears."""
+import os
+import runpy
+import signal
+import sys
+import threading
+
+
+def watch_parent(fd):
+    # Only the gateway holds the write end. EOF cannot refer to a recycled PID.
+    try:
+        while os.read(fd, 1):
+            pass
+        os.kill(os.getpid(), signal.SIGTERM)
+    finally:
+        os.close(fd)
+
+
+if __name__ == "__main__":
+    threading.Thread(target=watch_parent,
+                     args=(int(os.environ["QUNXIA_PARENT_FD"]),), daemon=True).start()
+    runpy.run_path(sys.argv[1], run_name="__main__")

--- a/server/test_fixtures/gateway_probe_server.py
+++ b/server/test_fixtures/gateway_probe_server.py
@@ -12,6 +12,8 @@ async def status(request):
         "checkpoint": {"enabled": True, "state": os.environ.get("PROBE_PHASE", "ready")},
         "pid": os.getpid(), "saves": os.environ["QUNXIA_SAVES"],
         "recording": os.environ["QUNXIA_RECORDING_FILE"],
+        "health": os.environ["QUNXIA_HEALTH_DIR"],
+        "diagnostic": os.environ["QUNXIA_DIAGNOSTIC_DIR"],
         "listen_host": os.environ["QUNXIA_HOST"],
         "prefix": request.headers.get("X-Forwarded-Prefix"),
         "bench": os.environ["QUNXIA_BENCH"]})

--- a/server/test_fixtures/gateway_probe_server.py
+++ b/server/test_fixtures/gateway_probe_server.py
@@ -1,0 +1,49 @@
+"""Gateway transport/ownership fixture; no native core or game required."""
+import os
+from pathlib import Path
+
+from aiohttp import web
+
+app = web.Application()
+
+
+async def status(request):
+    return web.json_response({"healthy": True,
+        "checkpoint": {"enabled": True, "state": os.environ.get("PROBE_PHASE", "ready")},
+        "pid": os.getpid(), "saves": os.environ["QUNXIA_SAVES"],
+        "recording": os.environ["QUNXIA_RECORDING_FILE"],
+        "listen_host": os.environ["QUNXIA_HOST"],
+        "prefix": request.headers.get("X-Forwarded-Prefix"),
+        "bench": os.environ["QUNXIA_BENCH"]})
+
+
+async def text(request):
+    return web.Response(text=request.path)
+
+
+async def websocket(request):
+    ws = web.WebSocketResponse()
+    await ws.prepare(request)
+    async for message in ws:
+        if message.data == "close":
+            await ws.close()
+            break
+        await ws.send_str(message.data)
+    return ws
+
+
+async def recording(_request):
+    return web.Response(body=b"old recording bytes\n", headers={"Content-Type": "application/x-ndjson"})
+
+
+async def close(_app):
+    folder = Path(os.environ["QUNXIA_SAVES"])
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / "clean-exit").write_text("closed")
+
+
+app.add_routes([web.get("/status", status), web.get("/", text),
+                web.get("/recording.js", text), web.get("/api/help", text),
+                web.get("/api/recording", recording), web.get("/ws", websocket)])
+app.on_cleanup.append(close)
+web.run_app(app, host=os.environ["QUNXIA_HOST"], port=int(os.environ["PORT"]), access_log=None)

--- a/server/test_lobby.py
+++ b/server/test_lobby.py
@@ -1,0 +1,39 @@
+import os
+from pathlib import Path
+import tempfile
+import unittest
+
+from lobby import lobby_page
+from multiuser import UserStore
+
+
+class LobbyTests(unittest.TestCase):
+    def test_save_order_escaping_and_no_recording_reads(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root=Path(tmp);game=root/'template';game.mkdir();(game/'PLAY.BAT').touch()
+            store=UserStore(root/'users',game)
+            first=store.create('Older');second=store.create('<script>" & new')
+            for user,stamp in [(first,1000),(second,2000)]:
+                saves=store.paths(user['id'])[2]
+                (saves/'live.state').touch();os.utime(saves/'live.state',(stamp,stamp))
+                # The lobby must not open the recording or start a worker.
+                (saves/'recording.jsonl').symlink_to(root/'unreadable-recording')
+            page=lobby_page(store,{second['id']})
+            self.assertLess(page.index('data-name="&lt;script&gt;'),page.index('data-name="Older"'))
+            self.assertNotIn('<script>" & new',page)
+            self.assertIn('data-saved="2000.0"',page)
+            self.assertEqual(page.count('data-session-tools='),2)
+            self.assertEqual(page.count('class="state is-active"'),1)
+
+    def test_missing_save_and_external_state_symlink_are_not_presented_as_saved(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root=Path(tmp);game=root/'template';game.mkdir();(game/'PLAY.BAT').touch()
+            store=UserStore(root/'users',game);user=store.create('New game')
+            (root/'outside.state').touch()
+            (store.paths(user['id'])[2]/'live.state').symlink_to(root/'outside.state')
+            page=lobby_page(store)
+            self.assertIn('尚未保存',page)
+            self.assertIn('data-saved="0"',page)
+
+
+if __name__=='__main__':unittest.main()

--- a/server/test_multiuser.py
+++ b/server/test_multiuser.py
@@ -1,0 +1,121 @@
+"""Real child processes plus HTTP/WebSocket routes in temporary user trees."""
+import asyncio
+import fcntl
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+
+from aiohttp import WSMsgType
+from aiohttp.test_utils import TestClient, TestServer
+
+from multiuser import BackendManager, UserStore, build_app
+
+
+class MultiuserTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="qunxia-gateway-")
+        self.root = Path(self.temp.name)
+        game = self.root / "template"
+        game.mkdir()
+        (game / "PLAY.BAT").write_text("fixture")
+        self.store = UserStore(self.root / "users", game)
+        self.user = self.store.create("Existing player")
+        self.manager = BackendManager(self.store, "unused",
+            server=Path(__file__).parent / "test_fixtures/gateway_probe_server.py",
+            startup_timeout=3, shutdown_timeout=3)
+        self.client = TestClient(TestServer(build_app(self.store, self.manager)))
+        await self.client.start_server()
+
+    async def asyncTearDown(self):
+        await self.client.close()
+        self.temp.cleanup()
+
+    async def wait_for(self, predicate):
+        for _ in range(100):
+            if predicate():
+                return
+            await asyncio.sleep(.02)
+        self.fail("worker did not reach the expected state")
+
+    async def test_concurrent_open_reuses_one_worker_and_private_paths(self):
+        a, b = await asyncio.gather(self.manager.ensure(self.user), self.manager.ensure(self.user))
+        self.assertIs(a, b)
+        identity = self.user["id"]
+        value = await (await self.client.get(f"/u/{identity}/status")).json()
+        self.assertEqual(value["pid"], a.process.pid)
+        self.assertEqual(value["prefix"], f"/u/{identity}")
+        self.assertEqual(value["saves"], str(self.store.root / identity / "saves"))
+        self.assertEqual(value["recording"], str(self.store.root / identity / "saves/recording.jsonl"))
+        self.assertEqual(value["listen_host"], "127.0.0.1")
+        self.assertEqual(value["bench"], "0")
+
+    async def test_existing_ids_survive_restart_and_new_users_have_separate_game_trees(self):
+        second = await (await self.client.post("/api/users", json={"name": "Second player"})).json()
+        first_game = self.store.paths(self.user["id"])[1] / "PLAY.BAT"
+        first_game.write_text("private progress")
+        self.assertEqual((self.store.paths(second["id"])[1] / "PLAY.BAT").read_text(), "fixture")
+        reloaded = UserStore(self.store.root)
+        self.assertEqual(reloaded.get(self.user["id"]), self.user)
+        self.assertEqual([u["name"] for u in reloaded.all()], ["Existing player", "Second player"])
+        self.assertEqual((await (await self.client.get("/api/users")).json())["users"], 2)
+
+    async def test_subpath_assets_streamed_recording_and_websocket_close(self):
+        prefix = f'/u/{self.user["id"]}'
+        response = await self.client.get(prefix, allow_redirects=False)
+        self.assertEqual(response.headers["Location"], prefix + "/")
+        for path in ("/", "/recording.js", "/api/help"):
+            self.assertEqual(await (await self.client.get(prefix + path)).text(), path)
+        response = await self.client.get(prefix + "/api/recording?format=jsonl")
+        self.assertEqual(await response.read(), b"old recording bytes\n")
+        ws = await self.client.ws_connect(prefix + "/ws")
+        await ws.send_str("hello")
+        self.assertEqual((await ws.receive(timeout=1)).data, "hello")
+        await ws.send_str("close")
+        self.assertEqual((await ws.receive(timeout=1)).type, WSMsgType.CLOSE)
+        await ws.close()
+
+    async def test_cancelled_start_reaps_only_its_child_and_releases_the_lease(self):
+        self.manager.environment["PROBE_PHASE"] = "warming"
+        task = asyncio.create_task(self.manager.ensure(self.user))
+        await self.wait_for(lambda: bool(self.manager.backends))
+        backend = self.manager.backends[self.user["id"]]
+        task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+        self.assertIsNotNone(backend.process.poll())
+        self.assertTrue(backend.log.closed)
+        self.assertIsNone(backend.parent_pipe)
+        self.assertFalse(backend.marker.exists())
+        with (self.store.paths(self.user["id"])[0] / ".backend.lock").open("r") as lease:
+            fcntl.flock(lease, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    async def test_parent_pipe_eof_exits_the_worker_cleanly(self):
+        backend = await self.manager.ensure(self.user)
+        os.close(backend.parent_pipe)
+        backend.parent_pipe = None
+        await self.wait_for(lambda: backend.process.poll() is not None)
+        self.assertEqual(backend.process.returncode, 0)
+        self.assertTrue((self.store.paths(self.user["id"])[2] / "clean-exit").is_file())
+
+    async def test_foreign_live_pid_is_never_terminated(self):
+        marker = self.store.paths(self.user["id"])[0] / "backend.json"
+        marker.write_text(json.dumps({"pid": os.getpid(), "port": 1}))
+        with self.assertRaisesRegex(RuntimeError, "previous backend"):
+            await self.manager.ensure(self.user)
+        self.assertEqual(self.manager.backends, {})
+        self.assertEqual(json.loads(marker.read_text())["pid"], os.getpid())
+
+    async def test_another_gateway_and_escaping_user_paths_are_refused(self):
+        other = BackendManager(self.store, "unused")
+        with self.assertRaisesRegex(RuntimeError, "another gateway"):
+            await other.start()
+        self.assertIsNone(self.store.get("../template"))
+        identity = "x" * 24
+        (self.store.root / identity).symlink_to(self.root / "template")
+        self.assertIsNone(self.store.get(identity))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/test_multiuser.py
+++ b/server/test_multiuser.py
@@ -107,6 +107,18 @@ class MultiuserTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual((await ws.receive(timeout=1)).type, WSMsgType.CLOSE)
         await ws.close()
 
+    async def test_shutdown_interrupts_a_request_waiting_for_worker_warmup(self):
+        self.manager.environment["PROBE_PHASE"] = "warming"
+        self.manager.startup_timeout = 30
+        request = asyncio.create_task(self.client.get(f'/u/{self.user["id"]}/'))
+        await self.wait_for(lambda: bool(self.manager.backends))
+        backend = self.manager.backends[self.user["id"]]
+        await self.client.server.app.shutdown()
+        response = await asyncio.wait_for(request, timeout=3)
+        self.assertEqual(response.status, 503)
+        self.assertIsNotNone(backend.process.poll())
+        self.assertFalse(backend.marker.exists())
+
     async def test_foreign_live_pid_is_never_terminated(self):
         marker = self.store.paths(self.user["id"])[0] / "backend.json"
         marker.write_text(json.dumps({"pid": os.getpid(), "port": 1}))

--- a/server/test_multiuser.py
+++ b/server/test_multiuser.py
@@ -39,6 +39,13 @@ class MultiuserTests(unittest.IsolatedAsyncioTestCase):
             await asyncio.sleep(.02)
         self.fail("worker did not reach the expected state")
 
+    async def test_lobby_does_not_start_any_game(self):
+        response = await self.client.get('/')
+        self.assertEqual(response.status, 200)
+        self.assertIn('Existing player', await response.text())
+        self.assertEqual(self.manager.backends, {})
+        self.assertEqual(response.headers['Cache-Control'], 'no-store')
+
     async def test_concurrent_open_reuses_one_worker_and_private_paths(self):
         a, b = await asyncio.gather(self.manager.ensure(self.user), self.manager.ensure(self.user))
         self.assertIs(a, b)

--- a/server/test_multiuser.py
+++ b/server/test_multiuser.py
@@ -58,6 +58,29 @@ class MultiuserTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(value["listen_host"], "127.0.0.1")
         self.assertEqual(value["bench"], "0")
 
+    async def test_relative_core_and_server_paths_survive_the_worker_chdir(self):
+        core = self.root / "probe-core.so"
+        core.write_text("fixture core")
+        script = self.root / "worker" / "probe.py"
+        script.parent.mkdir()
+        fixture = Path(__file__).parent / "test_fixtures/gateway_probe_server.py"
+        script.write_text("import os, pathlib, runpy\n"
+                          "assert pathlib.Path(os.environ['QUNXIA_CORE']).is_file()\n"
+                          f"runpy.run_path({str(fixture.resolve())!r}, run_name='__main__')\n")
+        for relative_core, relative_server in ((True, False), (False, True), (True, True)):
+            with self.subTest(core=relative_core, server=relative_server):
+                await self.client.close()
+                self.manager = BackendManager(self.store,
+                    os.path.relpath(core) if relative_core else core,
+                    server=os.path.relpath(script) if relative_server else script,
+                    startup_timeout=3, shutdown_timeout=3)
+                self.client = TestClient(TestServer(build_app(self.store, self.manager)))
+                await self.client.start_server()
+                backend = await self.manager.ensure(self.user)
+                self.assertIsNone(backend.process.poll())
+                self.assertEqual(Path(self.manager.core), core.resolve())
+                self.assertEqual(self.manager.server, script.resolve())
+
     async def test_existing_ids_survive_restart_and_new_users_have_separate_game_trees(self):
         second = await (await self.client.post("/api/users", json={"name": "Second player"})).json()
         first_game = self.store.paths(self.user["id"])[1] / "PLAY.BAT"

--- a/server/test_multiuser.py
+++ b/server/test_multiuser.py
@@ -99,6 +99,14 @@ class MultiuserTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(backend.process.returncode, 0)
         self.assertTrue((self.store.paths(self.user["id"])[2] / "clean-exit").is_file())
 
+    async def test_shutdown_closes_active_websockets_before_request_drain(self):
+        ws = await self.client.ws_connect(f'/u/{self.user["id"]}/ws')
+        await ws.send_str("still open")
+        self.assertEqual((await ws.receive(timeout=1)).data, "still open")
+        await asyncio.wait_for(self.client.server.app.shutdown(), timeout=3)
+        self.assertEqual((await ws.receive(timeout=1)).type, WSMsgType.CLOSE)
+        await ws.close()
+
     async def test_foreign_live_pid_is_never_terminated(self):
         marker = self.store.paths(self.user["id"])[0] / "backend.json"
         marker.write_text(json.dumps({"pid": os.getpid(), "port": 1}))

--- a/server/test_multiuser.py
+++ b/server/test_multiuser.py
@@ -55,8 +55,50 @@ class MultiuserTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(value["prefix"], f"/u/{identity}")
         self.assertEqual(value["saves"], str(self.store.root / identity / "saves"))
         self.assertEqual(value["recording"], str(self.store.root / identity / "saves/recording.jsonl"))
+        self.assertEqual(value["health"], str(self.store.root / identity / "saves/.health"))
+        self.assertEqual(value["diagnostic"], str(self.store.root / identity / "saves/.health/incidents"))
         self.assertEqual(value["listen_host"], "127.0.0.1")
         self.assertEqual(value["bench"], "0")
+
+    async def test_workers_never_share_health_or_diagnostic_paths(self):
+        """Worker-local watchdog files stay private despite shared parent env."""
+        second = self.store.create("Second player")
+
+        async def status(backend):
+            async with self.manager.client.get(f"http://127.0.0.1:{backend.port}/status") as response:
+                self.assertEqual(response.status, 200)
+                return await response.json()
+
+        # First exercise the normal environment with two workers, then repeat
+        # with gateway-level paths that would have been shared before the fix.
+        first, second_backend = await asyncio.gather(
+            self.manager.ensure(self.user), self.manager.ensure(second))
+        values = await asyncio.gather(status(first), status(second_backend))
+        self.assertNotEqual(values[0]["health"], values[1]["health"])
+        self.assertNotEqual(values[0]["diagnostic"], values[1]["diagnostic"])
+        for user, value in zip((self.user, second), values):
+            saves = self.store.paths(user["id"])[2]
+            self.assertEqual(value["health"], str(saves / ".health"))
+            self.assertEqual(value["diagnostic"], str(saves / ".health" / "incidents"))
+
+        shared = self.root / "shared-health"
+        self.manager.environment.update(
+            QUNXIA_HEALTH_DIR=str(shared),
+            QUNXIA_DIAGNOSTIC_DIR=str(shared / "incidents"),
+        )
+        third = self.store.create("Third player")
+        fourth = self.store.create("Fourth player")
+        third_backend, fourth_backend = await asyncio.gather(
+            self.manager.ensure(third), self.manager.ensure(fourth))
+        values = await asyncio.gather(status(third_backend), status(fourth_backend))
+        for user, value in zip((third, fourth), values):
+            saves = self.store.paths(user["id"])[2]
+            self.assertEqual(value["health"], str(saves / ".health"))
+            self.assertEqual(value["diagnostic"], str(saves / ".health" / "incidents"))
+            self.assertNotEqual(value["health"], str(shared))
+            self.assertNotEqual(value["diagnostic"], str(shared / "incidents"))
+        self.assertNotEqual(values[0]["health"], values[1]["health"])
+        self.assertNotEqual(values[0]["diagnostic"], values[1]["diagnostic"])
 
     async def test_relative_core_and_server_paths_survive_the_worker_chdir(self):
         core = self.root / "probe-core.so"


### PR DESCRIPTION
Add persistent interactive users under /u/<id>/ with separate game/save/recording directories and on-demand loopback workers. Existing user identifiers and checkpoints survive gateway restart. The dark Chinese lobby shows compact cards, save-time ordering, search, sorting and a new-game dialog; opening the lobby only reads metadata and does not launch idle games.

Directory and inherited worker leases prevent duplicate owners. Parent pipes stop orphaned children; unknown live PIDs are refused. Active proxy WebSockets close before request drain, including during warmup cancellation. Core and server paths are resolved before the worker changes directories, so relative command-line paths remain valid. Each worker now forcibly owns its per-user saves/.health and saves/.health/incidents directories even when the gateway inherits shared QUNXIA_HEALTH_DIR or QUNXIA_DIAGNOSTIC_DIR values, preventing cross-user heartbeat and incident races. This depends on checkpoint lifecycle #35 (and its atomic-saver requirement #34).

The gateway is for a local/shared deployment and adds no account authentication or provider configuration. Optional cached export links are supplied by a local adapter outside this PR.

Validation: 12 gateway/multiuser tests and 9 health/worker tests passed after the isolation fix, including shared-parent environment injection, real child processes, HTTP/WebSocket forwarding, cancellation, shutdown, path isolation, and relative-path combinations. Desktop and 390px mobile lobby layouts, search/empty states and creation-error recovery were checked in the browser.