### PR TITLE
server: add indexed recording access and archive downloads

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -183,3 +183,27 @@ execution lock. A time-limit ending still validates core health before it can
 be scored as valid. Input/environment failures remain invalid. The broker
 stores diagnostics under `<result-dir>/<session-id>.diagnostics` and archives
 the last heartbeat, fault and exit status before reclaiming worker scratch.
+
+
+## Recording files and reset archives
+
+Interactive servers expose `GET /api/recordings` with a `files` list containing
+the current recording and reset archives, including their IDs, filenames and
+byte sizes. `GET /api/recordings/{id}` downloads the original JSONL as an
+attachment. Single byte ranges, open-ended ranges, suffix ranges and `If-Range`
+are supported so a large download can resume. Each response pins its file
+descriptor and byte length before streaming; a concurrent reset or append does
+not change the bytes in that response.
+
+To replay an archive, start the existing paged reader with
+`/api/recording?view=paged&recording={id}`. Continue with the returned token and
+cursor as usual; subsequent requests keep the same snapshot. `current` remains
+the default. Archive IDs must match `YYYYMMDD-HHMMSS-<12 lowercase hex>.jsonl`
+inside the recording's `recordings/` directory. Symbolic links and other file
+types are refused. Archives are opened read-only, and their replay duration is
+recovered from a bounded file tail without opening another recording writer.
+
+In benchmark mode, the file-list and download routes are absent and archive
+selection is rejected. The existing current-recording endpoint and benchmark
+accounting remain unchanged. These file selectors do not change the source of
+the right-hand screenshot history.

--- a/server/RECORDING.md
+++ b/server/RECORDING.md
@@ -18,6 +18,22 @@ MP4 rendering and its timeline publication also consume the disk recording.
 Browser MediaRecorder output chunks are still held in the browser until download;
 this change bounds the server history and replay input, not all browser memory.
 
+Paged responses advertise `seek_supported`. To seek the same pinned snapshot,
+request `?view=paged&token=<token>&time=<recorded-seconds>`. The first seek builds
+a sparse SQLite keyframe index in `.replay-index/`, returning HTTP 202 with
+`indexing`, `scanned` and `total` until ready. Normal startup and sequential
+playback do not build that index. Later opens extend cached metadata only for
+newly committed bytes of the same inode.
+
+A ready seek returns the bounded page starting at the last complete frame at
+or before the requested time (or the first frame), plus `seek.at`, `seek.origin`
+and the held keys at that cursor. Apply that frame and subsequent deltas through
+the target time. Old unmarked complete frames are recognized from their tile
+headers. The JSONL remains unchanged; reset and append cannot change an open
+reader's prefix. Closing a reader cancels its index worker, which owns and
+releases a separate descriptor. The index stores offsets/key state, not frame
+payloads; SQLite uses a 2 MiB cache and temporary data stays on disk.
+
 Cloud Run's writable container filesystem uses instance memory and disappears
 when the instance stops. A path under `/tmp` does not solve that problem. Configure
 an actual POSIX persistent volume and point `QUNXIA_RECORDING_DIR` to it; startup

--- a/server/recording.py
+++ b/server/recording.py
@@ -87,8 +87,12 @@ class RecordingAPI:
     def __init__(self, store, archives=True):
         self.store = store
         self.archives = archives
-        self.files = RecordingFiles(store)
         self.readers = {}
+
+    @property
+    def files(self):
+        # Follow a replaced writer as the original current-recording API did.
+        return RecordingFiles(self.store)
 
     def pin(self, name='current'):
         if name != 'current' and not self.archives:

--- a/server/recording.py
+++ b/server/recording.py
@@ -1,5 +1,6 @@
 """Bounded reads of an immutable prefix of the append-only recording."""
 import json
+import math
 import os
 import time
 from pathlib import Path
@@ -11,6 +12,7 @@ class Snapshot:
     def __init__(self, path, fd, end, last_timestamp=0):
         self.path, self.fd, self.end = Path(path), fd, end
         self.closed = False
+        self.seek_index = None
         try:
             _, header = next(self.lines(0))
             self.header = json.loads(header)
@@ -70,6 +72,8 @@ class Snapshot:
     def close(self):
         if not self.closed:
             self.closed = True
+            if self.seek_index:
+                self.seek_index.close()
             os.close(self.fd)
 
     def __del__(self):
@@ -111,7 +115,22 @@ class RecordingAPI:
             if request.query.get('touch') == '1':
                 return web.json_response({'ok': True})
             try:
-                return web.json_response(dict(reader.page(request.query.get('start')), token=token))
+                if 'time' in request.query:
+                    from replay_index import SeekIndex
+                    when = float(request.query['time'])
+                    if not math.isfinite(when) or when < 0:
+                        raise ValueError('seek time must be finite and non-negative')
+                    if reader.seek_index is None:
+                        reader.seek_index = SeekIndex(reader)
+                    index = reader.seek_index
+                    if not index.done.is_set():
+                        return web.json_response({'token': token, 'indexing': True,
+                                                  'scanned': index.scanned, 'total': index.total}, status=202)
+                    location = index.locate(when)
+                    return web.json_response(dict(reader.page(location['start']), token=token,
+                                                  seek=location, seek_supported=True))
+                return web.json_response(dict(reader.page(request.query.get('start')), token=token,
+                                              seek_supported=True))
             except ValueError as exc:
                 return web.json_response({'error': str(exc)}, status=400)
 

--- a/server/recording.py
+++ b/server/recording.py
@@ -5,6 +5,8 @@ import os
 import time
 from pathlib import Path
 
+from recording_files import RecordingFiles, archive_name, download
+
 MAX_LINE = 4 << 20
 
 
@@ -82,16 +84,48 @@ class Snapshot:
 
 
 class RecordingAPI:
-    def __init__(self, store):
+    def __init__(self, store, archives=True):
         self.store = store
+        self.archives = archives
+        self.files = RecordingFiles(store)
         self.readers = {}
 
-    def snapshot(self):
-        return Snapshot(**self.store.pin())
+    def pin(self, name='current'):
+        if name != 'current' and not self.archives:
+            raise FileNotFoundError('recording archives are disabled')
+        return self.files.pin(name)
+
+    def snapshot(self, name='current'):
+        return Snapshot(**self.pin(name))
+
+    async def list_files(self, request):
+        from aiohttp import web
+        if not self.archives:
+            raise web.HTTPNotFound()
+        return web.json_response({'files': self.files.listing()}, headers={'Cache-Control': 'no-store'})
+
+    async def download_file(self, request):
+        from aiohttp import web
+        if not self.archives:
+            raise web.HTTPNotFound()
+        try:
+            pin = self.pin(request.match_info['name'])
+        except FileNotFoundError:
+            raise web.HTTPNotFound()
+        return await download(pin, request)
+
+    def install(self, app):
+        from aiohttp import web
+        if self.archives:
+            app.add_routes([web.get('/api/recordings', self.list_files),
+                            web.get('/api/recordings/{name}', self.download_file)])
 
     async def handle(self, request):
         from aiohttp import web
         import uuid
+        name = request.query.get('recording', 'current')
+        if name != 'current' and (not self.archives or not archive_name(name)):
+            raise web.HTTPNotFound()
         if request.query.get('view') == 'paged':
             now = time.monotonic()
             for token, (reader, touched) in list(self.readers.items()):
@@ -103,7 +137,10 @@ class RecordingAPI:
                 if len(self.readers) >= 4:
                     return web.json_response({'error': 'too many replay readers'}, status=429)
                 token = uuid.uuid4().hex
-                self.readers[token] = (self.snapshot(), now)
+                try:
+                    self.readers[token] = (self.snapshot(name), now)
+                except FileNotFoundError:
+                    raise web.HTTPNotFound()
             elif token not in self.readers:
                 return web.json_response({'error': 'replay expired; reopen it'}, status=410)
             reader, _ = self.readers[token]
@@ -134,7 +171,10 @@ class RecordingAPI:
             except ValueError as exc:
                 return web.json_response({'error': str(exc)}, status=400)
 
-        pin = self.store.pin()
+        try:
+            pin = self.pin(name)
+        except FileNotFoundError:
+            raise web.HTTPNotFound()
         raw = request.query.get('format') == 'jsonl'
         response = web.StreamResponse(headers={'Content-Type': 'application/x-ndjson' if raw else 'application/json'})
         reader = None
@@ -146,7 +186,8 @@ class RecordingAPI:
                 for start in range(0, pin['end'], 64 << 10):
                     await response.write(os.pread(pin['fd'], min(64 << 10, pin['end']-start), start))
             else:
-                head = json.dumps({'started': reader.header['started'], 'duration': reader.elapsed})[:-1]
+                head = json.dumps({'started': reader.header['started'],
+                                   'duration': reader.elapsed if name == 'current' else reader.duration})[:-1]
                 await response.write((head + ',"events":[').encode())
                 first = True
                 payload_bytes = 0

--- a/server/recording_files.py
+++ b/server/recording_files.py
@@ -1,0 +1,168 @@
+"""Read-only access to the current journal and its named reset archives."""
+import json
+import math
+import os
+import re
+import stat
+from email.utils import formatdate, parsedate_to_datetime
+
+
+ARCHIVE_NAME = re.compile(r'\d{8}-\d{6}-[a-f0-9]{12}\.jsonl', re.ASCII)
+TAIL_BYTES = (4 << 20) + (64 << 10)
+
+
+def archive_name(name):
+    return isinstance(name, str) and ARCHIVE_NAME.fullmatch(name) is not None
+
+
+def tail_timestamp(fd, end):
+    """Recover replay duration from one bounded tail without opening a writer."""
+    start = max(0, end - TAIL_BYTES)
+    data = os.pread(fd, end - start, start)
+    if start:
+        _, _, data = data.partition(b'\n')  # discard a possible partial first line
+    last = 0.0
+    for line in data.splitlines():
+        try:
+            event = json.loads(line)
+            when = float(event.get('t', 0))
+            if math.isfinite(when) and when >= 0:
+                last = max(last, when)
+        except (ValueError, TypeError, AttributeError):
+            continue
+    return last
+
+
+def byte_range(value, size):
+    """One inclusive HTTP range, returned as a bounded Python interval."""
+    match = re.fullmatch(r'bytes=(\d*)-(\d*)', value.strip(), re.ASCII)
+    if match is None or not any(match.groups()) or not size:
+        raise ValueError('invalid range')
+    first, last = match.groups()
+    if not first:
+        length = int(last)
+        if length <= 0:
+            raise ValueError('invalid suffix range')
+        return max(0, size - length), size
+    start = int(first)
+    end = min(size, int(last) + 1) if last else size
+    if start >= size or end <= start:
+        raise ValueError('unsatisfiable range')
+    return start, end
+
+
+def matches_if_range(value, etag, modified):
+    if value.startswith(('"', 'W/')):
+        return value == etag  # a weak validator is never a match
+    try:
+        date = parsedate_to_datetime(value)
+        return date.tzinfo is not None and int(modified) <= date.timestamp()
+    except (ValueError, TypeError, OverflowError):
+        return False
+
+
+async def download(pin, request):
+    """Stream a pinned prefix; a reset cannot switch a download to a new inode."""
+    from aiohttp import web
+    from aiohttp.helpers import content_disposition_header
+
+    fd, size = pin['fd'], pin['end']
+    try:
+        status = os.fstat(fd)
+        etag = f'"{status.st_dev:x}-{status.st_ino:x}-{size:x}-{status.st_mtime_ns:x}"'
+        headers = {
+            'Content-Type': 'application/x-ndjson; charset=utf-8',
+            'Content-Disposition': content_disposition_header('attachment', filename=pin['path'].name),
+            'Accept-Ranges': 'bytes', 'Cache-Control': 'no-store', 'ETag': etag,
+            'Last-Modified': formatdate(status.st_mtime, usegmt=True),
+        }
+        start, end, response_status = 0, size, 200
+        selected = request.headers.get('Range')
+        condition = request.headers.get('If-Range')
+        if selected and (not condition or matches_if_range(condition, etag, status.st_mtime)):
+            try:
+                start, end = byte_range(selected, size)
+            except ValueError:
+                raise web.HTTPRequestRangeNotSatisfiable(headers={'Content-Range': f'bytes */{size}'})
+            response_status = 206
+            headers['Content-Range'] = f'bytes {start}-{end-1}/{size}'
+        headers['Content-Length'] = str(end - start)
+        response = web.StreamResponse(status=response_status, headers=headers)
+        await response.prepare(request)
+        if request.method != 'HEAD':
+            while start < end:
+                data = os.pread(fd, min(64 << 10, end - start), start)
+                if not data:
+                    raise OSError('pinned recording was truncated')
+                await response.write(data)
+                start += len(data)
+        await response.write_eof()
+        return response
+    finally:
+        os.close(fd)
+
+
+class RecordingFiles:
+    def __init__(self, store):
+        self.store = store
+
+    def _directory(self):
+        # The configured journal directory is trusted; the selectable archive
+        # directory and its entries must never redirect readers through links.
+        parent = os.open(self.store.path.parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            return os.open('recordings', os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                           dir_fd=parent)
+        finally:
+            os.close(parent)
+
+    def pin(self, name='current'):
+        if name == 'current':
+            return self.store.pin()
+        if not archive_name(name):
+            raise FileNotFoundError('invalid recording name')
+        folder = fd = None
+        try:
+            folder = self._directory()
+            # NONBLOCK prevents a substituted FIFO from blocking before fstat;
+            # NOFOLLOW and dir_fd also cover swaps between validation and open.
+            fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=folder)
+            status = os.fstat(fd)
+            if not stat.S_ISREG(status.st_mode):
+                raise FileNotFoundError('recording is not a regular file')
+            result = {'path': self.store.path.parent / 'recordings' / name,
+                      'fd': fd, 'end': status.st_size,
+                      'last_timestamp': tail_timestamp(fd, status.st_size)}
+            fd = None
+            return result
+        except OSError as error:
+            raise FileNotFoundError('recording is unavailable') from error
+        finally:
+            if fd is not None:
+                os.close(fd)
+            if folder is not None:
+                os.close(folder)
+
+    def listing(self):
+        pin = self.store.pin()
+        try:
+            files = [{'id': 'current', 'name': self.store.path.name, 'bytes': pin['end']}]
+        finally:
+            os.close(pin['fd'])
+        try:
+            folder = self._directory()
+        except OSError:
+            return files
+        try:
+            for name in sorted(os.listdir(folder), reverse=True):
+                if not archive_name(name):
+                    continue
+                try:
+                    status = os.stat(name, dir_fd=folder, follow_symlinks=False)
+                except OSError:
+                    continue
+                if stat.S_ISREG(status.st_mode):
+                    files.append({'id': name, 'name': name, 'bytes': status.st_size})
+        finally:
+            os.close(folder)
+        return files

--- a/server/replay_index.py
+++ b/server/replay_index.py
@@ -1,0 +1,143 @@
+"""Disposable sparse seek metadata for an existing pinned JSONL snapshot."""
+import base64
+from contextlib import closing
+import hashlib
+import json
+import math
+import os
+import sqlite3
+import struct
+import threading
+import zlib
+
+INDEX_LOCK = threading.Lock()
+
+
+def whole_frame(event):
+    data = event.get("d")
+    if not isinstance(data, str):
+        return False
+    try:
+        # Reject ordinary deltas from their header; only complete-frame
+        # candidates need a full bounded decode. Old k markers are not trusted.
+        raw = base64.b64decode(data[:4096], validate=True)
+        header = zlib.decompressobj().decompress(raw, 13)
+        if len(header) != 13:
+            return False
+        _flag, w, h, tw, th, cols, rows, count = struct.unpack("<BHHBBHHH", header)
+        if not (0 < w <= 2048 and 0 < h <= 2048 and tw > 0 and th > 0
+                and cols == (w + tw - 1) // tw and rows == (h + th - 1) // th
+                and count == cols * rows):
+            return False
+        expected = 13 + count * (2 + tw * th * 3)
+        if expected > 16 << 20:
+            return False
+        inflater = zlib.decompressobj()
+        payload = inflater.decompress(base64.b64decode(data, validate=True), expected + 1)
+        if len(payload) != expected or not inflater.eof:
+            return False
+        indices = struct.unpack_from(f"<{count}H", payload, 13)
+        return len(set(indices)) == count and all(index < count for index in indices)
+    except (ValueError, zlib.error, struct.error):
+        return False
+
+
+class SeekIndex:
+    def __init__(self, source):
+        from recording import Snapshot
+        stat = os.fstat(source.fd)
+        directory = source.path.parent / ".replay-index"
+        directory.mkdir(exist_ok=True)
+        self.path = directory / f"{stat.st_dev}-{stat.st_ino}.sqlite3"
+        self.cancelled = threading.Event()
+        self.done = threading.Event()
+        self.error = None
+        self.scanned = source.begin
+        self.total = source.end
+        self.source = Snapshot(source.path, os.dup(source.fd), source.end, source.duration)
+        try:
+            self.thread = threading.Thread(target=self.build, daemon=True)
+            self.thread.start()
+        except BaseException:
+            self.source.close()
+            raise
+
+    def build(self):
+        db = None
+        acquired = False
+        try:
+            while not self.cancelled.is_set():
+                if INDEX_LOCK.acquire(timeout=.1):
+                    acquired = True
+                    break
+            if not acquired:
+                return
+            db = sqlite3.connect(self.path)
+            db.execute("PRAGMA journal_mode=WAL")
+            db.execute("PRAGMA cache_size=-2048")
+            db.execute("PRAGMA temp_store=FILE")
+            db.executescript("""
+                CREATE TABLE IF NOT EXISTS frames (off INTEGER PRIMARY KEY, t REAL, held TEXT);
+                CREATE INDEX IF NOT EXISTS frame_time ON frames(t,off);
+                CREATE TABLE IF NOT EXISTS metadata (id INTEGER PRIMARY KEY, value TEXT);
+            """)
+            row = db.execute("SELECT value FROM metadata WHERE id=1").fetchone()
+            progress = json.loads(row[0]) if row else {}
+            signature = hashlib.sha256(json.dumps(self.source.header, sort_keys=True).encode()).hexdigest()
+            if (progress.get("header") != signature
+                    or progress.get("end", 0) > os.fstat(self.source.fd).st_size):
+                db.execute("DELETE FROM frames")
+                progress = {}
+            start = progress.get("end", self.source.begin)
+            self.scanned = min(start, self.total)
+            last = progress.get("last", 0.0)
+            held = progress.get("held", {})
+            if start < self.total:
+                for offset, line in self.source.lines(start):
+                    if self.cancelled.is_set():
+                        return
+                    event = json.loads(line)
+                    when = float(event["t"])
+                    if not math.isfinite(when) or when < 0:
+                        raise ValueError("invalid recording timestamp")
+                    last = max(last, when)
+                    if whole_frame(event):
+                        db.execute("INSERT OR REPLACE INTO frames VALUES (?,?,?)",
+                                   (offset, last, json.dumps(held)))
+                    key = event.get("key")
+                    if isinstance(key, str) and len(key) <= 32:
+                        if event.get("down"):
+                            if len(held) < 256 or key in held:
+                                held[key] = str(event.get("who", ""))[:80]
+                        else:
+                            held.pop(key, None)
+                    self.scanned = offset + len(line)
+                progress = {"end": self.scanned, "last": last, "held": held, "header": signature}
+                db.execute("INSERT OR REPLACE INTO metadata VALUES (1,?)", (json.dumps(progress),))
+            db.commit()
+        except Exception as exc:
+            self.error = str(exc)
+        finally:
+            if db:
+                db.close()
+            if acquired:
+                INDEX_LOCK.release()
+            self.source.close()
+            self.done.set()
+
+    def locate(self, when):
+        if self.error:
+            raise ValueError(self.error)
+        with closing(sqlite3.connect(self.path, timeout=.1)) as db:
+            first = db.execute("SELECT off,t,held FROM frames WHERE off<? ORDER BY off LIMIT 1",
+                               (self.total,)).fetchone()
+            if first is None:
+                raise ValueError("recording has no complete frame")
+            row = db.execute("SELECT off,t,held FROM frames WHERE t<=? AND off<? "
+                             "ORDER BY t DESC,off DESC LIMIT 1", (when, self.total)).fetchone() or first
+        return {"start": row[0], "at": row[1], "held": json.loads(row[2]), "origin": first[1]}
+
+    def close(self):
+        # The worker owns a duplicate fd and closes it itself. Cancellation
+        # never closes a descriptor while its indexing thread is reading it.
+        self.cancelled.set()

--- a/server/server.py
+++ b/server/server.py
@@ -2308,7 +2308,7 @@ def main():
     path = pathlib.Path(os.environ.get("QUNXIA_RECORDING_FILE", str(pathlib.Path(directory) / f"{PORT}.jsonl")))
     validate_recording_directory(path.parent)
     recording_store = RecordingStore(path)
-    recording_api = RecordingAPI(recording_store)
+    recording_api = RecordingAPI(recording_store, archives=not warden.ON)
     rec.update(started=recording_store.started, events=[], bytes=recording_store.committed_size)
     health = Health(LIB.core_ticks, paused.is_set, os.environ.get("QUNXIA_HEALTH_DIR", str(pathlib.Path(SAVES) / ".health")))
     health.start()
@@ -2348,6 +2348,7 @@ def main():
         web.post("/api/save", api_save),
         web.post("/api/load", api_load),
     ])
+    recording_api.install(app)
     # Startup handlers are awaited, so the workers are detached tasks rather
     # than returned, or startup would block on loops that never end.
     app.on_startup.append(startup)

--- a/server/test_recording_archives.py
+++ b/server/test_recording_archives.py
@@ -1,0 +1,345 @@
+"""HTTP regressions for immutable current and archived recording reads."""
+import asyncio
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+from urllib.parse import quote
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from recording import RecordingAPI
+from recording_store import RecordingStore
+
+
+class RecordingArchiveTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.path = self.root / 'current.jsonl'
+        self.store = RecordingStore(self.path, started=10)
+        self.addCleanup(self.store.close)
+        self.old_events = [
+            {'t': 1, 'key': 'up', 'down': True},
+            {'t': 7.25, 'key': 'up', 'down': False, 'note': '旧录像'},
+        ]
+        for event in self.old_events:
+            self.assertTrue(self.store.append(event))
+        self.archive = self.store.reset(20)
+        self.current_events = [{'t': 2, 'key': 'left', 'down': True}]
+        for event in self.current_events:
+            self.assertTrue(self.store.append(event))
+        self.api, self.client = await self.make_client(archives=True)
+
+    async def make_client(self, archives):
+        api = RecordingAPI(self.store, archives=archives)
+        self.addCleanup(api.close)
+        app = web.Application()
+        app.router.add_get('/api/recording', api.handle)
+        api.install(app)
+        client = TestClient(TestServer(app))
+        await client.start_server()
+        self.addAsyncCleanup(client.close)
+        return api, client
+
+    async def get_json(self, query, client=None, status=200):
+        async with (client or self.client).get('/api/recording', params=query) as response:
+            self.assertEqual(response.status, status, await response.text())
+            return await response.json()
+
+    def download_path(self, name):
+        return '/api/recordings/' + quote(name, safe='')
+
+    async def inventory(self):
+        async with self.client.get('/api/recordings') as response:
+            self.assertEqual(response.status, 200, await response.text())
+            return (await response.json())['files']
+
+    async def test_inventory_includes_current_and_archive_sizes(self):
+        entries = {entry['id']: entry for entry in await self.inventory()}
+        self.assertEqual(set(entries), {'current', self.archive.name})
+        self.assertEqual(entries['current']['bytes'], self.path.stat().st_size)
+        self.assertEqual(entries[self.archive.name]['bytes'], self.archive.stat().st_size)
+        self.assertEqual(entries[self.archive.name]['name'], self.archive.name)
+        self.assertTrue(entries['current']['name'])
+
+    async def test_full_current_and_archive_downloads_are_exact_attachments(self):
+        for name, path in [('current', self.path), (self.archive.name, self.archive)]:
+            with self.subTest(recording=name):
+                expected = path.read_bytes()
+                async with self.client.get(self.download_path(name)) as response:
+                    self.assertEqual(response.status, 200, await response.text())
+                    self.assertEqual(await response.read(), expected)
+                    self.assertEqual(response.headers['Content-Length'], str(len(expected)))
+                    self.assertEqual(response.headers['Accept-Ranges'], 'bytes')
+                    self.assertIn('attachment;', response.headers['Content-Disposition'])
+                    self.assertIn('.jsonl', response.headers['Content-Disposition'])
+                    self.assertEqual(response.content_type, 'application/x-ndjson')
+
+    async def test_bounded_open_ended_suffix_and_clamped_ranges_are_exact(self):
+        for name, path in [('current', self.path), (self.archive.name, self.archive)]:
+            expected = path.read_bytes()
+            ranges = [
+                ('bytes=3-31', 3, 31),
+                ('bytes=5-', 5, len(expected) - 1),
+                ('bytes=-19', len(expected) - 19, len(expected) - 1),
+                ('bytes=0-999999', 0, len(expected) - 1),
+                ('bytes=-999999', 0, len(expected) - 1),
+            ]
+            for header, start, end in ranges:
+                with self.subTest(recording=name, range=header):
+                    async with self.client.get(self.download_path(name), headers={'Range': header}) as response:
+                        self.assertEqual(response.status, 206, await response.text())
+                        self.assertEqual(await response.read(), expected[start:end + 1])
+                        self.assertEqual(response.headers['Content-Length'], str(end - start + 1))
+                        self.assertEqual(response.headers['Content-Range'], f'bytes {start}-{end}/{len(expected)}')
+
+    async def test_malformed_multiple_and_unsatisfiable_ranges_return_416(self):
+        for name, path in [('current', self.path), (self.archive.name, self.archive)]:
+            size = path.stat().st_size
+            for header in [
+                'bytes=wrong', 'bytes=', 'bytes=8-3', 'bytes=-0',
+                'bytes=0-1,3-4', 'items=0-4', f'bytes={size}-',
+            ]:
+                with self.subTest(recording=name, range=header):
+                    async with self.client.get(self.download_path(name), headers={'Range': header}) as response:
+                        self.assertEqual(response.status, 416, await response.text())
+                        self.assertEqual(response.headers['Content-Range'], f'bytes */{size}')
+
+    async def test_if_range_requires_the_matching_validator(self):
+        expected = self.archive.read_bytes()
+        url = self.download_path(self.archive.name)
+        async with self.client.get(url) as response:
+            self.assertEqual(response.status, 200)
+            validators = [response.headers['ETag'], response.headers['Last-Modified']]
+            await response.read()
+        for validator in validators:
+            with self.subTest(validator=validator):
+                async with self.client.get(url, headers={'Range': 'bytes=1-9', 'If-Range': validator}) as response:
+                    self.assertEqual(response.status, 206, await response.text())
+                    self.assertEqual(await response.read(), expected[1:10])
+        for validator in ['"unrelated-recording"', 'Wed, 21 Oct 2015 07:28:00 GMT']:
+            with self.subTest(stale_validator=validator):
+                async with self.client.get(url, headers={'Range': 'bytes=1-9', 'If-Range': validator}) as response:
+                    self.assertEqual(response.status, 200, await response.text())
+                    self.assertEqual(await response.read(), expected)
+                    self.assertNotIn('Content-Range', response.headers)
+
+    async def test_current_download_keeps_its_prefix_during_append_and_reset(self):
+        self.assertTrue(self.store.append({'t': 3, 'd': 'x' * (192 << 10)}))
+        expected = self.path.read_bytes()
+        first_write = asyncio.Event()
+        release_write = asyncio.Event()
+        original_write = web.StreamResponse.write
+        write_count = 0
+
+        async def gated_write(response, data):
+            nonlocal write_count
+            write_count += 1
+            if write_count == 1:
+                first_write.set()
+                await release_write.wait()
+            return await original_write(response, data)
+
+        async def download():
+            async with self.client.get(self.download_path('current')) as response:
+                return response.status, dict(response.headers), await response.read()
+
+        with mock.patch.object(web.StreamResponse, 'write', new=gated_write):
+            transfer = asyncio.create_task(download())
+            try:
+                await asyncio.wait_for(first_write.wait(), 5)
+                self.assertTrue(self.store.append({'t': 4, 'note': 'late old-session append'}))
+                archived = self.store.reset(30)
+                self.assertTrue(self.store.append({'t': 1, 'note': 'new session'}))
+                release_write.set()
+                status, headers, actual = await asyncio.wait_for(transfer, 5)
+            finally:
+                release_write.set()
+                if not transfer.done():
+                    transfer.cancel()
+                    await asyncio.gather(transfer, return_exceptions=True)
+        self.assertEqual(status, 200)
+        self.assertGreater(write_count, 1)
+        self.assertEqual(actual, expected)
+        self.assertEqual(headers['Content-Length'], str(len(expected)))
+        self.assertIn(b'late old-session append', archived.read_bytes())
+        self.assertIn(b'new session', self.path.read_bytes())
+
+    async def test_current_range_still_reads_the_old_inode_after_headers_are_sent(self):
+        expected = self.path.read_bytes()
+        original_prepare = web.StreamResponse.prepare
+        replaced = False
+
+        async def reset_after_headers(response, request):
+            nonlocal replaced
+            result = await original_prepare(response, request)
+            if response.status == 206 and not replaced:
+                replaced = True
+                self.store.reset(30)
+                self.store.append({'t': 1, 'note': 'replacement current recording'})
+            return result
+
+        with mock.patch.object(web.StreamResponse, 'prepare', new=reset_after_headers):
+            async with self.client.get(self.download_path('current'), headers={'Range': 'bytes=7-55'}) as response:
+                self.assertEqual(response.status, 206)
+                self.assertEqual(await response.read(), expected[7:56])
+                self.assertEqual(response.headers['Content-Range'], f'bytes 7-55/{len(expected)}')
+        self.assertTrue(replaced)
+        self.assertIn(b'replacement current recording', self.path.read_bytes())
+
+    async def test_current_listing_and_download_exclude_an_uncommitted_suffix(self):
+        expected = self.path.read_bytes()
+        os.write(self.store.fd, b'{"t":999,"incomplete":')
+        current = next(row for row in await self.inventory() if row['id'] == 'current')
+        self.assertEqual(current['bytes'], len(expected))
+        async with self.client.get(self.download_path('current')) as response:
+            self.assertEqual(response.status, 200)
+            self.assertEqual(await response.read(), expected)
+            self.assertEqual(response.headers['Content-Length'], str(len(expected)))
+
+    async def test_archive_reader_and_duration_survive_name_replacement(self):
+        first = await self.get_json({'view': 'paged', 'recording': self.archive.name})
+        self.assertEqual(first['events'], self.old_events)
+        self.assertEqual(first['duration'], 7.25)
+        replacement = self.root / 'replacement.jsonl'
+        replacement_events = [{'t': 90, 'note': 'replacement'}]
+        replacement.write_bytes(
+            (json.dumps({'version': 1, 'started': 80}) + '\n' +
+             json.dumps(replacement_events[0]) + '\n').encode())
+        os.replace(replacement, self.archive)
+        self.store.reset(30)
+        old = await self.get_json({'view': 'paged', 'token': first['token']})
+        self.assertEqual(old, first)
+        fresh = await self.get_json({'view': 'paged', 'recording': self.archive.name})
+        self.assertEqual(fresh['events'], replacement_events)
+        self.assertEqual(fresh['started'], 80)
+        self.assertEqual(fresh['duration'], 90)
+
+    async def test_archive_tail_duration_and_reads_do_not_open_a_writer(self):
+        # Enough data to put the origin outside the bounded timestamp tail.
+        for index in range(5):
+            self.assertTrue(self.store.append({'t': index * 37.5, 'd': 'a' * (1 << 20)}))
+        self.assertTrue(self.store.append({'t': 187.5, 'key': 'esc', 'down': True}))
+        archive = self.store.reset(30)
+        expected = archive.read_bytes()
+        names_before = set(archive.parent.iterdir())
+        with mock.patch.object(RecordingStore, '__init__', side_effect=AssertionError('archive opened as a writer')):
+            reader = self.api.snapshot(archive.name)
+            try:
+                self.assertEqual(reader.duration, 187.5)
+                self.assertEqual(reader.header['started'], 20)
+                self.assertEqual(reader.end, len(expected))
+            finally:
+                reader.close()
+            async with self.client.get(self.download_path(archive.name)) as response:
+                self.assertEqual(response.status, 200, await response.text())
+                self.assertEqual(await response.read(), expected)
+        self.assertEqual(archive.read_bytes(), expected)
+        self.assertEqual(set(archive.parent.iterdir()), names_before)
+
+    async def test_archive_pages_can_traverse_refetch_touch_and_close(self):
+        events = [{'t': index + 10, 'd': str(index) * (550 << 10)} for index in range(5)]
+        for event in events:
+            self.assertTrue(self.store.append(event))
+        archive = self.store.reset(30)
+        expected = self.current_events + events
+        first = await self.get_json({'view': 'paged', 'recording': archive.name})
+        self.assertFalse(first['done'])
+        token = first['token']
+        collected = list(first['events'])
+        cursor = first['next']
+        starts = []
+        while not first['done']:
+            starts.append(cursor)
+            page = await self.get_json({'view': 'paged', 'token': token, 'start': str(cursor)})
+            repeated = await self.get_json({'view': 'paged', 'token': token, 'start': str(cursor)})
+            self.assertEqual(repeated, page)
+            self.assertEqual(page['token'], token)
+            self.assertGreater(page['next'], cursor)
+            self.assertEqual(page['end'], first['end'])
+            collected.extend(page['events'])
+            cursor = page['next']
+            if page['done']:
+                self.assertEqual(cursor, page['end'])
+                break
+        self.assertGreaterEqual(len(starts), 2)
+        self.assertEqual(collected, expected)
+        self.assertEqual(await self.get_json({'view': 'paged', 'token': token, 'touch': '1'}), {'ok': True})
+        closed = await self.get_json({'view': 'paged', 'token': token, 'close': '1'})
+        self.assertEqual(closed, {'ok': True})
+        self.assertNotIn(token, self.api.readers)
+        await self.get_json({'view': 'paged', 'token': token}, status=410)
+
+    async def test_invalid_names_and_traversal_are_rejected(self):
+        names = [
+            '../current.jsonl', '../recordings/' + self.archive.name,
+            '/etc/passwd', 'current.jsonl', self.archive.name.upper(),
+            '20260909-123456-123456789ab.jsonl',
+            '20260909-123456-123456789abc.jsonl.bak',
+            '20260909-123456-123456789abc.jsonl',
+        ]
+        for name in names:
+            with self.subTest(recording=name):
+                async with self.client.get('/api/recording', params={'view': 'paged', 'recording': name}) as response:
+                    self.assertEqual(response.status, 404, await response.text())
+                async with self.client.get(self.download_path(name)) as response:
+                    self.assertEqual(response.status, 404, await response.text())
+        self.assertFalse(self.api.readers)
+
+    async def test_inventory_omits_foreign_files_directories_and_file_symlinks(self):
+        folder = self.archive.parent
+        (folder / 'README.txt').write_text('not a recording')
+        (folder / '20260909-123456-aaaaaaaaaaaa.jsonl').mkdir()
+        linked_name = '20260909-123456-bbbbbbbbbbbb.jsonl'
+        (folder / linked_name).symlink_to(self.path)
+        entries = {entry['id'] for entry in await self.inventory()}
+        self.assertEqual(entries, {'current', self.archive.name})
+        async with self.client.get(self.download_path(linked_name)) as response:
+            self.assertEqual(response.status, 404, await response.text())
+        async with self.client.get('/api/recording', params={'view': 'paged', 'recording': linked_name}) as response:
+            self.assertEqual(response.status, 404, await response.text())
+
+    async def test_symlink_archive_directory_is_not_followed(self):
+        folder = self.archive.parent
+        target = self.root / 'outside-recordings'
+        original = self.archive.read_bytes()
+        folder.rename(target)
+        folder.symlink_to(target, target_is_directory=True)
+        self.assertEqual({entry['id'] for entry in await self.inventory()}, {'current'})
+        async with self.client.get(self.download_path(self.archive.name)) as response:
+            self.assertEqual(response.status, 404, await response.text())
+        async with self.client.get('/api/recording', params={'view': 'paged', 'recording': self.archive.name}) as response:
+            self.assertEqual(response.status, 404, await response.text())
+        async with self.client.get(self.download_path('current')) as response:
+            self.assertEqual(response.status, 200, await response.text())
+            self.assertEqual(await response.read(), self.path.read_bytes())
+        self.assertEqual((target / self.archive.name).read_bytes(), original)
+
+    async def test_benchmark_mode_has_no_archive_routes_or_selection(self):
+        api, client = await self.make_client(archives=False)
+        for url in ['/api/recordings', self.download_path('current'), self.download_path(self.archive.name)]:
+            async with client.get(url) as response:
+                self.assertEqual(response.status, 404, await response.text())
+        for query in [
+            {'view': 'paged', 'recording': self.archive.name},
+            {'format': 'jsonl', 'recording': self.archive.name},
+            {'recording': self.archive.name},
+        ]:
+            async with client.get('/api/recording', params=query) as response:
+                self.assertEqual(response.status, 404, await response.text())
+        self.assertFalse(api.readers)
+        for query in [{'format': 'jsonl'}, {'format': 'jsonl', 'recording': 'current'}]:
+            async with client.get('/api/recording', params=query) as response:
+                self.assertEqual(response.status, 200, await response.text())
+                self.assertEqual(await response.read(), self.path.read_bytes())
+        page = await self.get_json({'view': 'paged'}, client=client)
+        self.assertEqual(page['events'], self.current_events)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/test_recording_archives.py
+++ b/server/test_recording_archives.py
@@ -242,6 +242,23 @@ class RecordingArchiveTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(archive.read_bytes(), expected)
         self.assertEqual(set(archive.parent.iterdir()), names_before)
 
+    async def test_replacing_writer_updates_new_reads_without_repointing_old_tokens(self):
+        old = await self.get_json({'view': 'paged'})
+        self.store.close()
+        replacement = RecordingStore(self.root / 'other' / 'replacement.jsonl', started=99)
+        self.addCleanup(replacement.close)
+        replacement.append({'t': 3, 'key': 'down', 'down': True})
+        self.api.store = replacement
+        fresh = await self.get_json({'view': 'paged'})
+        retained = await self.get_json({'view': 'paged', 'token': old['token']})
+        self.assertEqual(fresh['started'], 99)
+        self.assertEqual(retained['started'], 20)
+        response = await self.client.get('/api/recordings')
+        files = (await response.json())['files']
+        self.assertEqual([file['name'] for file in files], ['replacement.jsonl'])
+        response = await self.client.get('/api/recordings/current')
+        self.assertEqual(await response.read(), replacement.path.read_bytes())
+
     async def test_archive_pages_can_traverse_refetch_touch_and_close(self):
         events = [{'t': index + 10, 'd': str(index) * (550 << 10)} for index in range(5)]
         for event in events:

--- a/server/test_replay_index.py
+++ b/server/test_replay_index.py
@@ -1,0 +1,149 @@
+"""Seek the existing recording format while keeping pages and indexes bounded."""
+import asyncio
+import base64
+import json
+import os
+from pathlib import Path
+import struct
+import tempfile
+import unittest
+import zlib
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from recording import RecordingAPI
+from recording_store import RecordingStore
+
+
+def frame(when, color, marked=True):
+    payload = struct.pack("<BHHBBHHHH", 1, 1, 1, 1, 1, 1, 1, 1, 0) + bytes(color)
+    event = {"t": when, "d": base64.b64encode(zlib.compress(payload)).decode()}
+    if marked:
+        event["k"] = 1
+    return event
+
+
+class ReplayIndexTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="qunxia-seek-")
+        self.path = Path(self.temp.name) / "recording.jsonl"
+        self.store = RecordingStore(self.path, started=100)
+        for event in [frame(5, (255, 0, 0), marked=False),
+                      {"t": 6, "key": "enter", "down": True, "who": "fixture"},
+                      frame(7, (0, 255, 0)), {"t": 8, "key": "enter", "down": False},
+                      frame(9, (0, 0, 255))]:
+            self.assertTrue(self.store.append(event))
+        self.api = RecordingAPI(self.store)
+        app = web.Application()
+        app.router.add_get("/api/recording", self.api.handle)
+        self.client = TestClient(TestServer(app))
+        await self.client.start_server()
+
+    async def asyncTearDown(self):
+        indexes = [r.seek_index for r, _ in self.api.readers.values() if r.seek_index]
+        self.api.close()
+        for index in indexes:
+            self.assertTrue(await asyncio.to_thread(index.done.wait, 3))
+        await self.client.close()
+        self.store.close()
+        self.temp.cleanup()
+
+    async def open(self):
+        return await (await self.client.get("/api/recording?view=paged")).json()
+
+    async def seek(self, token, when):
+        for _ in range(100):
+            response = await self.client.get("/api/recording", params={"view": "paged", "token": token, "time": when})
+            data = await response.json()
+            if response.status != 202:
+                self.assertEqual(response.status, 200, data)
+                return data
+            self.assertLessEqual(data["scanned"], data["total"])
+            await asyncio.sleep(.01)
+        self.fail("seek index did not finish")
+
+    async def test_start_and_bidirectional_seek_return_complete_frames_and_key_state(self):
+        original = self.path.read_bytes()
+        first = await self.open()
+        reader = self.api.readers[first["token"]][0]
+        self.assertIsNone(reader.seek_index, "ordinary playback does not start indexing")
+        for when, expected, held in [(0, 5, {}), (9, 9, {}), (7.5, 7, {"enter": "fixture"}), (5, 5, {})]:
+            data = await self.seek(first["token"], when)
+            self.assertEqual(data["events"][0]["t"], expected)
+            self.assertEqual(data["seek"]["held"], held)
+            self.assertEqual(data["seek"]["origin"], 5)
+        self.assertEqual(self.path.read_bytes(), original)
+
+    async def test_reader_remains_pinned_across_append_and_reset(self):
+        first = await self.open()
+        self.store.append(frame(10, (20, 30, 40)))
+        self.store.reset(200)
+        self.store.append(frame(0, (100, 100, 100)))
+        old = await self.seek(first["token"], 100)
+        self.assertEqual(old["events"][0]["t"], 9)
+        new = await self.open()
+        fresh = await self.seek(new["token"], 0)
+        self.assertEqual(fresh["events"][0]["t"], 0)
+
+    async def test_invalid_seek_and_expired_token_are_rejected(self):
+        first = await self.open()
+        for when in ("nan", "inf", "-1", "bad"):
+            response = await self.client.get("/api/recording", params={"view": "paged", "token": first["token"], "time": when})
+            self.assertEqual(response.status, 400)
+        await self.client.get("/api/recording", params={"view": "paged", "token": first["token"], "close": "1"})
+        response = await self.client.get("/api/recording", params={"view": "paged", "token": first["token"], "time": 0})
+        self.assertEqual(response.status, 410)
+
+    async def test_truncated_keyframe_marker_is_not_an_index_anchor(self):
+        broken = frame(0, (1, 2, 3))
+        payload = zlib.decompress(base64.b64decode(broken["d"]))[:-2]
+        broken["d"] = base64.b64encode(zlib.compress(payload)).decode()
+        self.store.close()
+        header, rest = self.path.read_bytes().split(b"\n", 1)
+        self.path.write_bytes(header + b"\n" + json.dumps(broken).encode() + b"\n" + rest)
+        self.store = RecordingStore(self.path)
+        self.api.store = self.store
+        first = await self.open()
+        page = await self.seek(first["token"], 0)
+        self.assertEqual(page["seek"]["origin"], 5)
+        self.assertEqual(page["events"][0]["t"], 5)
+
+    async def test_closing_an_indexing_reader_releases_its_duplicate_descriptor(self):
+        from replay_index import INDEX_LOCK
+        first = await self.open()
+        reader = self.api.readers[first["token"]][0]
+        with INDEX_LOCK:
+            response = await self.client.get("/api/recording", params={"view": "paged", "token": first["token"], "time": 0})
+            self.assertEqual(response.status, 202)
+            index = reader.seek_index
+            fd = index.source.fd
+            await self.client.get("/api/recording", params={"view": "paged", "token": first["token"], "close": "1"})
+        self.assertTrue(await asyncio.to_thread(index.done.wait, 3))
+        with self.assertRaises(OSError):
+            os.fstat(fd)
+
+    async def test_large_event_history_stays_on_disk_and_seek_pages_remain_bounded(self):
+        self.store.close()
+        with self.path.open("ab") as stream:
+            for n in range(100000):
+                stream.write((json.dumps({"t": n + 10, "act": "GET", "label": "look"}) + "\n").encode())
+            stream.write((json.dumps(frame(100010, (200, 200, 200))) + "\n").encode())
+        self.store = RecordingStore(self.path)
+        self.api.store = self.store
+        first = await self.open()
+        page = await self.seek(first["token"], 50000)
+        self.assertLessEqual(len(page["events"]), 2048)
+        self.assertLess(len(json.dumps(page)), 1 << 20)
+        self.assertFalse(page["done"])
+        import sqlite3
+        index = self.api.readers[first["token"]][0].seek_index
+        db = sqlite3.connect(index.path)
+        try:
+            self.assertEqual(db.execute("SELECT count(*) FROM frames").fetchone()[0], 4)
+        finally:
+            db.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Extend the existing pinned recording API with lazy indexed seeking and read-only archive access. Normal startup and sequential playback keep bounded reads; the first explicit seek builds a disposable sparse SQLite index and reports progress, and later seeks reuse or incrementally extend it. Old unmarked complete frames are recognized from their payload. The JSONL remains unchanged.

GET /api/recordings lists current and archived journals. /api/recordings/<name> downloads a fixed-prefix JSONL attachment with Range and If-Range support. Named archives can be selected on the first paged request; subsequent requests retain their pinned token even after reset or filename replacement. Files are opened read-only through validated directory descriptors, rejecting traversal, symlinks and non-regular files. Duration comes from bounded tail metadata. Replacing the active writer changes new reads without repointing existing readers.

Benchmark mode keeps its existing current-recording endpoint and does not expose archive routes or selection. PR #38 supplies playback controls and the restored recordings menu. The archive work previously split into #40 is now fully included here, so no separate archive PR is needed.

Validation: 30 recording/archive tests and 6 seek-index tests passed. Coverage includes exact Range bytes, reset while streaming, fixed older snapshots, source replacement, malformed paths, benchmark isolation, bounded seek pages and index cancellation. The resulting recording.py, recording_files.py and archive regression suite match the verified local integration byte-for-byte.