### PR TITLE
web: add action playback and background video export

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,11 +462,13 @@ that also carries input. A dialogue update is about 60 tiles and 5 KB; an idle
 screen sends nothing.
 
 Every session is recorded as those tile deltas plus the keys that caused them,
-appended to a JSONL journal on disk. The activity panel defaults to action
-playback: one saved action per 0.6 seconds before the selected speed is applied,
-skipping idle gaps. It shows the action, actor and original recording time, and
-loads only a small window of frames. The mode selector also offers the original
-continuous recording. MP4 export runs on the server, with progress, cancellation
+appended to a JSONL journal on disk. The activity panel plays saved actions:
+one action per 0.6 seconds before the selected speed is applied, skipping idle
+gaps. It shows the action and actor, with elapsed time from the start of the
+original recording displayed to the millisecond separately from playback
+progress. Original times beyond 24 hours do not wrap. Both current and archived recordings use this action
+playback and load only a small window of frames; the complete source journal
+remains on disk. MP4 export runs on the server, with progress, cancellation
 and a download button; it stays active after a page reload and does not block
 playback. Action playback and export require the saved-history backend; an
 unavailable backend is shown explicitly. The benchmark keeps its own ffmpeg

--- a/README.md
+++ b/README.md
@@ -462,9 +462,15 @@ that also carries input. A dialogue update is about 60 tiles and 5 KB; an idle
 screen sends nothing.
 
 Every session is recorded as those tile deltas plus the keys that caused them,
-appended to a JSONL journal on disk. The activity panel replays at 4x and
-exports an MP4 in the browser; the benchmark renders the same journal with
-ffmpeg.
+appended to a JSONL journal on disk. The activity panel defaults to action
+playback: one saved action per 0.6 seconds before the selected speed is applied,
+skipping idle gaps. It shows the action, actor and original recording time, and
+loads only a small window of frames. The mode selector also offers the original
+continuous recording. MP4 export runs on the server, with progress, cancellation
+and a download button; it stays active after a page reload and does not block
+playback. Action playback and export require the saved-history backend; an
+unavailable backend is shown explicitly. The benchmark keeps its own ffmpeg
+rendering path.
 
 ## Emulated CPU speed
 

--- a/Scripts/test-replay.mjs
+++ b/Scripts/test-replay.mjs
@@ -223,7 +223,7 @@ function replayDOM() {
       await this['on'+type]?.(event);
     }
     focus() { document.activeElement=this; this.focusCalls=(this.focusCalls || 0)+1; }
-    getContext() { return {fillRect(){}}; }
+    getContext() { const canvas=this; return {fillRect(){},drawImage(image){canvas.image=image;}}; }
   }
   return {document, elements};
 }
@@ -624,9 +624,9 @@ test('closing while the action token is opening still releases the late token an
   assert.equal(f.requests[1].options.method,'DELETE');
 });
 
-test('missing action history gives an explicit full-recording choice without falling back to a long replay', async () => {
+test('missing action history gives a retryable error without falling back to a long replay', async () => {
   const f=stepSourceVM(()=>jsonReply({},404));
-  await assert.rejects(f.Source.open(),/选择.*完整录制/);
+  await assert.rejects(f.Source.open(),/动作历史.*请重试/);
   assert.equal(f.requests.length,1);
 });
 
@@ -640,44 +640,91 @@ test('action source fallback decoding revokes object URLs even when decoding fai
   assert.deepEqual(revoked,made);
 });
 
-test('the playback mode selector retains the selected archive and explicitly opens the complete recording', async () => {
+test('all current and archived playback uses actions with no continuous recording option or fallback', async () => {
   const html=readFileSync(new URL('../server/index.html',import.meta.url),'utf8');
+  assert.doesNotMatch(html,/vcrmode|完整录制|ReplayRecording\.open|new ReplayPlayer/);
   const begin=html.indexOf('const vcr = document.getElementById("vcr")');
   const end=html.indexOf('// ---- export the recording',begin);
   const dom=replayDOM(), opened=[], closed=[];
   class Player {async start(){} close(){}}
   const context=vm.createContext({document:dom.document,addEventListener(){},AbortController,
-    ReplayKeys,GLYPH:{},ARROW:new Set(),colorOf:()=>'',ActionReplayPlayer:Player,ReplayPlayer:Player,
-    StepReplaySource:{open:async name=>{opened.push(['actions',name]);return {close:()=>closed.push(name)};}},
-    ReplayRecording:{open:async name=>{opened.push(['full',name]);return {close:()=>closed.push(name)};}},
+    ReplayKeys,GLYPH:{},ARROW:new Set(),colorOf:()=>'',ActionReplayPlayer:Player,
+    ReplayPlayer:class {constructor(){throw Error('Continuous replay is forbidden');}},
+    StepReplaySource:{open:async name=>{opened.push(name);return {close:()=>closed.push(name)};}},
+    ReplayRecording:{open:()=>{throw Error('Raw recording API fallback is forbidden');}},
   });
   vm.runInContext(html.slice(begin,end)+'\n'+namedHTMLFunction(html,'openPlayback'),context);
+  await context.openPlayback();
+  context.vcrClose();
   await context.openPlayback('archive.jsonl');
-  assert.equal(dom.document.getElementById('vcrmode').value,'actions');
-  dom.document.getElementById('vcrmode').value='full';
-  await dom.document.getElementById('vcrmode').dispatch('change');
-  assert.deepEqual(opened,[['actions','archive.jsonl'],['full','archive.jsonl']]);
-  assert.ok(closed.includes('archive.jsonl'));
-  assert.match(dom.document.getElementById('vcrstatus').textContent,/保留原始空闲/);
+  assert.deepEqual(opened,['current','archive.jsonl']);
+  assert.ok(closed.includes('current'));
   assert.equal(dom.document.activeElement,dom.document.getElementById('vcrclose'));
   context.vcrClose();
 });
 
-test('unsupported action playback leaves the mode selector available and reports the actionable error in the viewer', async () => {
+test('unsupported action playback shows a retryable error and retries the same archive without a raw API fallback', async () => {
+  const html=readFileSync(new URL('../server/index.html',import.meta.url),'utf8');
+  const begin=html.indexOf('const vcr = document.getElementById("vcr")');
+  const end=html.indexOf('// ---- export the recording',begin);
+  const dom=replayDOM(), opened=[];
+  const context=vm.createContext({document:dom.document,addEventListener(){},AbortController,
+    ReplayKeys,GLYPH:{},ARROW:new Set(),colorOf:()=>'',
+    ActionReplayPlayer:class {async start(){} close(){}},
+    StepReplaySource:{open:async name=>{
+      opened.push(name);
+      if(opened.length===1) throw Error('动作历史暂不可用，请重试。');
+      return {close(){}};
+    }},
+    ReplayRecording:{open:()=>{throw Error('Automatic fallback is forbidden');}},
+  });
+  vm.runInContext(html.slice(begin,end)+'\n'+namedHTMLFunction(html,'openPlayback'),context);
+  await context.openPlayback('archive.jsonl');
+  assert.match(dom.document.getElementById('vcrstatus').textContent,/动作历史.*请重试/);
+  assert.doesNotMatch(dom.document.getElementById('vcrstatus').textContent,/完整录制/);
+  assert.equal(dom.document.getElementById('vcrseek').disabled,true);
+  assert.equal(dom.document.getElementById('vcrretry').hidden,false);
+  assert.equal(dom.document.getElementById('vcrtime').textContent,'读取失败');
+  await dom.document.getElementById('vcrretry').dispatch('click');
+  assert.deepEqual(opened,['archive.jsonl','archive.jsonl']);
+  assert.equal(dom.document.getElementById('vcrretry').hidden,true);
+  context.vcrClose();
+});
+
+test('original time keeps milliseconds and long hours through action seeks independently of compressed progress', async () => {
   const html=readFileSync(new URL('../server/index.html',import.meta.url),'utf8');
   const begin=html.indexOf('const vcr = document.getElementById("vcr")');
   const end=html.indexOf('// ---- export the recording',begin);
   const dom=replayDOM();
+  const times={0:1.234,1:86399.9996,128:407160.789,10819:864001.005};
+  const source={steps:10820,step:async index=>({t:index===0 ? 1.25 : times[index],
+    ...(index===0 ? {recorded_t:90061.234} : {}),who:'agent-a',act:'KEY',on:'up'}),
+    frame:async index=>({index,width:320,height:200}),prefetch(){},close(){}};
   const context=vm.createContext({document:dom.document,addEventListener(){},AbortController,
     ReplayKeys,GLYPH:{},ARROW:new Set(),colorOf:()=>'',
-    StepReplaySource:{open:async ()=>{throw Error('请先升级动作历史接口，或选择“完整录制”。');}},
-    ReplayRecording:{open:()=>{throw Error('Automatic fallback is forbidden');}},
+    ActionReplayPlayer:class extends ActionReplayPlayer {
+      constructor(source,callbacks){super(source,{...callbacks,schedule:()=>0,cancel:()=>{},now:()=>0});}
+    },
+    StepReplaySource:{open:async ()=>source},
   });
-  vm.runInContext(html.slice(begin,end)+'\n'+namedHTMLFunction(html,'openPlayback'),context);
+  const format=html.match(/function fmt\(s\) \{[\s\S]*?\n\}/)[0];
+  vm.runInContext(html.slice(begin,end)+'\n'+format+'\n'+namedHTMLFunction(html,'openPlayback'),context);
   await context.openPlayback();
-  assert.match(dom.document.getElementById('vcrstatus').textContent,/选择.*完整录制/);
-  assert.equal(dom.document.getElementById('vcrseek').disabled,true);
-  assert.notEqual(dom.document.getElementById('vcrmode').disabled,true);
-  assert.equal(dom.document.getElementById('vcrtime').textContent,'读取失败');
+  const get=id=>dom.document.getElementById(id);
+  assert.equal(get('vcrtime').textContent,'播放 0:00');
+  assert.equal(get('vcrduration').textContent,'27:03');
+  assert.equal(get('vcrrecorded').textContent,'动作 1 / 10820 · 原始时间 25:01:01.234');
+  await get('vcrpause').dispatch('click');
+  for(const [index,expected] of [[128,'113:06:00.789'],[1,'24:00:00.000'],[0,'25:01:01.234'],[10819,'240:00:01.005']]) {
+    get('vcrseek').value=String(index*.6);
+    await get('vcrseek').dispatch('input');
+    assert.equal(get('vcv').image.index,index);
+    assert.equal(get('vcrrecorded').textContent,`动作 ${index+1} / 10820 · 原始时间 ${expected}`);
+    assert.ok(get('vcrseek').getAttribute('aria-valuetext').endsWith('原始时间 '+expected));
+    assert.equal(get('vcrpause').textContent,'resume');
+  }
+  get('vcrspeed').value='2'; await get('vcrspeed').dispatch('change');
+  assert.equal(get('vcrduration').textContent,'54:06');
+  assert.match(get('vcrrecorded').textContent,/原始时间 240:00:01\.005$/);
   context.vcrClose();
 });

--- a/Scripts/test-replay.mjs
+++ b/Scripts/test-replay.mjs
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {createRequire} from 'node:module';
+const {ReplayPlayer} = createRequire(import.meta.url)('../server/replay.js');
+
+function fixture(decode = async event => event.d) {
+  let now = 0, current, i = 0;
+  const colors = [];
+  const events = [{t:5,d:'red'}, {t:6,d:'green'}, {t:7,d:'blue'}];
+  const source = {
+    duration:7,
+    async peek() { return events[i] || null; },
+    take() { i++; },
+    async seek(when) {
+      i = Math.max(0, events.findLastIndex(event=>event.t<=when));
+      return {at:events[i].t, held:{}};
+    },
+    close() { this.closed = true; },
+  };
+  const player = new ReplayPlayer(source, {
+    now:()=>now, schedule:()=>0, cancel:()=>{}, decode, complete:()=>true,
+    reset:()=>{ current=null; },
+    paint:color=>{ if(color) {current=color; colors.push(color);} },
+    update:()=>{}, error:error=>{ throw error; },
+  });
+  return {player,source,colors, color:()=>current, advance:ms=>{now+=ms;}};
+}
+
+test('starts with the first picture at zero and pause/resume reanchors the clock', async () => {
+  const f = fixture();
+  await f.player.start();
+  f.player.setSpeed(1);
+  assert.equal(f.color(),'red');
+  assert.equal(f.player.position,0);
+  f.advance(500); await f.player.tick();
+  await f.player.pause();
+  f.advance(30000); await f.player.tick();
+  assert.equal(f.color(),'red');
+  assert.equal(f.player.position,.5);
+  f.player.play(); f.advance(600); await f.player.tick();
+  assert.equal(f.color(),'green');
+  assert.ok(Math.abs(f.player.position-1.1)<1e-9);
+  f.player.close();
+});
+
+test('forward and backward seeks repaint their target and keep an ended recording reusable', async () => {
+  const f=fixture(); await f.player.start(); await f.player.pause();
+  await f.player.seek(1.5); assert.equal(f.color(),'green');
+  await f.player.seek(0); assert.equal(f.color(),'red');
+  await f.player.seek(2); assert.equal(f.color(),'blue');
+  assert.equal(f.player.wantPlaying,false);
+  await f.player.play(); assert.equal(f.color(),'red');
+  assert.equal(f.player.position,0);
+  assert.equal(f.source.closed,undefined);
+  f.player.close(); assert.equal(f.source.closed,true);
+});
+
+test('a slow old seek cannot paint after a newer seek', async () => {
+  let release, began;
+  const started = new Promise(resolve=>{began=resolve;});
+  const delayed = new Promise(resolve=>{release=resolve;});
+  const f=fixture(async event=>{
+    if(event.d==='green') {began(); await delayed;}
+    return event.d;
+  });
+  await f.player.start(); await f.player.pause();
+  const old=f.player.seek(1);
+  await started;
+  const newest=f.player.seek(0);
+  release(); await Promise.all([old,newest]);
+  assert.equal(f.color(),'red');
+  assert.deepEqual(f.colors,['red','red']);
+  f.player.close();
+});
+
+test('closing during decode releases the source and prevents a late frame', async () => {
+  let release, began;
+  const started=new Promise(resolve=>{began=resolve;});
+  const delayed=new Promise(resolve=>{release=resolve;});
+  const f=fixture(async event=>{
+    if(event.d==='green') {began(); await delayed;}
+    return event.d;
+  });
+  await f.player.start(); await f.player.pause();
+  const pending=f.player.seek(1);
+  await started; f.player.close(); release(); await pending;
+  assert.equal(f.source.closed,true);
+  assert.deepEqual(f.colors,['red']);
+});

--- a/Scripts/test-replay.mjs
+++ b/Scripts/test-replay.mjs
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {createRequire} from 'node:module';
+import {readFileSync} from 'node:fs';
+import vm from 'node:vm';
 const {ReplayPlayer, ReplayKeys} = createRequire(import.meta.url)('../server/replay.js');
 
 function fixture(decode = async event => event.d) {
@@ -172,4 +174,230 @@ test('default browser timers are not invoked with the player as their receiver',
   } finally {
     globalThis.setTimeout=originalSet; globalThis.clearTimeout=originalClear;
   }
+});
+
+function deferred() {
+  let resolve;
+  const promise = new Promise(done=>{ resolve=done; });
+  return {promise, resolve};
+}
+
+function replayDOM() {
+  const elements = new Map();
+  const document = {
+    activeElement: null,
+    listeners: {},
+    addEventListener(type, listener) { (this.listeners[type] ??= []).push(listener); },
+    createElement: tag=>new Element(tag),
+    createTextNode: text=>Object.assign(new Element('#text'), {textContent:text}),
+    createDocumentFragment: ()=>new Element('#fragment'),
+    getElementById(id) {
+      if (!elements.has(id)) elements.set(id, new Element(id==='vcv' ? 'canvas' : 'div'));
+      return elements.get(id);
+    },
+  };
+  class Element {
+    constructor(tag) {
+      this.tagName=tag.toUpperCase(); this.children=[]; this.style={};
+      this.ownerDocument=document; this.attributes={}; this.listeners={};
+      this.width=320; this.height=200; this.open=false; this._text='';
+      const classes=new Set();
+      this.classList={add:name=>classes.add(name), remove:name=>classes.delete(name),
+        contains:name=>classes.has(name)};
+    }
+    get textContent() { return this._text + this.children.map(child=>child.textContent).join(''); }
+    set textContent(text) { this._text=String(text); this.children=[]; }
+    set innerHTML(_value) { throw new Error('Recording metadata must use text nodes, not HTML'); }
+    appendChild(child) { this.children.push(child); child.parentNode=this; return child; }
+    append(...children) {
+      for (const child of children) this.appendChild(typeof child==='string' ? document.createTextNode(child) : child);
+    }
+    replaceChildren(...children) { this.children=[]; this._text=''; this.append(...children); }
+    setAttribute(name, value) { this.attributes[name]=String(value); }
+    removeAttribute(name) { delete this.attributes[name]; }
+    getAttribute(name) { return this.attributes[name] ?? null; }
+    addEventListener(type, listener) { (this.listeners[type] ??= []).push(listener); }
+    async dispatch(type) {
+      const event={type, target:this};
+      for (const listener of this.listeners[type] || []) await listener(event);
+      await this['on'+type]?.(event);
+    }
+    focus() { document.activeElement=this; this.focusCalls=(this.focusCalls || 0)+1; }
+    getContext() { return {fillRect(){}}; }
+  }
+  return {document, elements};
+}
+
+function namedHTMLFunction(html, name) {
+  const start=html.indexOf('async function '+name+'(');
+  assert.notEqual(start, -1, 'Missing real HTML function '+name);
+  const end=html.indexOf('\n}', start);
+  assert.notEqual(end, -1, 'Missing function terminator for '+name);
+  return html.slice(start, end+2);
+}
+
+test('opening a replay twice pins one reader, focuses close, and can reopen during a pending open', async () => {
+  const html=readFileSync(new URL('../server/index.html', import.meta.url), 'utf8');
+  const begin=html.indexOf('const vcr = document.getElementById("vcr")');
+  const end=html.indexOf('// ---- export the recording', begin);
+  assert.ok(begin>=0 && end>begin, 'Real playback initialization must be present');
+  const dom=replayDOM(), opens=[], players=[];
+  const context=vm.createContext({document:dom.document, addEventListener(){},
+    ReplayKeys, GLYPH:{}, ARROW:new Set(), colorOf:()=>'',
+    ReplayRecording:{open(name) {
+      const pending=deferred(); opens.push({name,...pending}); return pending.promise;
+    }},
+    ReplayPlayer:class {
+      constructor(source) { this.source=source; players.push(this); }
+      async start() {}
+      close() { this.source.close(); }
+    },
+  });
+  const playBinding=html.match(/^playBtn\.onclick = .*;$/m);
+  assert.ok(playBinding, 'The Play button must bind the named playback entry point');
+  vm.runInContext(html.slice(begin,end)+'\n'+namedHTMLFunction(html,'openPlayback')+'\n'+playBinding[0], context);
+  const first=dom.document.getElementById('play').onclick({type:'click'});
+  assert.equal(opens.length,1);
+  assert.equal(opens[0].name,'current');
+  assert.equal(dom.document.activeElement,dom.document.getElementById('vcrclose'));
+  await context.openPlayback('archive-ignored.jsonl');
+  assert.equal(opens.length,1,'Opening while the first request is pending must not pin a second reader');
+  context.vcrClose();
+  const reopened=context.openPlayback('archive-selected.jsonl');
+  assert.equal(opens.length,2);
+  assert.equal(opens[1].name,'archive-selected.jsonl');
+  const obsolete={closeCalls:0,close(){this.closeCalls++;}};
+  opens[0].resolve(obsolete); await first;
+  assert.equal(obsolete.closeCalls,1);
+  assert.equal(players.length,0,'A reader arriving after close must never start painting');
+  const active={closeCalls:0,close(){this.closeCalls++;}};
+  opens[1].resolve(active); await reopened;
+  assert.equal(players.length,1);
+  assert.equal(players[0].source,active);
+  assert.equal(dom.document.getElementById('vcr').classList.contains('on'),true);
+  context.vcrClose();
+  assert.ok(active.closeCalls>=1);
+});
+
+test('archive selection is sent once and page, seek, keepalive, and close keep the pinned token', async () => {
+  const code=readFileSync(new URL('../server/recording.js', import.meta.url), 'utf8');
+  const requests=[], timers=[];
+  const context=vm.createContext({module:{exports:{}}, URLSearchParams, AbortController, AbortSignal,
+    setInterval:callback=>{timers.push(callback); return timers.length;}, clearInterval(){},
+    setTimeout, clearTimeout,
+    fetch:async (url, options)=>{
+      requests.push({url,options});
+      const query=new URL(url,'http://localhost/u/test/').searchParams;
+      const page={token:'pinned-archive',duration:12,seek_supported:true,next:200,
+        events:query.has('start') ? [{t:3,d:'next-page'}] : [{t:1,d:'first-page'}],
+        done:query.has('start'), ...(query.has('time') ? {seek:{at:6,held:{}}} : {})};
+      return {ok:true,json:async()=>page};
+    },
+  });
+  vm.runInContext(code,context);
+  const {ReplayRecording}=context.module.exports;
+  assert.equal(typeof ReplayRecording,'function');
+  const name='20260909-183000-abcdef012345.jsonl';
+  const source=await ReplayRecording.open(name);
+  assert.equal((await source.peek()).d,'first-page');
+  source.take();
+  assert.equal((await source.peek()).d,'next-page');
+  await source.seek(6);
+  await timers[0]();
+  source.close();
+  await Promise.resolve();
+  const queries=requests.map(({url})=>new URL(url,'http://localhost/u/test/').searchParams);
+  assert.equal(queries[0].get('recording'),name);
+  assert.equal(queries[0].has('token'),false);
+  for (const query of queries.slice(1)) {
+    assert.equal(query.has('recording'),false,'Subsequent requests must address the pinned reader, not reselect a file');
+    assert.equal(query.get('token'),'pinned-archive');
+  }
+  assert.ok(queries.some(query=>query.get('start')==='200'));
+  assert.ok(queries.some(query=>query.get('time')==='6'));
+  assert.ok(queries.some(query=>query.get('touch')==='1'));
+  assert.ok(queries.some(query=>query.get('close')==='1'));
+  assert.equal(requests.at(-1).options.signal,undefined,'Closing a reader must not use its aborted playback signal');
+});
+
+test('the recordings menu loads lazily and offers safe downloads and playback for current and archived files', async () => {
+  const html=readFileSync(new URL('../server/index.html', import.meta.url),'utf8');
+  assert.match(html, /<details id="recordingfiles">[\s\S]*?<div id="recordinglinks">/);
+  const begin=html.indexOf('// ---- recording files ');
+  const end=html.indexOf('// ---- live connection ',begin);
+  assert.ok(begin>=0 && end>begin, 'Real recording menu initialization must be present');
+  const dom=replayDOM(), requests=[], opened=[];
+  const files=[
+    {id:'current',name:'recording.jsonl',bytes:1048576},
+    {id:'20260909-183000-abcdef012345.jsonl',name:'20260909-183000-abcdef012345.jsonl',bytes:2097152},
+    {id:'special /?&#.jsonl',name:'<img src=x onerror=alert(1)>.jsonl',bytes:0},
+  ];
+  const context=vm.createContext({document:dom.document, addEventListener(){},
+    openPlayback:id=>opened.push(id),
+    fetch:async (url,options)=>{ requests.push({url,options}); return {ok:true,json:async()=>({files})}; },
+  });
+  vm.runInContext(html.slice(begin,end),context);
+  const details=dom.document.getElementById('recordingfiles');
+  const links=dom.document.getElementById('recordinglinks');
+  assert.equal(requests.length,0);
+  await details.dispatch('toggle');
+  assert.equal(requests.length,0,'A closed menu must not fetch the list');
+  details.open=true;
+  await details.dispatch('toggle');
+  assert.equal(requests.length,1);
+  assert.equal(requests[0].url,'api/recordings');
+  assert.equal(requests[0].options.cache,'no-store');
+  assert.equal(links.children.length,files.length);
+  for (const [index,file] of files.entries()) {
+    const row=links.children[index];
+    assert.equal(row.tagName,'DIV');
+    const label=row.children.find(child=>child.tagName==='SPAN');
+    const download=row.children.find(child=>child.tagName==='A');
+    const play=row.children.find(child=>child.tagName==='BUTTON');
+    assert.ok(label && download && play);
+    assert.equal(download.href,'api/recordings/'+encodeURIComponent(file.id));
+    assert.equal(download.download,file.name);
+    if (file.id==='current') assert.match(label.textContent,/当前录像/);
+    else assert.ok(label.textContent.includes(file.name.replace(/\.jsonl$/,'')));
+    assert.equal(label.children.length,0,'Recording names must stay inert text');
+    details.open=true;
+    await play.dispatch('click');
+    assert.equal(details.open,false);
+    assert.equal(opened.at(-1),file.id);
+  }
+  assert.deepEqual(opened,files.map(file=>file.id));
+});
+
+test('reopening the recordings menu ignores an older list response and reports unsupported servers', async () => {
+  const html=readFileSync(new URL('../server/index.html', import.meta.url),'utf8');
+  const begin=html.indexOf('// ---- recording files ');
+  const end=html.indexOf('// ---- live connection ',begin);
+  const dom=replayDOM(), pending=[];
+  const context=vm.createContext({document:dom.document, addEventListener(){}, openPlayback(){},
+    fetch:()=>{ const request=deferred(); pending.push(request); return request.promise; },
+  });
+  vm.runInContext(html.slice(begin,end),context);
+  const details=dom.document.getElementById('recordingfiles');
+  const links=dom.document.getElementById('recordinglinks');
+  details.open=true;
+  const old=details.dispatch('toggle');
+  details.open=false;
+  await details.dispatch('toggle');
+  details.open=true;
+  const fresh=details.dispatch('toggle');
+  const response=name=>({ok:true,json:async()=>({files:[{id:name,name,bytes:1}]})});
+  pending[1].resolve(response('fresh.jsonl'));
+  await fresh;
+  assert.match(links.textContent,/fresh/);
+  pending[0].resolve(response('obsolete.jsonl'));
+  await old;
+  assert.match(links.textContent,/fresh/);
+  assert.doesNotMatch(links.textContent,/obsolete/);
+  details.open=false;
+  await details.dispatch('toggle');
+  details.open=true;
+  const missing=details.dispatch('toggle');
+  pending[2].resolve({ok:false,status:404});
+  await missing;
+  assert.match(links.textContent,/暂不支持录像列表/);
 });

--- a/Scripts/test-replay.mjs
+++ b/Scripts/test-replay.mjs
@@ -3,7 +3,7 @@ import test from 'node:test';
 import {createRequire} from 'node:module';
 import {readFileSync} from 'node:fs';
 import vm from 'node:vm';
-const {ReplayPlayer, ReplayKeys} = createRequire(import.meta.url)('../server/replay.js');
+const {ReplayPlayer, ActionReplayPlayer, ReplayKeys} = createRequire(import.meta.url)('../server/replay.js');
 
 function fixture(decode = async event => event.d) {
   let now = 0, current, i = 0;
@@ -242,12 +242,12 @@ test('opening a replay twice pins one reader, focuses close, and can reopen duri
   const end=html.indexOf('// ---- export the recording', begin);
   assert.ok(begin>=0 && end>begin, 'Real playback initialization must be present');
   const dom=replayDOM(), opens=[], players=[];
-  const context=vm.createContext({document:dom.document, addEventListener(){},
+  const context=vm.createContext({document:dom.document, addEventListener(){}, AbortController,
     ReplayKeys, GLYPH:{}, ARROW:new Set(), colorOf:()=>'',
-    ReplayRecording:{open(name) {
+    StepReplaySource:{open(name) {
       const pending=deferred(); opens.push({name,...pending}); return pending.promise;
     }},
-    ReplayPlayer:class {
+    ActionReplayPlayer:class {
       constructor(source) { this.source=source; players.push(this); }
       async start() {}
       close() { this.source.close(); }
@@ -400,4 +400,284 @@ test('reopening the recordings menu ignores an older list response and reports u
   pending[2].resolve({ok:false,status:404});
   await missing;
   assert.match(links.textContent,/暂不支持录像列表/);
+});
+
+function actionFixture({count=3, frame=async index=>({index})} = {}) {
+  let now=0, timer, current;
+  const pictures=[], states=[], prefetched=[];
+  const source={steps:count, duration:113*3600,
+    step:async index=>({t:index*3600,who:index%2 ? 'agent-b' : 'agent-a',act:'KEY',on:'up'}),
+    frame,
+    prefetch(index,signal) { prefetched.push({index,signal}); },
+    close() {this.closed=true;},
+  };
+  const player=new ActionReplayPlayer(source, {
+    now:()=>now,
+    schedule:(callback,delay)=>{ timer={callback,delay}; return timer; },
+    cancel:handle=>{ if(handle===timer) timer=null; },
+    paint:(image,step)=>{ current=image.index; pictures.push({index:image.index,step}); },
+    update:state=>states.push(state), error:error=>{throw error;},
+  });
+  return {source,player,pictures,states,prefetched,advance:ms=>{now+=ms;},
+    current:()=>current, timer:()=>timer};
+}
+
+test('action playback starts immediately and maps 10820 actions to 27 minutes at 4x, independent of wall time', async () => {
+  const f=actionFixture({count:10820});
+  await f.player.start();
+  assert.equal(f.current(),0);
+  assert.equal(f.player.duration/4,1623);
+  assert.equal(f.timer().delay,150);
+  assert.equal(f.states.at(-1).step.t,0);
+  f.advance(150); await f.player.tick();
+  assert.equal(f.current(),1);
+  assert.equal(f.states.at(-1).step.t,3600);
+  assert.equal(f.states.at(-1).step.who,'agent-b');
+  f.player.pause();
+  for (const index of [127,128,9000,1,0,10819]) {
+    await f.player.seek(index*.6);
+    assert.equal(f.current(),index);
+    assert.equal(f.player.wantPlaying,false);
+  }
+  await f.player.seek(f.player.duration);
+  assert.equal(f.current(),10819);
+  assert.equal(f.player.wantPlaying,false);
+  await f.player.play();
+  assert.equal(f.current(),0);
+  f.player.close();
+});
+
+test('action pause and speed changes preserve the displayed action and its remaining hold time', async () => {
+  const f=actionFixture(); await f.player.start();
+  f.advance(50); f.player.pause();
+  assert.ok(Math.abs(f.player.position-.2)<1e-9);
+  f.advance(90000); await f.player.tick();
+  assert.equal(f.current(),0);
+  f.player.setSpeed(2); f.player.play();
+  assert.ok(Math.abs(f.timer().delay-200)<1e-9);
+  f.advance(200); await f.player.tick();
+  assert.equal(f.current(),1);
+  assert.ok(Math.abs(f.timer().delay-300)<1e-9);
+  f.player.close(); assert.equal(f.source.closed,true);
+});
+
+test('slow action frames do not skip actions and pausing during a pending frame remains paused', async () => {
+  const wait=deferred(), began=deferred();
+  const f=actionFixture({frame:async index=>{
+    if(index===1) {began.resolve(); await wait.promise;}
+    return {index};
+  }});
+  await f.player.start();
+  f.advance(150); const pending=f.player.tick(); await began.promise;
+  f.advance(900000); f.player.pause();
+  assert.equal(f.current(),0);
+  wait.resolve(); await pending;
+  assert.equal(f.current(),0,'A paused viewer must keep its last visible picture');
+  assert.equal(f.player.playing,false);
+  assert.equal(f.player.wantPlaying,false);
+  assert.equal(f.player.position,.6);
+  f.player.play(); assert.equal(f.timer().delay,0);
+  await f.player.tick(); assert.equal(f.current(),1);
+  assert.equal(f.timer().delay,150);
+  f.player.close();
+});
+
+test('a new action seek paints without waiting for a slow obsolete seek, which is aborted and cannot overwrite it', async () => {
+  const wait=deferred(), began=deferred(); let oldSignal;
+  const f=actionFixture({frame:async (index,signal)=>{
+    if(index===1) {oldSignal=signal; began.resolve(); await wait.promise;}
+    return {index};
+  }});
+  await f.player.start(); f.player.pause();
+  const stale=f.player.seek(.6); await began.promise;
+  await f.player.seek(1.2);
+  assert.equal(oldSignal.aborted,true);
+  assert.equal(f.current(),2,'The latest request must not queue behind a stale decode');
+  wait.resolve(); await stale;
+  assert.deepEqual(f.pictures.map(p=>p.index),[0,2]);
+  f.player.close();
+});
+
+test('closing or pausing during the first action frame never causes a late autoplay', async () => {
+  for (const close of [false,true]) {
+    const wait=deferred(), began=deferred();
+    const f=actionFixture({frame:async index=>{began.resolve(); await wait.promise; return {index};}});
+    const opening=f.player.start(); await began.promise;
+    if(close) f.player.close(); else f.player.pause();
+    await f.player.seek(1.2);
+    wait.resolve(); await opening;
+    assert.equal(f.player.wantPlaying,false);
+    assert.equal(f.player.playing,false);
+    assert.equal(f.current(),close ? undefined : 0);
+    f.player.close();
+  }
+});
+
+test('action playback holds the last frame before stopping and restarts from the first frame', async () => {
+  const f=actionFixture({count:1}); await f.player.start();
+  assert.equal(f.player.wantPlaying,true);
+  assert.equal(f.timer().delay,150);
+  f.advance(150); await f.player.tick();
+  assert.equal(f.player.position,.6);
+  assert.equal(f.player.wantPlaying,false);
+  assert.equal(f.source.closed,undefined);
+  await f.player.play(); assert.equal(f.current(),0);
+  assert.equal(f.player.position,0);
+  assert.equal(f.player.wantPlaying,true);
+  f.player.close();
+});
+
+test('action key display preserves actor switches, repeated keys, arrows, and failed actions', () => {
+  const dom=replayDOM(), container=dom.document.getElementById('keys');
+  const keys=new ReplayKeys(container,{glyphs:{up:'↗',enter:'⏎'},arrows:new Set(['up']),colorOf:who=>who});
+  keys.showStep({who:'agent-a',act:'KEYS',on:'up up enter'});
+  assert.deepEqual(container.children.map(x=>x.textContent),['agent-a','↗','↗','⏎']);
+  assert.equal(container.children[1].className,'k arrow');
+  keys.showStep({who:'agent-b',act:'WAIT',on:'100',ok:false});
+  assert.deepEqual(container.children.map(x=>x.textContent),['agent-b','等待',' · 未执行 / 失败']);
+  keys.showStep({who:'<img>',act:'GET'});
+  assert.equal(container.children[0].textContent,'<img>');
+  assert.equal(container.children[0].children.length,0);
+});
+
+function stepSourceVM(fetch, extra={}) {
+  const requests=[], intervals=[], pictures=[], disposed=[];
+  const context=vm.createContext({module:{exports:{}}, URL, URLSearchParams, AbortController, AbortSignal,
+    setTimeout:(callback)=>setTimeout(callback,0),clearTimeout,
+    setInterval:callback=>{intervals.push(callback); return intervals.length;},clearInterval(){},
+    createImageBitmap:async blob=>{
+      const image={index:blob.index,close(){disposed.push(this.index);}};
+      pictures.push(image); return image;
+    },
+    fetch:async (url,options={})=>{
+      requests.push({url,options});
+      return fetch(new URL(url,'http://local/u/test/'),options);
+    }, ...extra});
+  vm.runInContext(readFileSync(new URL('../server/recording.js',import.meta.url),'utf8'),context);
+  return {Source:context.module.exports.StepReplaySource,requests,intervals,pictures,disposed};
+}
+const jsonReply = (body,status=200)=>({ok:status<400,status,json:async()=>body});
+function stepResponse(url) {
+  const number=Number(url.searchParams.get('step'));
+  if(url.pathname.endsWith('/frame')) return {ok:true,status:200,blob:async()=>({index:number})};
+  if(url.pathname.endsWith('/steps')) {
+    const start=Number(url.searchParams.get('start'));
+    return jsonReply({start,total:10820,steps:Array.from({length:128},(_,offset)=>({t:(start+offset)*3600,act:'KEY',on:'up'}))});
+  }
+  return jsonReply({token:'pinned-archive',steps:10820,duration:113*3600});
+}
+
+test('action source polls one pinned archive, pages 128 steps, caches four pictures, and deletes its token', async () => {
+  let opening=true;
+  const f=stepSourceVM(url=>{
+    if(opening) {opening=false; return jsonReply({token:'pinned-archive',indexing:true,scanned:1,total:2},202);}
+    return stepResponse(url);
+  });
+  const progress=[];
+  const source=await f.Source.open('archive &?.jsonl',{progress:meta=>progress.push(meta)});
+  assert.equal(progress.length,1);
+  assert.equal(source.steps,10820);
+  assert.equal(new URL(f.requests[0].url,'http://local/').searchParams.get('recording'),'archive &?.jsonl');
+  for(const number of [0,127,128,256,128]) await source.step(number);
+  const pages=f.requests.filter(r=>r.url.includes('/steps')).map(r=>new URL(r.url,'http://local/'));
+  assert.deepEqual(pages.map(url=>url.searchParams.get('start')),['0','128','256']);
+  assert.ok(pages.every(url=>url.searchParams.get('count')==='128'));
+  assert.equal(source.pages.size,2);
+  for(let number=0;number<6;number++) await source.frame(number);
+  assert.equal(source.frames.size,4);
+  assert.deepEqual(f.disposed,[0,1]);
+  const count=f.requests.length; await source.frame(5);
+  assert.equal(f.requests.length,count);
+  await f.intervals[0](); source.close();
+  assert.equal(f.requests.at(-1).options.method,'DELETE');
+  assert.equal(f.requests.at(-1).options.signal,undefined);
+  assert.equal(f.disposed.length,6);
+  assert.equal(source.frames.size,0);
+  assert.ok(f.requests.slice(1).every(r=>r.url.startsWith('api/replay/pinned-archive')));
+});
+
+test('action source prefetches only the next two pictures and closes a cancelled late decode', async () => {
+  const wait=deferred(), began=deferred(), closed=[];
+  const f=stepSourceVM(stepResponse,{createImageBitmap:async blob=>{
+    if(blob.index===1) {began.resolve(); await wait.promise;}
+    return {index:blob.index,close(){closed.push(blob.index);}};
+  }});
+  const source=await f.Source.open();
+  const abort=new AbortController();
+  source.prefetch(0,abort.signal); await began.promise;
+  assert.deepEqual(f.requests.filter(r=>r.url.includes('/frame')).map(r=>new URL(r.url,'http://local/').searchParams.get('step')),['1','2']);
+  abort.abort(); wait.resolve();
+  await new Promise(resolve=>setTimeout(resolve,0));
+  assert.ok(closed.includes(1));
+  assert.equal(source.frames.has(1),false);
+  source.close();
+});
+
+test('closing while the action token is opening still releases the late token and does not poll it', async () => {
+  const wait=deferred();
+  const f=stepSourceVM((url,options)=>options.method==='DELETE' ? jsonReply({ok:true}) : wait.promise);
+  const abort=new AbortController(), pending=f.Source.open('current',{signal:abort.signal});
+  abort.abort(); wait.resolve(jsonReply({token:'late',indexing:true},202));
+  await assert.rejects(pending);
+  assert.equal(f.requests.length,2);
+  assert.equal(f.requests[1].url,'api/replay/late');
+  assert.equal(f.requests[1].options.method,'DELETE');
+});
+
+test('missing action history gives an explicit full-recording choice without falling back to a long replay', async () => {
+  const f=stepSourceVM(()=>jsonReply({},404));
+  await assert.rejects(f.Source.open(),/选择.*完整录制/);
+  assert.equal(f.requests.length,1);
+});
+
+test('action source fallback decoding revokes object URLs even when decoding fails', async () => {
+  const revoked=[], made=[];
+  const f=stepSourceVM(stepResponse,{createImageBitmap:undefined,
+    URL:{createObjectURL:()=>{made.push('blob:frame'); return 'blob:frame';},revokeObjectURL:url=>revoked.push(url)},
+    Image:class {async decode(){throw Error('bad image');}},
+  });
+  await assert.rejects(f.Source.decode({}),/bad image/);
+  assert.deepEqual(revoked,made);
+});
+
+test('the playback mode selector retains the selected archive and explicitly opens the complete recording', async () => {
+  const html=readFileSync(new URL('../server/index.html',import.meta.url),'utf8');
+  const begin=html.indexOf('const vcr = document.getElementById("vcr")');
+  const end=html.indexOf('// ---- export the recording',begin);
+  const dom=replayDOM(), opened=[], closed=[];
+  class Player {async start(){} close(){}}
+  const context=vm.createContext({document:dom.document,addEventListener(){},AbortController,
+    ReplayKeys,GLYPH:{},ARROW:new Set(),colorOf:()=>'',ActionReplayPlayer:Player,ReplayPlayer:Player,
+    StepReplaySource:{open:async name=>{opened.push(['actions',name]);return {close:()=>closed.push(name)};}},
+    ReplayRecording:{open:async name=>{opened.push(['full',name]);return {close:()=>closed.push(name)};}},
+  });
+  vm.runInContext(html.slice(begin,end)+'\n'+namedHTMLFunction(html,'openPlayback'),context);
+  await context.openPlayback('archive.jsonl');
+  assert.equal(dom.document.getElementById('vcrmode').value,'actions');
+  dom.document.getElementById('vcrmode').value='full';
+  await dom.document.getElementById('vcrmode').dispatch('change');
+  assert.deepEqual(opened,[['actions','archive.jsonl'],['full','archive.jsonl']]);
+  assert.ok(closed.includes('archive.jsonl'));
+  assert.match(dom.document.getElementById('vcrstatus').textContent,/保留原始空闲/);
+  assert.equal(dom.document.activeElement,dom.document.getElementById('vcrclose'));
+  context.vcrClose();
+});
+
+test('unsupported action playback leaves the mode selector available and reports the actionable error in the viewer', async () => {
+  const html=readFileSync(new URL('../server/index.html',import.meta.url),'utf8');
+  const begin=html.indexOf('const vcr = document.getElementById("vcr")');
+  const end=html.indexOf('// ---- export the recording',begin);
+  const dom=replayDOM();
+  const context=vm.createContext({document:dom.document,addEventListener(){},AbortController,
+    ReplayKeys,GLYPH:{},ARROW:new Set(),colorOf:()=>'',
+    StepReplaySource:{open:async ()=>{throw Error('请先升级动作历史接口，或选择“完整录制”。');}},
+    ReplayRecording:{open:()=>{throw Error('Automatic fallback is forbidden');}},
+  });
+  vm.runInContext(html.slice(begin,end)+'\n'+namedHTMLFunction(html,'openPlayback'),context);
+  await context.openPlayback();
+  assert.match(dom.document.getElementById('vcrstatus').textContent,/选择.*完整录制/);
+  assert.equal(dom.document.getElementById('vcrseek').disabled,true);
+  assert.notEqual(dom.document.getElementById('vcrmode').disabled,true);
+  assert.equal(dom.document.getElementById('vcrtime').textContent,'读取失败');
+  context.vcrClose();
 });

--- a/Scripts/test-replay.mjs
+++ b/Scripts/test-replay.mjs
@@ -87,3 +87,20 @@ test('closing during decode releases the source and prevents a late frame', asyn
   assert.equal(f.source.closed,true);
   assert.deepEqual(f.colors,['red']);
 });
+
+test('default browser timers are not invoked with the player as their receiver', async () => {
+  const originalSet=globalThis.setTimeout, originalClear=globalThis.clearTimeout;
+  function browserTimer() {
+    assert.ok(this===undefined || this===globalThis, 'Window timer called with an invalid receiver');
+    return 1;
+  }
+  globalThis.setTimeout=browserTimer; globalThis.clearTimeout=browserTimer;
+  try {
+    const f=fixture();
+    const player=new ReplayPlayer(f.source, {decode:async e=>e.d,paint:()=>{},
+      complete:()=>true,reset:()=>{},update:()=>{},error:e=>{throw e;}});
+    await player.start(); await player.pause(); player.close();
+  } finally {
+    globalThis.setTimeout=originalSet; globalThis.clearTimeout=originalClear;
+  }
+});

--- a/Scripts/test-replay.mjs
+++ b/Scripts/test-replay.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {createRequire} from 'node:module';
-const {ReplayPlayer} = createRequire(import.meta.url)('../server/replay.js');
+const {ReplayPlayer, ReplayKeys} = createRequire(import.meta.url)('../server/replay.js');
 
 function fixture(decode = async event => event.d) {
   let now = 0, current, i = 0;
@@ -86,6 +86,75 @@ test('closing during decode releases the source and prevents a late frame', asyn
   await started; f.player.close(); release(); await pending;
   assert.equal(f.source.closed,true);
   assert.deepEqual(f.colors,['red']);
+});
+
+test('a seek during the first decode cannot discard the recording origin', async () => {
+  let release, began;
+  const started = new Promise(resolve=>{began=resolve;});
+  const delayed = new Promise(resolve=>{release=resolve;});
+  const f = fixture(async event=>{
+    if (event.d==='red') { began(); await delayed; }
+    return event.d;
+  });
+  const states = [];
+  f.player.update = state=>states.push(state);
+  const opening = f.player.start();
+  await started;
+  assert.equal(states.at(-1).ready, false);
+  assert.equal(states.at(-1).loading, true);
+  await f.player.seek(1.5);
+  release(); await opening;
+  assert.equal(f.player.origin, 5);
+  assert.equal(f.player.duration, 2);
+  assert.equal(f.player.position, 0);
+  assert.equal(f.color(), 'red');
+  assert.equal(states.at(-1).ready, true);
+  assert.equal(states.at(-1).loading, false);
+  await f.player.pause();
+  await f.player.seek(1.5);
+  assert.equal(f.color(), 'green');
+  f.player.close();
+});
+
+test('pausing during the first decode stays paused once its picture arrives', async () => {
+  let release, began;
+  const started = new Promise(resolve=>{began=resolve;});
+  const delayed = new Promise(resolve=>{release=resolve;});
+  const f = fixture(async event=>{ began(); await delayed; return event.d; });
+  const opening = f.player.start();
+  await started; await f.player.pause();
+  release(); await opening;
+  assert.equal(f.color(), 'red');
+  assert.equal(f.player.position, 0);
+  assert.equal(f.player.playing, false);
+  assert.equal(f.player.wantPlaying, false);
+  f.player.close();
+});
+
+test('seek snapshots and later key events retain actor names and styled key chips', () => {
+  const container = {
+    children: [],
+    ownerDocument: {createElement:()=>({style:{}})},
+    replaceChildren() { this.children = []; },
+    appendChild(child) { this.children.push(child); },
+  };
+  const keys = new ReplayKeys(container, {
+    glyphs:{up:'↗',enter:'⏎'}, arrows:new Set(['up']),
+    colorOf:actor=>actor==='agent-a' ? '#abcdef' : '#123456',
+  });
+  const labels = ()=>container.children.map(child=>child.textContent);
+  keys.reset({up:'agent-a', enter:'agent-b'});
+  assert.deepEqual(labels(), ['agent-a','↗','agent-b','⏎']);
+  assert.equal(container.children[0].style.color, '#abcdef');
+  assert.equal(container.children[1].className, 'k arrow');
+  assert.equal(container.children[2].style.color, '#123456');
+  assert.equal(container.children[3].className, 'k');
+  keys.apply({key:'up',down:false,who:'agent-a'});
+  assert.deepEqual(labels(), ['agent-b','⏎','agent-a']);
+  keys.apply({key:'space',down:true,who:'<operator>'});
+  assert.deepEqual(labels(), ['agent-b','⏎','<operator>','space']);
+  keys.reset({});
+  assert.deepEqual(labels(), []);
 });
 
 test('default browser timers are not invoked with the player as their receiver', async () => {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "node": ">=22.19.0"
   },
   "scripts": {
-    "test:pi-runner": "node --test Scripts/test-pi-run.mjs Scripts/test-pi-launch.mjs Scripts/test-pi-usage.mjs"
+    "test:pi-runner": "node --test Scripts/test-pi-run.mjs Scripts/test-pi-launch.mjs Scripts/test-pi-usage.mjs",
+    "test:replay": "node --test Scripts/test-replay.mjs"
   },
   "dependencies": {
     "@earendil-works/pi-coding-agent": "0.84.4"

--- a/server/README.md
+++ b/server/README.md
@@ -66,10 +66,16 @@ Needs `../cores/dosbox_pure_libretro.so` (libretro buildbot) and `../game/`.
   It uses ffmpeg on the server, with progress, cancellation and a completed MP4
   download. Encoding does not wait through original recording timestamps and
   does not disable playback. Temporary status-query failures retain the job and
-  retry it; a confirmed missing or expired job allows a new export. ffmpeg must
-  be installed on the server. Cached results are bounded by a 2 GiB / 30-day
-  policy, retaining the latest result and active downloads. The source recording
-  and benchmark counters are unaffected by export.
+  retry it. An `X-Video-Request-Id` header or JSON `requestId` makes submission
+  idempotent while its in-process job record is retained: retries return the
+  same queued/active job, or replay cancelled/error terminal state with HTTP
+  200. Reusing a token with a different recording or speed is HTTP 409. If a
+  ready MP4 has been evicted while its job record remains, the token returns
+  HTTP 410 so the caller can submit a new token instead of silently creating a
+  second export. ffmpeg must be installed on the server. Cached results are
+  bounded by a 2 GiB / 30-day policy, retaining the latest result and active
+  downloads. The source recording and benchmark counters are unaffected by
+  export.
 - `/api/history?limit=100` the bounded action log. Every REST call and every key pressed in a
   browser is recorded and pushed to all connected pages over the same
   WebSocket, so the activity panel shows an agent and a human acting on the

--- a/server/README.md
+++ b/server/README.md
@@ -57,7 +57,13 @@ Needs `../cores/dosbox_pure_libretro.so` (libretro buildbot) and `../game/`.
   and once idle keeps only the last 30 seconds so an untouched game still shows
   its own animation without growing forever. A whole picture is forced every 30
   seconds so a pruned recording always has somewhere to start replaying from.
-  The page plays it back at 4x from a button in the activity header, and can
+  The page starts playback at the first complete picture. Pause/resume keeps
+  the current position; the slider seeks in both directions, and speed can be
+  1x, 2x, 4x or 8x. A newer seek cannot be overwritten by a late frame from an
+  older one. Playback keeps its pinned snapshot open until the viewer closes,
+  so the end can be replayed or inspected without refreshing. With server seek
+  support the slider uses its sparse keyframe index; older servers fall back
+  to reading bounded pages from the beginning. The page can also
   export it as a video from another. Export composites the frames with the keys
   that were held and encodes in the browser with MediaRecorder, so the server
   spends nothing on it. MediaRecorder captures in real time, so an export takes

--- a/server/README.md
+++ b/server/README.md
@@ -52,22 +52,24 @@ Needs `../cores/dosbox_pure_libretro.so` (libretro buildbot) and `../game/`.
   without the token from `QUNXIA_RESET_TOKEN` rather than 403, so the path
   cannot be confirmed by probing. Pauses the emulation thread first, since
   `retro_reset` underneath a running `retro_run` is a race.
-- `/api/recording` the session as tile deltas plus key presses, for playback.
-  Recording restarts with the game, keeps every frame while anyone is acting,
-  and once idle keeps only the last 30 seconds so an untouched game still shows
-  its own animation without growing forever. A whole picture is forced every 30
-  seconds so a pruned recording always has somewhere to start replaying from.
-  The page starts playback at the first complete picture. Pause/resume keeps
-  the current position; the slider seeks in both directions, and speed can be
-  1x, 2x, 4x or 8x. A newer seek cannot be overwritten by a late frame from an
-  older one. Playback keeps its pinned snapshot open until the viewer closes,
-  so the end can be replayed or inspected without refreshing. With server seek
-  support the slider uses its sparse keyframe index; older servers fall back
-  to reading bounded pages from the beginning. The page can also
-  export it as a video from another. Export composites the frames with the keys
-  that were held and encodes in the browser with MediaRecorder, so the server
-  spends nothing on it. MediaRecorder captures in real time, so an export takes
-  the length of the recording divided by four.
+- `/api/recording` streams the original recording journal; `?format=jsonl`
+  downloads its tile deltas, input events and action markers as JSONL. Readers
+  pin a committed file prefix, so later appends or reset do not change an open
+  snapshot. The source journal remains on disk.
+  With the saved-history backend, the page plays current and archived recordings
+  as saved actions, skipping idle gaps. Each action occupies 0.6 / speed seconds;
+  pause/resume and both seek directions retain the selected picture. Original
+  JSONL timestamps (`recorded_t`) are shown separately to the millisecond and do
+  not wrap after 24 hours. There is no continuous-recording fallback; an
+  unavailable action source can be retried.
+- `/api/video` submits a background action-video job to the saved-history backend.
+  It uses ffmpeg on the server, with progress, cancellation and a completed MP4
+  download. Encoding does not wait through original recording timestamps and
+  does not disable playback. Temporary status-query failures retain the job and
+  retry it; a confirmed missing or expired job allows a new export. ffmpeg must
+  be installed on the server. Cached results are bounded by a 2 GiB / 30-day
+  policy, retaining the latest result and active downloads. The source recording
+  and benchmark counters are unaffected by export.
 - `/api/history?limit=100` the bounded action log. Every REST call and every key pressed in a
   browser is recorded and pushed to all connected pages over the same
   WebSocket, so the activity panel shows an agent and a human acting on the
@@ -76,8 +78,8 @@ Needs `../cores/dosbox_pure_libretro.so` (libretro buildbot) and `../game/`.
   (about 2 KB). Attaching one to every keypress buried the log. Only the
   newest 40 entries keep their image.
 
-The live canvas uses the small `zlib` tile encoder. Pillow is used only for
-on-demand PNG/WebP observations and activity thumbnails.
+The live canvas uses the small `zlib` tile encoder. Pillow is used for on-demand PNG/WebP observations, activity thumbnails,
+history reconstruction and background video captions.
 
 ## Several agents on one session
 

--- a/server/README.md
+++ b/server/README.md
@@ -72,10 +72,12 @@ Needs `../cores/dosbox_pure_libretro.so` (libretro buildbot) and `../game/`.
   200. Reusing a token with a different recording or speed is HTTP 409. If a
   ready MP4 has been evicted while its job record remains, the token returns
   HTTP 410 so the caller can submit a new token instead of silently creating a
-  second export. ffmpeg must be installed on the server. Cached results are
-  bounded by a 2 GiB / 30-day policy, retaining the latest result and active
-  downloads. The source recording and benchmark counters are unaffected by
-  export.
+  second export. Request-token mappings are not persisted: the same-job-ID
+  guarantee ends when the job record is reaped or the service restarts. The
+  completed MP4 cache remains persistent. ffmpeg must be installed on the
+  server. Cached results are bounded by a 2 GiB / 30-day policy, retaining the
+  latest result and active downloads. The source recording and benchmark
+  counters are unaffected by export.
 - `/api/history?limit=100` the bounded action log. Every REST call and every key pressed in a
   browser is recorded and pushed to all connected pages over the same
   WebSocket, so the activity panel shows an agent and a human acting on the

--- a/server/index.html
+++ b/server/index.html
@@ -29,7 +29,7 @@
     display: flex; justify-content: space-between; align-items: baseline;
   }
   #side h2 em { font-style: normal; color: #5b5b66; font-size: 10px; letter-spacing: 0; }
-  #side h2 .right { display: flex; align-items: center; gap: 8px; }
+  #side h2 .right { display: flex; align-items: center; justify-content: flex-end; flex-wrap: wrap; gap: 6px; }
   #play, #save {
     padding: 3px 9px; font-size: 10.5px; letter-spacing: .04em;
     background: #17171b; border: 1px solid #2e2e36; border-radius: 4px;
@@ -61,7 +61,8 @@
   }
   #vcrkeys .k { font-size: 13px; min-width: 20px; padding: 2px 6px; }
   #vcrbar { display: flex; align-items: center; gap: 10px; font-size: 11px; color: #9a9aa6; }
-  #vcrkeys { display: flex; gap: 4px; min-height: 20px; align-items: center; }
+  #vcrkeys { display: flex; flex-wrap: wrap; justify-content: center; gap: 4px; min-height: 20px; align-items: center; }
+  #vcrrecorded, #vcrstatus { color: #9a9aa6; font-size: 12px; max-width: 90vw; text-align: center; }
   #vcrbar { flex-wrap: wrap; justify-content: center; max-width: 94vw; }
   #vcrseek { width: min(35vw, 360px); accent-color: #6cb6ff; }
   #logrows { overflow-y: auto; padding: 6px 0 10px; flex: 1; }
@@ -319,7 +320,10 @@
 <div id="vcr">
   <canvas id="vcv" width="320" height="200"></canvas>
   <div id="vcrkeys"></div>
+  <div id="vcrrecorded"></div>
+  <div id="vcrstatus" role="status"></div>
   <div id="vcrbar">
+    <select id="vcrmode" aria-label="回放模式"><option value="actions">动作回放（跳过空闲）</option><option value="full">完整录制（含空闲）</option></select>
     <span id="vcrtime">0:00</span>
     <input id="vcrseek" type="range" min="0" max="0" step="0.1" value="0" aria-label="Replay position">
     <span id="vcrduration">0:00</span>
@@ -344,7 +348,7 @@
   <div id="roster"></div>
   <h2>ACTIVITY
     <span class="right"><em id="logcount"></em>
-      <button id="play">▶ 4×</button><button id="save">⤓ mp4</button>
+      <button id="play">▶ 回放</button><button id="save">⤓ mp4</button>
       <details id="recordingfiles"><summary aria-label="更多录像" title="更多录像">···</summary><div id="recordinglinks">正在读取录像文件…</div></details></span>
   </h2>
   <div id="meter">
@@ -435,7 +439,7 @@ function vcrClose() {
   if (vcrStop) { vcrStop(); vcrStop = null; }
   vcr.classList.remove("on");
   playBtn.disabled = false;
-  playBtn.textContent = "▶ 4×";
+  playBtn.textContent = "▶ 回放";
 }
 document.getElementById("vcrclose").onclick = vcrClose;
 vcr.onclick = e => { if (e.target === vcr) vcrClose(); };
@@ -447,145 +451,9 @@ addEventListener("keydown", e => {
   if (e.key === "Escape" && vcr.classList.contains("on")) { escSwallow = true; vcrClose(); }
 });
 
-// ---- export the recording as a video ---------------------------------------
-const saveBtn = document.getElementById("save");
+// ---- export the recording in the background (video-export.js) --------------
 
-function pickMime() {
-  for (const t of ["video/mp4;codecs=avc1.42E01E", "video/mp4",
-                   "video/webm;codecs=vp9", "video/webm"]) {
-    if (MediaRecorder.isTypeSupported(t)) return t;
-  }
-  return "";
-}
-
-saveBtn.onclick = async () => {
-  if (!window.MediaRecorder) return;
-  const mime = pickMime();
-  if (!mime) { saveBtn.textContent = "unsupported"; return; }
-
-  saveBtn.disabled = true;
-  playBtn.disabled = true;
-  saveBtn.title = "encodes in real time at 4x, so about a quarter of the session length";
-  saveBtn.textContent = "loading";
-  let recording;
-  // MediaRecorder samples in real time, so the export takes the recording
-  // length divided by the playback speed. Say so rather than appear stuck.
-  try {
-    recording = await ReplayRecording.open();
-  } catch { saveBtn.disabled = playBtn.disabled = false; saveBtn.textContent = "⤓ mp4"; return; }
-  if (!(await recording.peek())) { recording.close(); saveBtn.disabled = playBtn.disabled = false; saveBtn.textContent = "⤓ mp4"; return; }
-
-  // 640x400 keeps both game modes at a whole multiple, plus a strip for keys.
-  const W = 640, H = 400, BAR = 56;
-  const out = document.createElement("canvas");
-  out.width = W; out.height = H + BAR;
-  const octx = out.getContext("2d", { alpha: false });
-  octx.imageSmoothingEnabled = false;
-  const work = document.createElement("canvas");
-  const wctx = work.getContext("2d", { alpha: false });
-  const cache = {};
-  const down = new Set();
-  let clock = 0, actor = "";
-
-  const chip = (label, x, y, arrow) => {
-    const w = octx.measureText(label).width + 20;
-    octx.fillStyle = "#1c1c22";
-    octx.strokeStyle = arrow ? "#3f6076" : "#33333d";
-    octx.beginPath();
-    octx.roundRect(x, y, w, 32, 5);
-    octx.fill(); octx.stroke();
-    octx.fillStyle = arrow ? "#8ecdf7" : "#cdcdd6";
-    octx.fillText(label, x + 10, y + 16);
-    return w;
-  };
-
-  const compose = () => {
-    octx.fillStyle = "#0b0b0d";
-    octx.fillRect(0, 0, W, H + BAR);
-    if (work.width) {
-      const sc = Math.min(W / work.width, H / work.height);
-      const dw = work.width * sc, dh = work.height * sc;
-      octx.drawImage(work, (W - dw) / 2, (H - dh) / 2, dw, dh);
-    }
-    octx.fillStyle = "#101014";
-    octx.fillRect(0, H, W, BAR);
-    octx.textBaseline = "middle";
-    let x = 14;
-    if (actor) {
-      octx.font = "17px ui-monospace, Menlo, monospace";
-      octx.fillStyle = colorOf(actor);
-      octx.fillText(actor, x, H + 28);
-      x += octx.measureText(actor).width + 16;
-    }
-    octx.font = "20px ui-monospace, Menlo, monospace";
-    for (const k of down) x += chip(GLYPH[k] ?? k, x, H + 12, ARROW.has(k)) + 8;
-    octx.fillStyle = "#6c6c78";
-    octx.font = "16px ui-monospace, Menlo, monospace";
-    octx.textAlign = "right";
-    octx.fillText(fmt(clock) + "  4x", W - 14, H + 28);
-    octx.textAlign = "left";
-  };
-
-  compose();
-  const stream = out.captureStream(30);
-  const mr = new MediaRecorder(stream, { mimeType: mime, videoBitsPerSecond: 4_000_000 });
-  const chunks = [];
-  mr.ondataavailable = e => e.data.size && chunks.push(e.data);
-  const finished = new Promise(r => (mr.onstop = r));
-  mr.start();
-
-  const SPEED = 4;
-  const total = recording.duration || 1;
-  const t0 = performance.now();
-  let exportError = null;
-  let raf = requestAnimationFrame(function loop() { compose(); raf = requestAnimationFrame(loop); });
-
-  try {
-  while (true) {
-    const ev = await recording.peek();
-    if (!ev) break;
-    const wait = t0 + (ev.t * 1000) / SPEED - performance.now();
-    if (wait > 2) { await new Promise(r => setTimeout(r, wait)); continue; }
-    recording.take();
-    clock = ev.t;
-    if (ev.d) {
-      paintDelta(await inflate(b64bytes(ev.d)), work, wctx, cache);
-    } else if (ev.key) {
-      if (ev.who) actor = ev.who;
-      ev.down ? down.add(ev.key) : down.delete(ev.key);
-    }
-    const left = Math.max(0, (total - ev.t) / SPEED);
-    saveBtn.textContent = Math.round((ev.t / total) * 100) + "% " + fmt(left);
-  }
-
-  } catch (error) { exportError = error; }
-  finally { recording.close(); }
-
-  await new Promise(r => setTimeout(r, 300));   // let the tail frames be sampled
-  cancelAnimationFrame(raf);
-  mr.stop();
-  await finished;
-
-  if (exportError) {
-    saveBtn.textContent = "export failed";
-    saveBtn.title = exportError.message;
-    saveBtn.disabled = playBtn.disabled = false;
-    return;
-  }
-
-  const ext = mime.startsWith("video/mp4") ? "mp4" : "webm";
-  const blob = new Blob(chunks, { type: mime });
-  const a = document.createElement("a");
-  a.href = URL.createObjectURL(blob);
-  a.download = `jy-crpg-bench-${new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-")}.${ext}`;
-  a.click();
-  setTimeout(() => URL.revokeObjectURL(a.href), 10000);
-
-  saveBtn.textContent = "⤓ " + ext;
-  saveBtn.disabled = playBtn.disabled = false;
-};
-
-async function openPlayback(recording = 'current') {
+async function openPlayback(recording = 'current', mode = 'actions') {
   // A focused Play button can be activated again before its first fetch ends.
   // Keep exactly one owner of the canvas and of the pinned replay reader.
   if (vcrStop || vcr.classList.contains("on")) return;
@@ -595,28 +463,50 @@ async function openPlayback(recording = 'current') {
   document.getElementById("recordingfiles").open = false;
   document.getElementById("vcrclose").focus();
   let source, player, closed = false;
+  const lifetime = new AbortController();
   const cache = {};
   const keys = new ReplayKeys(vcrKeys, {glyphs:GLYPH, arrows:ARROW, colorOf});
   const seek = document.getElementById("vcrseek"), pause = document.getElementById("vcrpause");
-  const speed = document.getElementById("vcrspeed");
+  const speed = document.getElementById("vcrspeed"), modeSelect = document.getElementById("vcrmode");
+  const status = document.getElementById("vcrstatus"), recorded = document.getElementById("vcrrecorded");
+  const actions = mode !== 'full';
+  modeSelect.value = actions ? 'actions' : 'full';
+  modeSelect.onchange = () => { const selected = modeSelect.value; vcrClose(); openPlayback(recording, selected); };
   seek.disabled = pause.disabled = speed.disabled = true;
   seek.max = seek.value = "0";
   seek.setAttribute("aria-valuetext", "0:00 / 0:00");
   document.getElementById("vcrtime").textContent = "loading…";
   document.getElementById("vcrduration").textContent = "0:00";
+  recorded.textContent = '';
+  status.textContent = actions ? '正在读取动作记录…' : '完整录制保留原始空闲，播放时间可能很长。';
   pause.textContent = "pause";
   speed.value = "4";
-  vcrStop = () => { closed = true; player?.close(); source?.close(); };
+  vcrStop = () => { closed = true; lifetime.abort(); player?.close(); source?.close(); };
   const reset = held => {
     vctx.fillStyle = "#000"; vctx.fillRect(0, 0, vcv.width, vcv.height);
     cache.img = null;
     keys.reset(held);
   };
+  const failed = error => {
+    if (closed) return;
+    playBtn.textContent = "replay unavailable";
+    playBtn.title = error.message;
+    status.textContent = error.message;
+    document.getElementById("vcrtime").textContent = '读取失败';
+    seek.disabled = pause.disabled = speed.disabled = true;
+  };
   reset({});
   try {
-    source = await ReplayRecording.open(recording);
+    source = actions ? await StepReplaySource.open(recording, {
+      signal:lifetime.signal,
+      progress:meta => {
+        if (closed) return;
+        const percent = meta.total ? ' ' + Math.min(100, Math.floor(100 * meta.scanned / meta.total)) + '%' : '';
+        status.textContent = '正在准备磁盘动作索引' + percent + '，完成后开始回放。';
+      },
+    }) : await ReplayRecording.open(recording);
     if (closed) { source.close(); return; }
-    player = new ReplayPlayer(source, {
+    const callbacks = {
       decode: ev => inflate(b64bytes(ev.d)),
       complete: d => {
         const v = new DataView(d.buffer, d.byteOffset, d.byteLength);
@@ -624,28 +514,46 @@ async function openPlayback(recording = 'current') {
       },
       reset,
       paint: (decoded, ev) => {
-        if (decoded) paintDelta(decoded, vcv, vctx, cache);
-        keys.apply(ev);
+        if (actions) {
+          vcv.width = decoded.width; vcv.height = decoded.height;
+          vctx.imageSmoothingEnabled = false;
+          vctx.drawImage(decoded, 0, 0);
+          keys.showStep(ev);
+        } else {
+          if (decoded) paintDelta(decoded, vcv, vctx, cache);
+          keys.apply(ev);
+          recorded.textContent = '原时间 ' + fmt(ev.t || 0);
+        }
       },
       update: state => {
+        if (closed) return;
         seek.max = String(state.duration); seek.value = String(state.position);
         seek.disabled = pause.disabled = speed.disabled = !state.ready;
-        seek.setAttribute("aria-valuetext", fmt(state.position) + " / " + fmt(state.duration));
-        document.getElementById("vcrtime").textContent = state.loading ? "loading…" : fmt(state.position);
-        document.getElementById("vcrduration").textContent = fmt(state.duration);
+        const scale = actions ? state.speed : 1;
+        const clock = fmt(state.position / scale), duration = fmt(state.duration / scale);
+        seek.setAttribute("aria-valuetext", actions
+          ? `动作 ${state.index + 1} / ${state.total}，原时间 ${fmt(state.step?.t || 0)}`
+          : clock + " / " + duration);
+        document.getElementById("vcrtime").textContent = state.loading ? "loading…" : clock;
+        document.getElementById("vcrduration").textContent = duration;
+        if (actions) {
+          recorded.textContent = `动作 ${state.index + 1} / ${state.total} · 原时间 ${fmt(state.step?.t || 0)}`;
+          status.textContent = state.loading ? '正在读取动作画面…' : `每步 ${(0.6 / state.speed).toFixed(2)} 秒 · 已跳过动作间空闲`;
+        }
         pause.textContent = state.playing ? "pause" : "resume";
         speed.value = String(state.speed);
         playBtn.textContent = "replay";
       },
-      error: error => { playBtn.textContent = "replay unavailable"; playBtn.title = error.message; },
-    });
+      error:failed,
+    };
+    player = actions ? new ActionReplayPlayer(source, callbacks) : new ReplayPlayer(source, callbacks);
     pause.onclick = () => player.wantPlaying ? player.pause() : player.play();
     seek.oninput = () => player.seek(Number(seek.value));
     speed.onchange = e => player.setSpeed(Number(e.target.value));
     await player.start();
   } catch (error) {
     source?.close();
-    if (!closed) { playBtn.textContent = "replay unavailable"; playBtn.title = error.message; }
+    failed(error);
   }
 }
 playBtn.onclick = () => openPlayback();
@@ -1218,3 +1126,5 @@ document.getElementById("open").onclick = () => window.open("/api/help?lang=" + 
 fit();
 connect();
 </script>
+
+<script src="video-export.js"></script>

--- a/server/index.html
+++ b/server/index.html
@@ -577,15 +577,24 @@ playBtn.onclick = async () => {
   playBtn.textContent = "loading";
   vcr.classList.add("on");
   let source, player, closed = false;
-  const cache = {}, down = new Set();
+  const cache = {};
+  const keys = new ReplayKeys(vcrKeys, {glyphs:GLYPH, arrows:ARROW, colorOf});
   const seek = document.getElementById("vcrseek"), pause = document.getElementById("vcrpause");
+  const speed = document.getElementById("vcrspeed");
+  seek.disabled = pause.disabled = speed.disabled = true;
+  seek.max = seek.value = "0";
+  seek.setAttribute("aria-valuetext", "0:00 / 0:00");
+  document.getElementById("vcrtime").textContent = "loading…";
+  document.getElementById("vcrduration").textContent = "0:00";
+  pause.textContent = "pause";
+  speed.value = "4";
   vcrStop = () => { closed = true; player?.close(); source?.close(); };
   const reset = held => {
     vctx.fillStyle = "#000"; vctx.fillRect(0, 0, vcv.width, vcv.height);
-    cache.img = null; down.clear();
-    for (const key of Object.keys(held)) down.add(key);
-    vcrKeys.textContent = [...down].map(k=>GLYPH[k] ?? k).join(" ");
+    cache.img = null;
+    keys.reset(held);
   };
+  reset({});
   try {
     source = await ReplayRecording.open();
     if (closed) { source.close(); return; }
@@ -598,25 +607,23 @@ playBtn.onclick = async () => {
       reset,
       paint: (decoded, ev) => {
         if (decoded) paintDelta(decoded, vcv, vctx, cache);
-        if (ev.key) {
-          ev.down ? down.add(ev.key) : down.delete(ev.key);
-          vcrKeys.textContent = [...down].map(k=>GLYPH[k] ?? k).join(" ");
-        }
+        keys.apply(ev);
       },
       update: state => {
         seek.max = String(state.duration); seek.value = String(state.position);
+        seek.disabled = pause.disabled = speed.disabled = !state.ready;
         seek.setAttribute("aria-valuetext", fmt(state.position) + " / " + fmt(state.duration));
         document.getElementById("vcrtime").textContent = state.loading ? "loading…" : fmt(state.position);
         document.getElementById("vcrduration").textContent = fmt(state.duration);
         pause.textContent = state.playing ? "pause" : "resume";
-        document.getElementById("vcrspeed").value = String(state.speed);
+        speed.value = String(state.speed);
         playBtn.textContent = "replay";
       },
       error: error => { playBtn.textContent = "replay unavailable"; playBtn.title = error.message; },
     });
     pause.onclick = () => player.wantPlaying ? player.pause() : player.play();
     seek.oninput = () => player.seek(Number(seek.value));
-    document.getElementById("vcrspeed").onchange = e => player.setSpeed(Number(e.target.value));
+    speed.onchange = e => player.setSpeed(Number(e.target.value));
     await player.start();
   } catch (error) {
     source?.close();
@@ -1051,25 +1058,50 @@ const MAP = {
   ArrowUp: "up", ArrowDown: "down", ArrowLeft: "left", ArrowRight: "right",
   Enter: "enter", Escape: "esc", " ": "space", Backspace: "backspace", Tab: "tab",
 };
+// Game keyboard routing. UI controls own their keys and never steer the game.
 const held = new Set();
+function uiOwnsKeyboard(target) {
+  if (slotOpen() || document.getElementById("vcr")?.classList.contains("on")) return true;
+  return !!(target?.isContentEditable || target?.closest?.(
+    "input,textarea,select,button:not([data-k]),a,summary,[role=tab],[role=slider]"));
+}
+function releaseGameKeys() {
+  for (const k of held) send({t:"key", k, down:false});
+  held.clear();
+}
 addEventListener("keydown", e => {
   if (e.key === "Escape" && escSwallow) { escSwallow = false; return; }
-  if (slotOpen()) return;           // reading the save is not playing
+  if (e.isComposing || e.metaKey || e.ctrlKey || e.altKey || uiOwnsKeyboard(e.target)) {
+    releaseGameKeys();
+    return;
+  }
   const k = MAP[e.key] || (e.key.length === 1 ? e.key.toLowerCase() : null);
   if (!k) return;
   e.preventDefault();
-  if (held.has(k)) return;          // ignore auto-repeat, the game does its own
+  if (held.has(k)) return;
   held.add(k);
-  send({ t: "key", k, down: true });
+  send({t:"key", k, down:true});
 });
 addEventListener("keyup", e => {
-  if (slotOpen() && !held.size) return;
   const k = MAP[e.key] || (e.key.length === 1 ? e.key.toLowerCase() : null);
-  if (!k) return;
+  if (!held.has(k)) return;
+  // Release a game-owned key even if focus moved into a control meanwhile.
   e.preventDefault();
   held.delete(k);
-  send({ t: "key", k, down: false });
+  send({t:"key", k, down:false});
 });
+addEventListener("blur", releaseGameKeys);
+document.addEventListener("visibilitychange", () => { if (document.hidden) releaseGameKeys(); });
+document.addEventListener("focusin", e => { if (uiOwnsKeyboard(e.target)) releaseGameKeys(); });
+document.addEventListener("pointerdown", e => { if (uiOwnsKeyboard(e.target)) releaseGameKeys(); });
+if (typeof MutationObserver !== "undefined") {
+  const observer = new MutationObserver(() => { if (uiOwnsKeyboard(null)) releaseGameKeys(); });
+  for (const id of ["vcr", "slot"]) {
+    const modal = document.getElementById(id);
+    if (modal) observer.observe(modal, {attributes:true, attributeFilter:["class"]});
+  }
+}
+// End game keyboard routing.
 
 for (const b of document.querySelectorAll("button[data-k]")) {
   const k = b.dataset.k;

--- a/server/index.html
+++ b/server/index.html
@@ -320,14 +320,14 @@
 <div id="vcr">
   <canvas id="vcv" width="320" height="200"></canvas>
   <div id="vcrkeys"></div>
-  <div id="vcrrecorded"></div>
+  <div id="vcrrecorded" title="原始时间从这份录像开始计时，播放进度已跳过空闲。"></div>
   <div id="vcrstatus" role="status"></div>
   <div id="vcrbar">
-    <select id="vcrmode" aria-label="回放模式"><option value="actions">动作回放（跳过空闲）</option><option value="full">完整录制（含空闲）</option></select>
     <span id="vcrtime">0:00</span>
-    <input id="vcrseek" type="range" min="0" max="0" step="0.1" value="0" aria-label="Replay position">
+    <input id="vcrseek" type="range" min="0" max="0" step="0.1" value="0" aria-label="动作回放进度">
     <span id="vcrduration">0:00</span>
     <button id="vcrpause">pause</button>
+    <button id="vcrretry" hidden>重试</button>
     <select id="vcrspeed" aria-label="Replay speed"><option value="1">1×</option><option value="2">2×</option><option value="4" selected>4×</option><option value="8">8×</option></select>
     <button id="vcrclose">close</button>
   </div>
@@ -453,7 +453,7 @@ addEventListener("keydown", e => {
 
 // ---- export the recording in the background (video-export.js) --------------
 
-async function openPlayback(recording = 'current', mode = 'actions') {
+async function openPlayback(recording = 'current') {
   // A focused Play button can be activated again before its first fetch ends.
   // Keep exactly one owner of the canvas and of the pinned replay reader.
   if (vcrStop || vcr.classList.contains("on")) return;
@@ -464,27 +464,32 @@ async function openPlayback(recording = 'current', mode = 'actions') {
   document.getElementById("vcrclose").focus();
   let source, player, closed = false;
   const lifetime = new AbortController();
-  const cache = {};
   const keys = new ReplayKeys(vcrKeys, {glyphs:GLYPH, arrows:ARROW, colorOf});
   const seek = document.getElementById("vcrseek"), pause = document.getElementById("vcrpause");
-  const speed = document.getElementById("vcrspeed"), modeSelect = document.getElementById("vcrmode");
+  const speed = document.getElementById("vcrspeed"), retry = document.getElementById("vcrretry");
   const status = document.getElementById("vcrstatus"), recorded = document.getElementById("vcrrecorded");
-  const actions = mode !== 'full';
-  modeSelect.value = actions ? 'actions' : 'full';
-  modeSelect.onchange = () => { const selected = modeSelect.value; vcrClose(); openPlayback(recording, selected); };
+  retry.hidden = true;
+  retry.onclick = () => { vcrClose(); return openPlayback(recording); };
+  const formatRecordedTime = seconds => {
+    if (!Number.isFinite(Number(seconds)) || seconds == null) return '—';
+    const millis = Math.max(0, Math.round(Number(seconds) * 1000));
+    const hours = Math.floor(millis / 3600000);
+    const minutes = Math.floor(millis / 60000) % 60;
+    const wholeSeconds = Math.floor(millis / 1000) % 60;
+    return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(wholeSeconds).padStart(2, '0')}.${String(millis % 1000).padStart(3, '0')}`;
+  };
   seek.disabled = pause.disabled = speed.disabled = true;
   seek.max = seek.value = "0";
   seek.setAttribute("aria-valuetext", "0:00 / 0:00");
   document.getElementById("vcrtime").textContent = "loading…";
   document.getElementById("vcrduration").textContent = "0:00";
   recorded.textContent = '';
-  status.textContent = actions ? '正在读取动作记录…' : '完整录制保留原始空闲，播放时间可能很长。';
+  status.textContent = '正在读取动作记录…';
   pause.textContent = "pause";
   speed.value = "4";
   vcrStop = () => { closed = true; lifetime.abort(); player?.close(); source?.close(); };
   const reset = held => {
     vctx.fillStyle = "#000"; vctx.fillRect(0, 0, vcv.width, vcv.height);
-    cache.img = null;
     keys.reset(held);
   };
   const failed = error => {
@@ -493,60 +498,45 @@ async function openPlayback(recording = 'current', mode = 'actions') {
     playBtn.title = error.message;
     status.textContent = error.message;
     document.getElementById("vcrtime").textContent = '读取失败';
+    retry.hidden = false;
     seek.disabled = pause.disabled = speed.disabled = true;
   };
   reset({});
   try {
-    source = actions ? await StepReplaySource.open(recording, {
+    source = await StepReplaySource.open(recording, {
       signal:lifetime.signal,
       progress:meta => {
         if (closed) return;
         const percent = meta.total ? ' ' + Math.min(100, Math.floor(100 * meta.scanned / meta.total)) + '%' : '';
         status.textContent = '正在准备磁盘动作索引' + percent + '，完成后开始回放。';
       },
-    }) : await ReplayRecording.open(recording);
+    });
     if (closed) { source.close(); return; }
     const callbacks = {
-      decode: ev => inflate(b64bytes(ev.d)),
-      complete: d => {
-        const v = new DataView(d.buffer, d.byteOffset, d.byteLength);
-        return d.length >= 13 && v.getUint16(11, true) === v.getUint16(7, true) * v.getUint16(9, true);
-      },
-      reset,
       paint: (decoded, ev) => {
-        if (actions) {
-          vcv.width = decoded.width; vcv.height = decoded.height;
-          vctx.imageSmoothingEnabled = false;
-          vctx.drawImage(decoded, 0, 0);
-          keys.showStep(ev);
-        } else {
-          if (decoded) paintDelta(decoded, vcv, vctx, cache);
-          keys.apply(ev);
-          recorded.textContent = '原时间 ' + fmt(ev.t || 0);
-        }
+        vcv.width = decoded.width; vcv.height = decoded.height;
+        vctx.imageSmoothingEnabled = false;
+        vctx.drawImage(decoded, 0, 0);
+        keys.showStep(ev);
       },
       update: state => {
         if (closed) return;
         seek.max = String(state.duration); seek.value = String(state.position);
         seek.disabled = pause.disabled = speed.disabled = !state.ready;
-        const scale = actions ? state.speed : 1;
-        const clock = fmt(state.position / scale), duration = fmt(state.duration / scale);
-        seek.setAttribute("aria-valuetext", actions
-          ? `动作 ${state.index + 1} / ${state.total}，原时间 ${fmt(state.step?.t || 0)}`
-          : clock + " / " + duration);
-        document.getElementById("vcrtime").textContent = state.loading ? "loading…" : clock;
+        const clock = fmt(state.position / state.speed), duration = fmt(state.duration / state.speed);
+        const original = formatRecordedTime(state.step?.recorded_t ?? state.step?.t);
+        seek.setAttribute("aria-valuetext", `播放 ${clock} / ${duration}，动作 ${state.index + 1} / ${state.total}，原始时间 ${original}`);
+        document.getElementById("vcrtime").textContent = state.loading ? "loading…" : '播放 ' + clock;
         document.getElementById("vcrduration").textContent = duration;
-        if (actions) {
-          recorded.textContent = `动作 ${state.index + 1} / ${state.total} · 原时间 ${fmt(state.step?.t || 0)}`;
-          status.textContent = state.loading ? '正在读取动作画面…' : `每步 ${(0.6 / state.speed).toFixed(2)} 秒 · 已跳过动作间空闲`;
-        }
+        recorded.textContent = `动作 ${state.index + 1} / ${state.total} · 原始时间 ${original}`;
+        status.textContent = state.loading ? '正在读取动作画面…' : `每步 ${(0.6 / state.speed).toFixed(2)} 秒 · 已跳过动作间空闲`;
         pause.textContent = state.playing ? "pause" : "resume";
         speed.value = String(state.speed);
         playBtn.textContent = "replay";
       },
       error:failed,
     };
-    player = actions ? new ActionReplayPlayer(source, callbacks) : new ReplayPlayer(source, callbacks);
+    player = new ActionReplayPlayer(source, callbacks);
     pause.onclick = () => player.wantPlaying ? player.pause() : player.play();
     seek.oninput = () => player.seek(Number(seek.value));
     speed.onchange = e => player.setSpeed(Number(e.target.value));

--- a/server/index.html
+++ b/server/index.html
@@ -50,8 +50,8 @@
   #vcrkeys .k { font-size: 13px; min-width: 20px; padding: 2px 6px; }
   #vcrbar { display: flex; align-items: center; gap: 10px; font-size: 11px; color: #9a9aa6; }
   #vcrkeys { display: flex; gap: 4px; min-height: 20px; align-items: center; }
-  #vcrtrack { width: 260px; height: 4px; background: #26262c; border-radius: 2px; overflow: hidden; }
-  #vcrfill { display: block; height: 4px; width: 0; background: #6cb6ff; }
+  #vcrbar { flex-wrap: wrap; justify-content: center; max-width: 94vw; }
+  #vcrseek { width: min(35vw, 360px); accent-color: #6cb6ff; }
   #logrows { overflow-y: auto; padding: 6px 0 10px; flex: 1; }
   .r { display: flex; gap: 7px; padding: 2px 12px; font-size: 11px; line-height: 1.5; white-space: nowrap; }
   .r:hover { background: #17171c; }
@@ -309,7 +309,10 @@
   <div id="vcrkeys"></div>
   <div id="vcrbar">
     <span id="vcrtime">0:00</span>
-    <span id="vcrtrack"><span id="vcrfill"></span></span>
+    <input id="vcrseek" type="range" min="0" max="0" step="0.1" value="0" aria-label="Replay position">
+    <span id="vcrduration">0:00</span>
+    <button id="vcrpause">pause</button>
+    <select id="vcrspeed" aria-label="Replay speed"><option value="1">1×</option><option value="2">2×</option><option value="4" selected>4×</option><option value="8">8×</option></select>
     <button id="vcrclose">close</button>
   </div>
 </div>
@@ -343,7 +346,8 @@
 </aside>
 </div>
 
-<script src="/recording.js"></script>
+<script src="recording.js"></script>
+<script src="replay.js"></script>
 <script>
 const cv = document.getElementById("screen");
 const ctx = cv.getContext("2d", { alpha: false });
@@ -571,65 +575,53 @@ saveBtn.onclick = async () => {
 playBtn.onclick = async () => {
   playBtn.disabled = true;
   playBtn.textContent = "loading";
-  let recording;
-  try {
-    recording = await ReplayRecording.open();
-  } catch { playBtn.disabled = false; playBtn.textContent = "▶ 4×"; return; }
-  if (!(await recording.peek())) { recording.close(); playBtn.disabled = false; playBtn.textContent = "▶ 4×"; return; }
-
-  playBtn.textContent = "playing";
   vcr.classList.add("on");
-  vctx.fillStyle = "#000";
-  vctx.fillRect(0, 0, vcv.width, vcv.height);
-  vcrKeys.textContent = "";
-
-  const SPEED = 4;
-  const total = recording.duration || 1;
-  const cache = {};
-  const down = new Set();
-  let cancelled = false;
-  vcrStop = () => { cancelled = true; recording.close(); };
-
-  const t0 = performance.now();
-  const step = async () => {
-    try {
-    while (!cancelled) {
-      const ev = await recording.peek();
-      if (!ev) break;
-      const due = t0 + (ev.t * 1000) / SPEED;
-      const wait = due - performance.now();
-      if (wait > 4) { setTimeout(step, wait); return; }
-      recording.take();
-      if (ev.d) {
-        paintDelta(await inflate(b64bytes(ev.d)), vcv, vctx, cache);
-      } else if (ev.key) {
-        ev.down ? down.add(ev.key) : down.delete(ev.key);
-        vcrKeys.textContent = "";
-        if (ev.who) {
-          const who = document.createElement("span");
-          who.textContent = ev.who;
-          who.style.color = colorOf(ev.who);
-          who.style.marginRight = "6px";
-          vcrKeys.appendChild(who);
-        }
-        for (const k of down) {
-          const chip = document.createElement("span");
-          chip.className = "k" + (ARROW.has(k) ? " arrow" : "");
-          chip.textContent = GLYPH[k] ?? k;
-          vcrKeys.appendChild(chip);
-        }
-      }
-      document.getElementById("vcrfill").style.width = (ev.t / total) * 100 + "%";
-      document.getElementById("vcrtime").textContent = fmt(ev.t);
-    }
-    recording.close();
-    if (!cancelled) { playBtn.textContent = "▶ 4×"; }
-    } catch (error) {
-      recording.close();
-      if (!cancelled) { playBtn.textContent = "replay unavailable"; playBtn.title = error.message; }
-    }
+  let source, player, closed = false;
+  const cache = {}, down = new Set();
+  const seek = document.getElementById("vcrseek"), pause = document.getElementById("vcrpause");
+  vcrStop = () => { closed = true; player?.close(); source?.close(); };
+  const reset = held => {
+    vctx.fillStyle = "#000"; vctx.fillRect(0, 0, vcv.width, vcv.height);
+    cache.img = null; down.clear();
+    for (const key of Object.keys(held)) down.add(key);
+    vcrKeys.textContent = [...down].map(k=>GLYPH[k] ?? k).join(" ");
   };
-  step();
+  try {
+    source = await ReplayRecording.open();
+    if (closed) { source.close(); return; }
+    player = new ReplayPlayer(source, {
+      decode: ev => inflate(b64bytes(ev.d)),
+      complete: d => {
+        const v = new DataView(d.buffer, d.byteOffset, d.byteLength);
+        return d.length >= 13 && v.getUint16(11, true) === v.getUint16(7, true) * v.getUint16(9, true);
+      },
+      reset,
+      paint: (decoded, ev) => {
+        if (decoded) paintDelta(decoded, vcv, vctx, cache);
+        if (ev.key) {
+          ev.down ? down.add(ev.key) : down.delete(ev.key);
+          vcrKeys.textContent = [...down].map(k=>GLYPH[k] ?? k).join(" ");
+        }
+      },
+      update: state => {
+        seek.max = String(state.duration); seek.value = String(state.position);
+        seek.setAttribute("aria-valuetext", fmt(state.position) + " / " + fmt(state.duration));
+        document.getElementById("vcrtime").textContent = state.loading ? "loading…" : fmt(state.position);
+        document.getElementById("vcrduration").textContent = fmt(state.duration);
+        pause.textContent = state.playing ? "pause" : "resume";
+        document.getElementById("vcrspeed").value = String(state.speed);
+        playBtn.textContent = "replay";
+      },
+      error: error => { playBtn.textContent = "replay unavailable"; playBtn.title = error.message; },
+    });
+    pause.onclick = () => player.wantPlaying ? player.pause() : player.play();
+    seek.oninput = () => player.seek(Number(seek.value));
+    document.getElementById("vcrspeed").onchange = e => player.setSpeed(Number(e.target.value));
+    await player.start();
+  } catch (error) {
+    source?.close();
+    if (!closed) { playBtn.textContent = "replay unavailable"; playBtn.title = error.message; }
+  }
 };
 
 function connect() {

--- a/server/index.html
+++ b/server/index.html
@@ -37,6 +37,18 @@
   }
   #play:hover, #save:hover { border-color: #4a4a58; color: #fff; }
   #play[disabled], #save[disabled] { opacity: .45; cursor: default; }
+  #recordingfiles { position: relative; width: auto; border: 0; background: none; }
+  #recordingfiles summary { display: block; padding: 1px 5px; font-size: 17px; line-height: 1.2; letter-spacing: 0; }
+  #recordinglinks {
+    position: absolute; right: 0; top: 28px; width: min(280px, 80vw);
+    max-height: 300px; overflow: auto; z-index: 25; padding: 12px;
+    background: #17171d; border: 1px solid #383844; border-radius: 5px;
+    box-shadow: 0 7px 25px #0008; font-size: 11px; letter-spacing: 0;
+  }
+  .recording-file + .recording-file { margin-top: 12px; }
+  .recording-file-name { display: block; margin-bottom: 5px; overflow-wrap: anywhere; }
+  #recordinglinks a { color: #8ecdf7; }
+  #recordinglinks button { margin-left: 10px; padding: 3px 7px; font-size: 10px; }
   #vcr {
     position: fixed; inset: 0; z-index: 20; display: none;
     background: #000d; backdrop-filter: blur(2px);
@@ -332,7 +344,8 @@
   <div id="roster"></div>
   <h2>ACTIVITY
     <span class="right"><em id="logcount"></em>
-      <button id="play">▶ 4×</button><button id="save">⤓ mp4</button></span>
+      <button id="play">▶ 4×</button><button id="save">⤓ mp4</button>
+      <details id="recordingfiles"><summary aria-label="更多录像" title="更多录像">···</summary><div id="recordinglinks">正在读取录像文件…</div></details></span>
   </h2>
   <div id="meter">
     <span>played <b id="m-time">0:00</b></span>
@@ -572,10 +585,15 @@ saveBtn.onclick = async () => {
   saveBtn.disabled = playBtn.disabled = false;
 };
 
-playBtn.onclick = async () => {
+async function openPlayback(recording = 'current') {
+  // A focused Play button can be activated again before its first fetch ends.
+  // Keep exactly one owner of the canvas and of the pinned replay reader.
+  if (vcrStop || vcr.classList.contains("on")) return;
   playBtn.disabled = true;
   playBtn.textContent = "loading";
   vcr.classList.add("on");
+  document.getElementById("recordingfiles").open = false;
+  document.getElementById("vcrclose").focus();
   let source, player, closed = false;
   const cache = {};
   const keys = new ReplayKeys(vcrKeys, {glyphs:GLYPH, arrows:ARROW, colorOf});
@@ -596,7 +614,7 @@ playBtn.onclick = async () => {
   };
   reset({});
   try {
-    source = await ReplayRecording.open();
+    source = await ReplayRecording.open(recording);
     if (closed) { source.close(); return; }
     player = new ReplayPlayer(source, {
       decode: ev => inflate(b64bytes(ev.d)),
@@ -629,7 +647,60 @@ playBtn.onclick = async () => {
     source?.close();
     if (!closed) { playBtn.textContent = "replay unavailable"; playBtn.title = error.message; }
   }
-};
+}
+playBtn.onclick = () => openPlayback();
+
+// ---- recording files ------------------------------------------------------
+const recordingFiles = document.getElementById("recordingfiles");
+const recordingLinks = document.getElementById("recordinglinks");
+let recordingsRequest = 0;
+recordingFiles.addEventListener("toggle", async () => {
+  const request = ++recordingsRequest;
+  if (!recordingFiles.open) return;
+  recordingLinks.textContent = "正在读取录像文件…";
+  try {
+    const response = await fetch("api/recordings", {cache:"no-store"});
+    if (response.status === 404) throw new Error("当前服务器暂不支持录像列表。");
+    if (!response.ok) throw new Error("暂时无法读取录像文件，请稍后重试。");
+    const body = await response.json();
+    if (!recordingFiles.open || request !== recordingsRequest) return;
+    if (!Array.isArray(body.files)) throw new Error("录像列表格式无法识别。");
+    recordingLinks.replaceChildren();
+    for (const file of body.files) {
+      const row = document.createElement("div");
+      row.className = "recording-file";
+      const name = document.createElement("span");
+      name.className = "recording-file-name";
+      name.textContent = (file.id === "current" ? "当前录像" : file.name.replace(/\.jsonl$/, ""))
+        + " · " + (file.bytes / 1048576).toFixed(1) + " MB";
+      const download = document.createElement("a");
+      download.href = "api/recordings/" + encodeURIComponent(file.id);
+      download.download = file.name;
+      download.textContent = "下载原文";
+      const replay = document.createElement("button");
+      replay.type = "button";
+      replay.textContent = "回放";
+      replay.onclick = () => { recordingFiles.open = false; openPlayback(file.id); };
+      row.append(name, download, replay);
+      recordingLinks.appendChild(row);
+    }
+    if (!body.files.length) recordingLinks.textContent = "还没有录像文件。";
+  } catch (error) {
+    if (recordingFiles.open && request === recordingsRequest) recordingLinks.textContent = error.message;
+  }
+});
+document.addEventListener("click", event => {
+  if (!event.target.closest("#recordingfiles")) recordingFiles.open = false;
+});
+addEventListener("keydown", event => {
+  if (recordingFiles.open && event.key === "Escape") {
+    recordingFiles.open = false;
+    recordingFiles.querySelector("summary").focus();
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  }
+}, true);
+// ---- live connection ------------------------------------------------------
 
 function connect() {
   sock = new WebSocket((location.protocol === "https:" ? "wss://" : "ws://") + location.host + "/ws");

--- a/server/recording.js
+++ b/server/recording.js
@@ -1,9 +1,11 @@
 // One page at a time; the server pins the recording so reset cannot change it.
 class ReplayRecording {
   abort = new AbortController();
-  static async open() {
+  static async open(recording = 'current') {
     const source = new ReplayRecording();
-    await source.load({});
+    // Select a file only when opening it. Every later request uses the token
+    // for that pinned file, even if the current recording is reset meanwhile.
+    await source.load({recording});
     source.keepalive = setInterval(() => source.request({touch:'1'}).catch(() => {}), 60000);
     return source;
   }
@@ -57,3 +59,4 @@ class ReplayRecording {
     this.page = {events:[],done:true};
   }
 }
+if (typeof module !== 'undefined') module.exports = {ReplayRecording};

--- a/server/recording.js
+++ b/server/recording.js
@@ -1,23 +1,46 @@
 // One page at a time; the server pins the recording so reset cannot change it.
 class ReplayRecording {
+  abort = new AbortController();
   static async open() {
     const source = new ReplayRecording();
     await source.load({});
     source.keepalive = setInterval(() => source.request({touch:'1'}).catch(() => {}), 60000);
     return source;
   }
-  async request(extra) {
+  async request(extra, signal) {
     const query = new URLSearchParams({view:'paged', ...(this.token ? {token:this.token} : {}), ...extra});
-    const response = await fetch('/api/recording?' + query);
+    const response = await fetch('api/recording?' + query, {
+      signal: extra.close ? undefined : signal ? AbortSignal.any([signal, this.abort.signal]) : this.abort.signal,
+    });
     const page = await response.json();
     if (!response.ok) throw new Error(page.error || 'Recording unavailable');
     return page;
   }
   async load(extra) {
-    this.page = await this.request(extra);
+    this.setPage(await this.request(extra));
+  }
+  setPage(page) {
+    this.page = page;
     this.token = this.page.token;
     this.duration = this.page.duration;
+    this.canSeek = this.page.seek_supported ?? this.canSeek ?? false;
     this.index = 0;
+  }
+  async seek(when, signal) {
+    for (;;) {
+      const page = await this.request(this.canSeek ? {time:String(when)} : {}, signal);
+      if (!page.indexing) {
+        this.setPage(page);
+        return page.seek || {at:0, held:{}};
+      }
+      await new Promise((resolve, reject) => {
+        const timer = setTimeout(done, 100);
+        function done() { signal?.removeEventListener('abort', cancel); resolve(); }
+        function cancel() { clearTimeout(timer); reject(signal.reason); }
+        if (signal?.aborted) cancel();
+        else signal?.addEventListener('abort', cancel, {once:true});
+      });
+    }
   }
   async peek() {
     if (this.closed) return null;
@@ -29,6 +52,7 @@ class ReplayRecording {
     if (this.closed) return;
     this.closed = true;
     clearInterval(this.keepalive);
+    this.abort.abort();
     this.request({close:'1'}).catch(() => {});
     this.page = {events:[],done:true};
   }

--- a/server/recording.js
+++ b/server/recording.js
@@ -81,7 +81,7 @@ class StepReplaySource {
       let response = await fetch('api/replay?' + new URLSearchParams({recording}), {cache:'no-store'});
       let meta = await source.json(response);
       source.token = meta.token;
-      if (!source.token) throw Error('动作回放未能开始，可选择“完整录制”。');
+      if (!source.token) throw Error('动作回放未能开始，请重试。');
       if (source.closed) { source.release(); throw source.abort.signal.reason; }
       while (response.status === 202 || meta.indexing) {
         progress(meta);
@@ -90,7 +90,7 @@ class StepReplaySource {
         meta = await source.json(response);
       }
       if (!Number.isSafeInteger(meta.steps) || meta.steps < 1)
-        throw Error('该录像没有可回放的动作，可选择“完整录制”。');
+        throw Error('该录像暂无可回放的动作，稍后可以重试。');
       source.steps = meta.steps;
       source.duration = Number(meta.duration) || 0;
       source.beat = .6;
@@ -100,8 +100,8 @@ class StepReplaySource {
   }
   async json(response) {
     if (!response.ok) throw Error(response.status === 404
-      ? '该录像暂不支持动作回放，请选择“完整录制”。'
-      : '动作回放读取失败，请重试或选择“完整录制”。');
+      ? '该录像的动作历史暂不可用，请重试。'
+      : '动作回放读取失败，请重试。');
     return response.json();
   }
   request(path, signal) {

--- a/server/recording.js
+++ b/server/recording.js
@@ -59,4 +59,142 @@ class ReplayRecording {
     this.page = {events:[],done:true};
   }
 }
-if (typeof module !== 'undefined') module.exports = {ReplayRecording};
+
+// Read action metadata in small pages and reconstruct only the pictures being
+// watched. Recorded wall time is metadata, never the action playback clock.
+class StepReplaySource {
+  constructor() {
+    this.abort = new AbortController();
+    this.pages = new Map();
+    this.frames = new Map();
+    this.pending = new Map();
+  }
+  static async open(recording = 'current', {signal, progress = ()=>{}} = {}) {
+    const source = new StepReplaySource();
+    const close = () => source.close();
+    source.detach = () => signal?.removeEventListener('abort', close);
+    signal?.addEventListener('abort', close, {once:true});
+    try {
+      if (signal?.aborted) throw signal.reason;
+      // The response owns a pinned token. Do not abandon it on close before
+      // learning that token; release it even if a newer viewer has opened.
+      let response = await fetch('api/replay?' + new URLSearchParams({recording}), {cache:'no-store'});
+      let meta = await source.json(response);
+      source.token = meta.token;
+      if (!source.token) throw Error('动作回放未能开始，可选择“完整录制”。');
+      if (source.closed) { source.release(); throw source.abort.signal.reason; }
+      while (response.status === 202 || meta.indexing) {
+        progress(meta);
+        await source.wait(400);
+        response = await source.request('');
+        meta = await source.json(response);
+      }
+      if (!Number.isSafeInteger(meta.steps) || meta.steps < 1)
+        throw Error('该录像没有可回放的动作，可选择“完整录制”。');
+      source.steps = meta.steps;
+      source.duration = Number(meta.duration) || 0;
+      source.beat = .6;
+      source.keepalive = setInterval(() => source.request('').catch(()=>{}), 60000);
+      return source;
+    } catch (error) { source.close(); throw error; }
+  }
+  async json(response) {
+    if (!response.ok) throw Error(response.status === 404
+      ? '该录像暂不支持动作回放，请选择“完整录制”。'
+      : '动作回放读取失败，请重试或选择“完整录制”。');
+    return response.json();
+  }
+  request(path, signal) {
+    return fetch('api/replay/' + encodeURIComponent(this.token) + path, {
+      cache:'no-store', signal:signal ? AbortSignal.any([signal, this.abort.signal]) : this.abort.signal,
+    });
+  }
+  wait(delay) {
+    const signal = this.abort.signal;
+    return new Promise((resolve, reject) => {
+      const done = () => { signal.removeEventListener('abort', aborted); resolve(); };
+      const timer = setTimeout(done, delay);
+      const aborted = () => { clearTimeout(timer); reject(signal.reason); };
+      if (signal.aborted) aborted();
+      else signal.addEventListener('abort', aborted, {once:true});
+    });
+  }
+  check(signal) {
+    if (this.closed || this.abort.signal.aborted) throw this.abort.signal.reason;
+    if (signal?.aborted) throw signal.reason;
+  }
+  async step(number, signal) {
+    this.check(signal);
+    const start = Math.floor(number / 128) * 128;
+    let page = this.pages.get(start);
+    if (!page) {
+      page = await this.json(await this.request(`/steps?start=${start}&count=128`, signal));
+      this.check(signal);
+      if (page.start !== start || !Array.isArray(page.steps)) throw Error('动作列表无法读取。');
+    }
+    this.pages.delete(start); this.pages.set(start, page);
+    while (this.pages.size > 2) this.pages.delete(this.pages.keys().next().value);
+    const step = page.steps[number - start];
+    if (!step) throw Error('该动作不存在。');
+    return step;
+  }
+  async frame(number, signal) {
+    this.check(signal);
+    if (this.frames.has(number)) {
+      const image = this.frames.get(number);
+      this.frames.delete(number); this.frames.set(number, image);
+      return image;
+    }
+    const previous = this.pending.get(number);
+    if (previous && !previous.signal.aborted) return previous.promise;
+    const combined = signal ? AbortSignal.any([signal, this.abort.signal]) : this.abort.signal;
+    const pending = {signal:combined};
+    pending.promise = (async () => {
+      let image;
+      try {
+        const response = await this.request(`/frame?step=${number}`, combined);
+        if (!response.ok || response.status === 202) throw Error('动作画面暂时无法读取，请重试。');
+        const blob = await response.blob();
+        this.check(combined);
+        image = await StepReplaySource.decode(blob);
+        this.check(combined);
+        this.frames.set(number, image);
+        while (this.frames.size > 4) {
+          const oldest = this.frames.keys().next().value;
+          this.frames.get(oldest).close?.(); this.frames.delete(oldest);
+        }
+        return image;
+      } catch (error) { image?.close?.(); throw error; }
+      finally { if (this.pending.get(number) === pending) this.pending.delete(number); }
+    })();
+    this.pending.set(number, pending);
+    return pending.promise;
+  }
+  static async decode(blob) {
+    if (typeof createImageBitmap === 'function') return createImageBitmap(blob);
+    const url = URL.createObjectURL(blob);
+    try { const image = new Image(); image.src = url; await image.decode(); return image; }
+    finally { URL.revokeObjectURL(url); }
+  }
+  prefetch(number, signal) {
+    // At most two future pictures, not the next metadata page's 128 pictures.
+    for (let next = number + 1; next < Math.min(this.steps, number + 3); next++)
+      this.frame(next, signal).catch(()=>{});
+  }
+  release() {
+    if (!this.token || this.released) return;
+    this.released = true;
+    fetch('api/replay/' + encodeURIComponent(this.token), {method:'DELETE',keepalive:true}).catch(()=>{});
+  }
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    this.detach?.();
+    clearInterval(this.keepalive);
+    this.abort.abort();
+    for (const image of this.frames.values()) image.close?.();
+    this.frames.clear(); this.pages.clear(); this.pending.clear();
+    this.release();
+  }
+}
+if (typeof module !== 'undefined') module.exports = {ReplayRecording, StepReplaySource};

--- a/server/replay.js
+++ b/server/replay.js
@@ -2,7 +2,8 @@
 // painted yet; pause/resume keeps the cursor and anchors a new playback clock.
 class ReplayPlayer {
   constructor(source, {decode, paint, complete, reset, update, error,
-                       now=()=>performance.now(), schedule=setTimeout, cancel=clearTimeout}) {
+                       now=()=>performance.now(), schedule=(fn, delay)=>setTimeout(fn, delay),
+                       cancel=timer=>clearTimeout(timer)}) {
     Object.assign(this, {source, decode, paint, complete, reset, update, error, now, schedule, cancel});
     this.position = this.origin = this.duration = this.floor = 0;
     this.speed = 4;

--- a/server/replay.js
+++ b/server/replay.js
@@ -10,7 +10,8 @@ class ReplayPlayer {
     this.epoch = 0;
     this.queue = Promise.resolve();
     this.controller = new AbortController();
-    this.playing = this.wantPlaying = this.loading = this.closed = false;
+    this.playing = this.wantPlaying = this.ready = this.closed = false;
+    this.loading = true;
   }
   current() {
     return Math.min(this.duration, this.playing
@@ -18,7 +19,7 @@ class ReplayPlayer {
   }
   emit() {
     this.update({position:this.position, duration:this.duration, playing:this.wantPlaying,
-                 loading:this.loading, speed:this.speed});
+                 loading:this.loading, ready:this.ready, speed:this.speed});
   }
   enqueue(work) {
     this.queue = this.queue.catch(()=>{}).then(work);
@@ -28,6 +29,8 @@ class ReplayPlayer {
     const epoch = this.epoch;
     let prefixTime = 0;
     this.reset({});
+    this.wantPlaying = true;
+    this.emit();
     for (;;) {
       const event = await this.source.peek();
       if (this.closed || epoch !== this.epoch) return;
@@ -42,8 +45,10 @@ class ReplayPlayer {
       this.origin = this.floor = prefixTime;
       this.duration = Math.max(0, this.source.duration - this.origin);
       this.position = 0;
+      this.ready = true;
+      this.loading = false;
       this.emit();
-      this.play();
+      if (this.wantPlaying) this.play();
       return;
     }
   }
@@ -110,6 +115,9 @@ class ReplayPlayer {
     this.emit();
   }
   seek(position) {
+    // The time origin is unknown until the first complete frame is decoded.
+    // A stale control event must not invalidate that initialization.
+    if (!this.ready || this.closed) return Promise.resolve();
     this.position = Math.max(0, Math.min(this.duration, Number(position) || 0));
     this.playing = false;
     this.loading = true;
@@ -148,4 +156,50 @@ class ReplayPlayer {
     this.source.close();
   }
 }
-if (typeof module !== 'undefined') module.exports = {ReplayPlayer};
+
+// Keep actor ownership when restoring held keys from a seek snapshot.
+class ReplayKeys {
+  constructor(container, {glyphs, arrows, colorOf}) {
+    Object.assign(this, {container, glyphs, arrows, colorOf});
+    this.held = new Map();
+    this.actor = '';
+  }
+  reset(held = {}) {
+    this.held = new Map(Object.entries(held));
+    this.actor = '';
+    this.render();
+  }
+  apply(event) {
+    if (!event.key) return;
+    if (event.who) this.actor = event.who;
+    if (event.down) this.held.set(event.key, event.who || this.actor);
+    else this.held.delete(event.key);
+    this.render();
+  }
+  render() {
+    const groups = new Map();
+    for (const [key, actor] of this.held) {
+      if (!groups.has(actor)) groups.set(actor, []);
+      groups.get(actor).push(key);
+    }
+    if (this.actor && !groups.has(this.actor)) groups.set(this.actor, []);
+    this.container.replaceChildren();
+    const document = this.container.ownerDocument;
+    for (const [actor, keys] of groups) {
+      if (actor) {
+        const who = document.createElement('span');
+        who.textContent = actor;
+        who.style.color = this.colorOf(actor);
+        who.style.marginRight = '6px';
+        this.container.appendChild(who);
+      }
+      for (const key of keys) {
+        const chip = document.createElement('span');
+        chip.className = 'k' + (this.arrows.has(key) ? ' arrow' : '');
+        chip.textContent = this.glyphs[key] ?? key;
+        this.container.appendChild(chip);
+      }
+    }
+  }
+}
+if (typeof module !== 'undefined') module.exports = {ReplayPlayer, ReplayKeys};

--- a/server/replay.js
+++ b/server/replay.js
@@ -1,0 +1,150 @@
+// One serialized render queue. A newer seek invalidates a decode that has not
+// painted yet; pause/resume keeps the cursor and anchors a new playback clock.
+class ReplayPlayer {
+  constructor(source, {decode, paint, complete, reset, update, error,
+                       now=()=>performance.now(), schedule=setTimeout, cancel=clearTimeout}) {
+    Object.assign(this, {source, decode, paint, complete, reset, update, error, now, schedule, cancel});
+    this.position = this.origin = this.duration = this.floor = 0;
+    this.speed = 4;
+    this.epoch = 0;
+    this.queue = Promise.resolve();
+    this.controller = new AbortController();
+    this.playing = this.wantPlaying = this.loading = this.closed = false;
+  }
+  current() {
+    return Math.min(this.duration, this.playing
+      ? this.anchorPosition + (this.now() - this.anchorTime) / 1000 * this.speed : this.position);
+  }
+  emit() {
+    this.update({position:this.position, duration:this.duration, playing:this.wantPlaying,
+                 loading:this.loading, speed:this.speed});
+  }
+  enqueue(work) {
+    this.queue = this.queue.catch(()=>{}).then(work);
+    return this.queue;
+  }
+  async start() {
+    const epoch = this.epoch;
+    let prefixTime = 0;
+    this.reset({});
+    for (;;) {
+      const event = await this.source.peek();
+      if (this.closed || epoch !== this.epoch) return;
+      if (!event) throw new Error('No complete frame in this recording');
+      this.source.take();
+      prefixTime = Math.max(prefixTime, Number(event.t) || 0);
+      const decoded = event.d ? await this.decode(event) : null;
+      if (this.closed || epoch !== this.epoch) return;
+      if (!decoded) { this.paint(null, event); continue; }
+      if (!this.complete(decoded)) continue;
+      this.paint(decoded, event);
+      this.origin = this.floor = prefixTime;
+      this.duration = Math.max(0, this.source.duration - this.origin);
+      this.position = 0;
+      this.emit();
+      this.play();
+      return;
+    }
+  }
+  async renderThrough(target, epoch) {
+    while (!this.closed && epoch === this.epoch) {
+      const event = await this.source.peek();
+      if (this.closed || epoch !== this.epoch || !event) return;
+      const when = Math.max(this.floor, Number(event.t) || 0);
+      if (when > target) return;
+      this.source.take();
+      const decoded = event.d ? await this.decode(event) : null;
+      if (this.closed || epoch !== this.epoch) return;
+      this.paint(decoded, event);
+      this.floor = when;
+    }
+  }
+  arm() {
+    this.cancel(this.timer);
+    if (this.playing && !this.closed) this.timer = this.schedule(()=>this.tick(), 16);
+  }
+  async tick() {
+    if (!this.playing || this.closed || this.loading) return;
+    const epoch = this.epoch, target = this.current();
+    try {
+      await this.enqueue(()=>this.renderThrough(this.origin + target, epoch));
+      if (epoch !== this.epoch || this.closed) return;
+      if (this.playing) this.position = target;
+      if (this.position >= this.duration) this.playing = this.wantPlaying = false;
+      this.emit();
+      this.arm();
+    } catch (error) {
+      if (epoch === this.epoch && !this.closed) this.fail(error);
+    }
+  }
+  play() {
+    if (this.closed) return;
+    this.wantPlaying = true;
+    if (this.loading) return;
+    if (this.position >= this.duration && this.duration > 0) return this.seek(0);
+    this.playing = true;
+    this.anchorPosition = this.position;
+    this.anchorTime = this.now();
+    this.emit();
+    this.arm();
+  }
+  async pause() {
+    this.position = this.current();
+    this.wantPlaying = this.playing = false;
+    this.cancel(this.timer);
+    const epoch = this.epoch;
+    try {
+      if (!this.loading) await this.enqueue(()=>this.renderThrough(this.origin + this.position, epoch));
+    } catch (error) {
+      if (epoch === this.epoch && !this.closed) this.fail(error);
+    }
+    if (epoch === this.epoch && !this.closed) this.emit();
+  }
+  setSpeed(speed) {
+    if (![1,2,4,8].includes(speed)) return;
+    this.position = this.current();
+    this.speed = speed;
+    this.anchorPosition = this.position;
+    this.anchorTime = this.now();
+    this.emit();
+  }
+  seek(position) {
+    this.position = Math.max(0, Math.min(this.duration, Number(position) || 0));
+    this.playing = false;
+    this.loading = true;
+    this.cancel(this.timer);
+    const epoch = ++this.epoch, target = this.position;
+    this.controller.abort();
+    this.controller = new AbortController();
+    this.emit();
+    return this.enqueue(async () => {
+      if (epoch !== this.epoch || this.closed) return;
+      const location = await this.source.seek(this.origin + target, this.controller.signal);
+      if (epoch !== this.epoch || this.closed) return;
+      this.reset(location.held || {});
+      this.floor = location.at || 0;
+      await this.renderThrough(this.origin + target, epoch);
+      if (epoch !== this.epoch || this.closed) return;
+      this.loading = false;
+      if (this.position >= this.duration) this.wantPlaying = false;
+      this.emit();
+      if (this.wantPlaying) this.play();
+    }).catch(error => {
+      if (epoch === this.epoch && !this.closed) this.fail(error);
+    });
+  }
+  fail(error) {
+    this.close();
+    this.error(error);
+  }
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    this.playing = this.wantPlaying = false;
+    this.epoch++;
+    this.controller.abort();
+    this.cancel(this.timer);
+    this.source.close();
+  }
+}
+if (typeof module !== 'undefined') module.exports = {ReplayPlayer};

--- a/server/replay.js
+++ b/server/replay.js
@@ -157,6 +157,117 @@ class ReplayPlayer {
   }
 }
 
+// Action playback holds each recorded result for .6 / speed seconds. A slow
+// picture extends its wait instead of skipping actions or replaying idle hours.
+class ActionReplayPlayer {
+  constructor(source, {paint, update, error, now=()=>performance.now(),
+                       schedule=(fn, delay)=>setTimeout(fn, delay), cancel=timer=>clearTimeout(timer)}) {
+    Object.assign(this, {source, paint, update, error, now, schedule, cancel});
+    this.beat = .6;
+    this.duration = source.steps * this.beat;
+    this.position = this.index = this.epoch = 0;
+    this.speed = 4;
+    this.controller = new AbortController();
+    this.playing = this.wantPlaying = this.ready = this.closed = false;
+    this.loading = true;
+  }
+  current() {
+    return this.playing && !this.loading ? Math.min(this.duration, (this.index + 1) * this.beat,
+      this.anchorPosition + (this.now() - this.anchorTime) / 1000 * this.speed) : this.position;
+  }
+  emit() {
+    this.update({position:this.position, duration:this.duration, index:this.index, total:this.source.steps,
+      step:this.step, playing:this.wantPlaying, loading:this.loading, ready:this.ready, speed:this.speed});
+  }
+  async start() {
+    if (this.closed) return;
+    this.wantPlaying = true;
+    await this.show(0);
+  }
+  arm() {
+    this.cancel(this.timer);
+    if (!this.wantPlaying || this.loading || this.closed) return;
+    this.playing = true;
+    this.anchorPosition = this.position;
+    this.anchorTime = this.now();
+    const remaining = Math.max(0, Math.min(this.duration, (this.index + 1) * this.beat) - this.position);
+    this.timer = this.schedule(()=>this.tick(), remaining * 1000 / this.speed);
+  }
+  async show(index, advancing = false) {
+    const epoch = this.epoch, signal = this.controller.signal;
+    this.advancing = advancing;
+    this.loading = true;
+    this.playing = false;
+    this.emit();
+    try {
+      const [step, image] = await Promise.all([this.source.step(index, signal), this.source.frame(index, signal)]);
+      if (this.closed || epoch !== this.epoch || signal.aborted) return;
+      this.index = index; this.step = step;
+      this.paint(image, step);
+      this.loading = false; this.ready = true;
+      this.source.prefetch(index, signal);
+      this.emit();
+      this.arm();
+    } catch (error) {
+      if (!this.closed && epoch === this.epoch && !signal.aborted) this.fail(error);
+    }
+  }
+  async tick() {
+    if (!this.playing || this.loading || this.closed) return;
+    this.position = Math.min(this.duration, (this.index + 1) * this.beat);
+    if (this.index + 1 >= this.source.steps) {
+      this.wantPlaying = this.playing = false;
+      this.emit();
+    } else await this.show(this.index + 1, true);
+  }
+  play() {
+    if (this.closed) return;
+    this.wantPlaying = true;
+    if (this.position >= this.duration) return this.seek(0);
+    this.emit(); this.arm();
+  }
+  pause() {
+    this.position = this.current();
+    this.playing = this.wantPlaying = false;
+    this.cancel(this.timer);
+    // Freeze the currently visible action even if its successor is slow.
+    // An explicit seek still finishes at the requested picture while paused.
+    if (this.ready && this.loading && this.advancing) {
+      this.epoch++;
+      this.controller.abort(); this.controller = new AbortController();
+      this.loading = this.advancing = false;
+    }
+    this.emit();
+  }
+  setSpeed(speed) {
+    if (![1,2,4,8].includes(speed) || this.closed) return;
+    this.position = this.current();
+    this.speed = speed;
+    this.emit(); this.arm();
+  }
+  seek(position) {
+    if (!this.ready || this.closed) return Promise.resolve();
+    this.position = Math.max(0, Math.min(this.duration, Number(position) || 0));
+    const index = Math.min(this.source.steps - 1, Math.floor(this.position / this.beat + 1e-9));
+    this.epoch++;
+    this.controller.abort(); this.controller = new AbortController();
+    this.cancel(this.timer);
+    if (this.position >= this.duration) this.wantPlaying = false;
+    // A fresh seek starts immediately. It never queues behind a stale decode.
+    return this.show(index);
+  }
+  fail(error) { this.close(); this.error(error); }
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    this.playing = this.wantPlaying = false;
+    this.epoch++;
+    this.controller.abort();
+    this.cancel(this.timer);
+    this.source.close();
+  }
+}
+
 // Keep actor ownership when restoring held keys from a seek snapshot.
 class ReplayKeys {
   constructor(container, {glyphs, arrows, colorOf}) {
@@ -175,6 +286,25 @@ class ReplayKeys {
     if (event.down) this.held.set(event.key, event.who || this.actor);
     else this.held.delete(event.key);
     this.render();
+  }
+  showStep(step) {
+    this.reset({});
+    this.actor = step.who || '';
+    this.render();
+    const document = this.container.ownerDocument;
+    const tokens = /^KEYS?$/.test(step.act) ? String(step.on || '').split(/\s+/).filter(Boolean)
+      : [({GET:'截图',WAIT:'等待'})[step.act] || step.act || '动作'];
+    for (const key of tokens) {
+      const chip = document.createElement('span');
+      chip.className = 'k' + (this.arrows.has(key) ? ' arrow' : '');
+      chip.textContent = this.glyphs[key] ?? key;
+      this.container.appendChild(chip);
+    }
+    if (step.ok === false) {
+      const failed = document.createElement('span');
+      failed.textContent = ' · 未执行 / 失败';
+      this.container.appendChild(failed);
+    }
   }
   render() {
     const groups = new Map();
@@ -202,4 +332,4 @@ class ReplayKeys {
     }
   }
 }
-if (typeof module !== 'undefined') module.exports = {ReplayPlayer, ReplayKeys};
+if (typeof module !== 'undefined') module.exports = {ReplayPlayer, ActionReplayPlayer, ReplayKeys};

--- a/server/server.py
+++ b/server/server.py
@@ -2128,6 +2128,10 @@ async def recording_script(_request):
     return web.FileResponse(ROOT / "recording.js")
 
 
+async def video_export_script(_request):
+    return web.FileResponse(ROOT / "video-export.js", headers={"Cache-Control": "no-store"})
+
+
 async def replay_script(_request):
     return web.FileResponse(ROOT / "replay.js")
 
@@ -2336,6 +2340,7 @@ def main():
         web.get("/", index),
         web.get("/recording.js", recording_script),
         web.get("/replay.js", replay_script),
+        web.get("/video-export.js", video_export_script),
         web.get("/ws", ws_handler),
         web.get("/status", status),
         web.get("/progress", progress),

--- a/server/server.py
+++ b/server/server.py
@@ -2128,6 +2128,10 @@ async def recording_script(_request):
     return web.FileResponse(ROOT / "recording.js")
 
 
+async def replay_script(_request):
+    return web.FileResponse(ROOT / "replay.js")
+
+
 async def index(_request):
     return web.FileResponse(ROOT / "index.html")
 
@@ -2331,6 +2335,7 @@ def main():
     app.add_routes([
         web.get("/", index),
         web.get("/recording.js", recording_script),
+        web.get("/replay.js", replay_script),
         web.get("/ws", ws_handler),
         web.get("/status", status),
         web.get("/progress", progress),

--- a/server/test_game_keyboard.js
+++ b/server/test_game_keyboard.js
@@ -1,0 +1,46 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const test = require('node:test');
+const html = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
+const begin = html.indexOf('// Game keyboard routing.');
+const end = html.indexOf('// End game keyboard routing.');
+assert(begin >= 0 && end > begin);
+const source = html.slice(begin, end);
+
+function fixture() {
+  const handlers={}, docHandlers={}, sent=[];
+  let replay=false, slot=false, observer;
+  const context={MAP:{ArrowRight:'right',Enter:'enter',' ':'space',Escape:'esc'},escSwallow:false,
+    send:e=>sent.push({...e}),slotOpen:()=>slot,
+    addEventListener:(name,fn)=>handlers[name]=fn,
+    document:{hidden:false,getElementById:id=>({classList:{contains:()=>id==='vcr'?replay:slot}}),
+      addEventListener:(name,fn)=>docHandlers[name]=fn},
+    MutationObserver:class {constructor(fn){observer=fn;}observe(){}},
+  };
+  vm.runInNewContext(source,context);
+  const target=(kind='canvas')=>({isContentEditable:kind==='editable',closest:()=>kind==='canvas'||kind==='game-button'?null:{}});
+  function event(key,kind='canvas',extra={}) {return {key,target:target(kind),prevented:false,preventDefault(){this.prevented=true;},...extra};}
+  return {handlers,docHandlers,sent,event,context,openReplay(){replay=true;observer();},openSlot(){slot=true;observer();}};
+}
+
+test('replay controls keep native arrow/space/enter behavior without game messages',()=>{
+  const f=fixture();f.openReplay();
+  for(const key of ['ArrowRight',' ','Enter']) {const e=f.event(key,'slider');f.handlers.keydown(e);f.handlers.keyup(e);assert.equal(e.prevented,false);}
+  assert.deepEqual(f.sent,[]);
+});
+test('history buttons, links, form controls, and shortcuts do not reach the game',()=>{
+  const f=fixture();
+  for(const target of ['button','link','input','select','editable']) {const e=f.event('Enter',target);f.handlers.keydown(e);assert.equal(e.prevented,false);}
+  f.handlers.keydown(f.event('c','canvas',{metaKey:true}));assert.deepEqual(f.sent,[]);
+});
+test('opening a replay or save modal releases a held key once',()=>{
+  for(const open of ['openReplay','openSlot']) {const f=fixture();f.handlers.keydown(f.event('ArrowRight'));f[open]();f.handlers.keyup(f.event('ArrowRight','slider'));assert.deepEqual(f.sent,[{t:'key',k:'right',down:true},{t:'key',k:'right',down:false}]);}
+});
+test('game keys retain repeat suppression and release across focus changes',()=>{
+  const f=fixture();f.handlers.keydown(f.event('ArrowRight'));f.handlers.keydown(f.event('ArrowRight'));f.docHandlers.focusin(f.event('Enter','input'));f.handlers.keyup(f.event('ArrowRight','input'));assert.equal(f.sent.length,2);assert.equal(f.sent[1].down,false);
+});
+test('window blur and hidden page release active game keys',()=>{
+  const f=fixture();f.handlers.keydown(f.event('ArrowRight'));f.handlers.blur();f.handlers.keydown(f.event('Enter'));f.context.document.hidden=true;f.docHandlers.visibilitychange();assert.deepEqual(f.sent.map(e=>e.down),[true,false,true,false]);
+});

--- a/server/test_game_keyboard.py
+++ b/server/test_game_keyboard.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+import shutil
+import subprocess
+import unittest
+class GameKeyboardTests(unittest.TestCase):
+    @unittest.skipUnless(shutil.which('node'), 'Node.js is not installed')
+    def test_ui_keys_never_reach_game(self):
+        run=subprocess.run([shutil.which('node'),'--test',str(Path(__file__).with_suffix('.js'))],capture_output=True,text=True,timeout=30)
+        self.assertEqual(run.returncode,0,run.stdout+run.stderr)

--- a/server/test_video_export_ui.js
+++ b/server/test_video_export_ui.js
@@ -1,0 +1,67 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const path = require('node:path');
+const source = fs.readFileSync(path.join(__dirname,'video-export.js'),'utf8');
+const base = 'http://localhost:8084/u/test-user/';
+const key = 'qunxia-video-job:/u/test-user/';
+const response = (body,status=200) => ({ok:status<400,status,json:async()=>body});
+const row = (state,extra={}) => ({id:'job1',state,completed:2,total:4,...extra});
+const flush = () => new Promise(resolve=>setImmediate(resolve));
+function setup(handle, saved=null) {
+  const storage = new Map(saved ? [[key,JSON.stringify({id:saved})]] : []);
+  const elements = {save:{disabled:false},play:{disabled:false}};
+  const calls=[],downloads=[],timers=new Map(),events={};let sequence=0;
+  const sandbox={URL,location:{href:base},document:{
+    getElementById:id=>elements[id],
+    createElement:tag=>({style:{},click(){if(tag==='a')downloads.push(String(this.href));}}),
+  },sessionStorage:{setItem:(k,v)=>storage.set(k,v),getItem:k=>storage.get(k),removeItem:k=>storage.delete(k)},
+  setTimeout:fn=>{timers.set(++sequence,fn);return sequence;},clearTimeout:id=>timers.delete(id),
+  addEventListener:(name,fn)=>events[name]=fn,
+  fetch:async(url,options={})=>{const call={url:new URL(url),method:options.method||'GET',options};calls.push(call);return handle(call);}};
+  elements.save.after=element=>elements.cancel=element;
+  vm.runInNewContext(source,sandbox);
+  return {elements,calls,downloads,storage,events,timers,
+    tick:async()=>{const first=timers.entries().next().value;assert.ok(first);timers.delete(first[0]);await first[1]();await flush();}};
+}
+test('starts a backend job, preserves Play, reports packaging, then downloads at the user URL',async()=>{
+  let state='finalizing';
+  const f=setup(call=>call.method==='POST'?response(row('queued'),202):response(row(state,{download:'api/video/job1/file'})));
+  await f.elements.save.onclick();assert.equal(f.elements.play.disabled,false);
+  assert.equal(f.elements.save.disabled,true);assert.equal(f.elements.cancel.hidden,false);
+  assert.equal(f.calls[0].url.href,base+'api/video');
+  assert.deepEqual(JSON.parse(f.calls[0].options.body),{recording:'current',speed:4});
+  await f.tick();assert.equal(f.elements.save.textContent,'封装 50%');
+  state='ready';await f.tick();assert.equal(f.elements.save.disabled,false);
+  await f.elements.save.onclick();assert.deepEqual(f.downloads,[base+'api/video/job1/file']);
+  assert.equal(f.storage.size,0);assert.equal(f.elements.save.textContent,'⤓ MP4');
+});
+test('cancel wins against an older status response and allows another export',async()=>{
+  let release;
+  const f=setup(call=>call.method==='POST'?response(row('encoding'),202):call.method==='DELETE'?response(row('cancelled')):new Promise(resolve=>release=resolve));
+  await f.elements.save.onclick();const old=f.tick();await flush();
+  await f.elements.cancel.onclick();release(response(row('encoding')));await old;
+  assert.equal(f.elements.save.textContent,'⤓ MP4');assert.equal(f.elements.save.disabled,false);
+  assert.equal(f.elements.cancel.hidden,true);assert.equal(f.timers.size,0);assert.equal(f.storage.size,0);
+});
+test('reload resumes a saved task and unload leaves the backend running',async()=>{
+  const f=setup(()=>response(row('encoding')),'job1');
+  assert.equal(f.elements.save.disabled,true);await flush();
+  assert.equal(f.calls[0].url.href,base+'api/video/job1');
+  assert.equal(f.elements.save.textContent,'生成 50%');
+  f.events.pagehide();assert.equal(f.timers.size,0);assert.equal(f.calls.length,1);
+  assert.ok(f.storage.has(key));
+});
+test('an expired task or request error remains retryable',async()=>{
+  const f=setup(()=>response({error:'task expired'},404),'old');await flush();
+  assert.equal(f.elements.save.disabled,false);assert.equal(f.elements.save.title,'task expired');
+  assert.equal(f.elements.save.textContent,'重试导出');assert.equal(f.storage.size,0);
+});
+test('a cache hit is immediately downloadable and never disables Play',async()=>{
+  const f=setup(()=>response(row('ready',{cached:true,download:'api/video/job1/file'})));
+  await f.elements.save.onclick();assert.equal(f.elements.save.textContent,'⤓ 下载 MP4');
+  assert.equal(f.elements.play.disabled,false);assert.equal(f.elements.cancel.hidden,true);
+  assert.equal(f.timers.size,0);
+});

--- a/server/test_video_export_ui.js
+++ b/server/test_video_export_ui.js
@@ -13,18 +13,19 @@ const flush = () => new Promise(resolve=>setImmediate(resolve));
 function setup(handle, saved=null) {
   const storage = new Map(saved ? [[key,JSON.stringify({id:saved})]] : []);
   const elements = {save:{disabled:false},play:{disabled:false}};
-  const calls=[],downloads=[],timers=new Map(),events={};let sequence=0;
-  const sandbox={URL,location:{href:base},document:{
+  const calls=[],downloads=[],timers=new Map(),delays=new Map(),events={};let sequence=0;
+  const sandbox={URL,AbortController,location:{href:base},document:{
     getElementById:id=>elements[id],
     createElement:tag=>({style:{},click(){if(tag==='a')downloads.push(String(this.href));}}),
   },sessionStorage:{setItem:(k,v)=>storage.set(k,v),getItem:k=>storage.get(k),removeItem:k=>storage.delete(k)},
-  setTimeout:fn=>{timers.set(++sequence,fn);return sequence;},clearTimeout:id=>timers.delete(id),
+  setTimeout:(fn,delay)=>{timers.set(++sequence,fn);delays.set(sequence,delay);return sequence;},
+  clearTimeout:id=>{timers.delete(id);delays.delete(id);},
   addEventListener:(name,fn)=>events[name]=fn,
   fetch:async(url,options={})=>{const call={url:new URL(url),method:options.method||'GET',options};calls.push(call);return handle(call);}};
   elements.save.after=element=>elements.cancel=element;
   vm.runInNewContext(source,sandbox);
-  return {elements,calls,downloads,storage,events,timers,
-    tick:async()=>{const first=timers.entries().next().value;assert.ok(first);timers.delete(first[0]);await first[1]();await flush();}};
+  return {elements,calls,downloads,storage,events,timers,delays,
+    tick:async()=>{const first=timers.entries().next().value;assert.ok(first);timers.delete(first[0]);delays.delete(first[0]);await first[1]();await flush();}};
 }
 test('starts a backend job, preserves Play, reports packaging, then downloads at the user URL',async()=>{
   let state='finalizing';
@@ -54,7 +55,7 @@ test('reload resumes a saved task and unload leaves the backend running',async()
   f.events.pagehide();assert.equal(f.timers.size,0);assert.equal(f.calls.length,1);
   assert.ok(f.storage.has(key));
 });
-test('an expired task or request error remains retryable',async()=>{
+test('an expired task allows generating a replacement',async()=>{
   const f=setup(()=>response({error:'task expired'},404),'old');await flush();
   assert.equal(f.elements.save.disabled,false);assert.equal(f.elements.save.title,'task expired');
   assert.equal(f.elements.save.textContent,'重试导出');assert.equal(f.storage.size,0);
@@ -64,4 +65,208 @@ test('a cache hit is immediately downloadable and never disables Play',async()=>
   await f.elements.save.onclick();assert.equal(f.elements.save.textContent,'⤓ 下载 MP4');
   assert.equal(f.elements.play.disabled,false);assert.equal(f.elements.cancel.hidden,true);
   assert.equal(f.timers.size,0);
+});
+
+test('one lost status response preserves the job, cancellation, and automatic recovery without another POST',async()=>{
+  let polls=0;
+  const f=setup(call=>{
+    if(call.method==='POST')return response(row('encoding'),202);
+    if(++polls===1)throw new TypeError('Failed to fetch');
+    return response(row('ready',{download:'api/video/job1/file'}));
+  });
+  await f.elements.save.onclick();await f.tick();
+  assert.equal(f.elements.save.textContent,'连接中断，正在重试');
+  assert.equal(f.elements.save.disabled,true);
+  assert.equal(f.elements.cancel.hidden,false);
+  assert.equal(f.elements.cancel.disabled,false);
+  assert.deepEqual(JSON.parse(f.storage.get(key)),{id:'job1'});
+  assert.equal(f.timers.size,1);
+  await f.elements.save.onclick();
+  assert.equal(f.calls.filter(call=>call.method==='POST').length,1,'A direct retry click cannot submit a duplicate');
+  await f.tick();
+  assert.equal(f.elements.save.textContent,'⤓ 下载 MP4');
+  assert.ok(f.calls.filter(call=>call.method==='GET').every(call=>call.url.href===base+'api/video/job1'));
+  assert.equal(f.calls.filter(call=>call.method==='POST').length,1);
+});
+
+test('repeated network, 5xx and 429 failures keep the saved id and cap the retry delay before recovery',async()=>{
+  const failures=[new TypeError('offline'),500,503,429,new TypeError('offline'),502,503,403];
+  let polls=0;
+  const f=setup(call=>{
+    if(call.method==='POST')return response(row('rendering'),202);
+    const failure=failures[polls++];
+    if(failure instanceof Error)throw failure;
+    return failure ? response({error:'temporary'},failure) : response(row('rendering'));
+  });
+  await f.elements.save.onclick();
+  const waited=[];
+  for(let index=0;index<failures.length;index++){
+    await f.tick();
+    assert.deepEqual(JSON.parse(f.storage.get(key)),{id:'job1'});
+    assert.equal(f.elements.save.disabled,true);
+    assert.equal(f.elements.cancel.hidden,false);
+    assert.equal(f.delays.size,1);
+    waited.push([...f.delays.values()][0]);
+  }
+  assert.deepEqual(waited,[700,1400,2800,5600,11200,15000,15000,15000]);
+  await f.tick();
+  assert.equal(f.elements.save.textContent,'生成 50%');
+  assert.deepEqual([...f.delays.values()],[700],'A successful status resets the backoff');
+  assert.equal(f.calls.filter(call=>call.method==='POST').length,1);
+  assert.ok(f.calls.filter(call=>call.method==='GET').every(call=>call.url.pathname.endsWith('/job1')));
+});
+
+test('cancelling after a polling outage deletes the original task and stops its retries',async()=>{
+  const f=setup(call=>{
+    if(call.method==='POST')return response(row('encoding'),202);
+    if(call.method==='DELETE')return response(row('cancelled'));
+    return response({error:'temporary'},503);
+  });
+  await f.elements.save.onclick();await f.tick();
+  await f.elements.cancel.onclick();
+  const deletes=f.calls.filter(call=>call.method==='DELETE');
+  assert.equal(deletes.length,1);assert.equal(deletes[0].url.href,base+'api/video/job1');
+  assert.equal(f.elements.save.textContent,'⤓ MP4');
+  assert.equal(f.elements.save.disabled,false);assert.equal(f.elements.cancel.hidden,true);
+  assert.equal(f.timers.size,0);assert.equal(f.storage.size,0);
+});
+
+test('a failed cancellation keeps the original task available for polling and another cancellation',async()=>{
+  let deletes=0;
+  const f=setup(call=>{
+    if(call.method==='POST')return response(row('encoding'),202);
+    if(call.method==='DELETE'){
+      if(++deletes===1)throw new TypeError('connection lost');
+      return response(row('cancelled'));
+    }
+    return response(row('encoding'));
+  });
+  await f.elements.save.onclick();await f.elements.cancel.onclick();
+  assert.deepEqual(JSON.parse(f.storage.get(key)),{id:'job1'});
+  assert.equal(f.elements.cancel.disabled,false);assert.equal(f.elements.save.disabled,true);
+  await f.tick();await f.elements.cancel.onclick();
+  assert.ok(f.calls.filter(call=>call.method==='DELETE').every(call=>call.url.href===base+'api/video/job1'));
+  assert.equal(f.storage.size,0);assert.equal(f.timers.size,0);
+});
+
+for(const status of [404,410])test(`authoritative ${status} removes an expired restored job and permits a replacement`,async()=>{
+  const f=setup(call=>call.method==='POST'?response(row('queued'),202):response({error:'task expired'},status),'expired');
+  await flush();
+  assert.equal(f.elements.save.disabled,false);assert.equal(f.elements.cancel.hidden,true);
+  assert.equal(f.storage.size,0);assert.equal(f.timers.size,0);
+  await f.elements.save.onclick();
+  assert.equal(f.calls.filter(call=>call.method==='POST').length,1);
+  assert.deepEqual(JSON.parse(f.storage.get(key)),{id:'job1'});
+});
+
+test('fast repeated cancellation cannot revive a task from a late recovery poll',async()=>{
+  let polls=0,releaseGet,releaseDelete;
+  const f=setup(call=>{
+    if(call.method==='POST')return response(row('encoding'),202);
+    if(call.method==='DELETE')return new Promise(resolve=>releaseDelete=resolve);
+    if(++polls===1)return response({},503);
+    return new Promise(resolve=>releaseGet=resolve);
+  });
+  await f.elements.save.onclick();await f.tick();
+  const pendingPoll=f.tick();await flush();
+  const pendingCancel=f.elements.cancel.onclick();
+  await f.elements.cancel.onclick();await f.elements.save.onclick();
+  assert.equal(f.calls.filter(call=>call.method==='DELETE').length,1);
+  assert.equal(f.calls.filter(call=>call.method==='POST').length,1);
+  releaseDelete(response(row('cancelled')));await pendingCancel;
+  releaseGet(response(row('ready',{download:'api/video/job1/file'})));await pendingPoll;
+  assert.equal(f.elements.save.textContent,'⤓ MP4');
+  assert.equal(f.elements.cancel.hidden,true);assert.equal(f.storage.size,0);assert.equal(f.timers.size,0);
+});
+
+test('a hung status request times out, preserves its id, and cannot overwrite a later successful retry',async()=>{
+  let release,polls=0;
+  const f=setup(call=>{
+    if(call.method==='POST')return response(row('encoding'),202);
+    if(++polls===1)return new Promise(resolve=>release=resolve);
+    return response(row('ready',{download:'api/video/job1/file'}));
+  });
+  await f.elements.save.onclick();
+  const hung=f.tick();await flush();
+  assert.deepEqual([...f.delays.values()],[15000]);
+  await f.tick();await hung;
+  assert.equal(f.calls[1].options.signal.aborted,true);
+  assert.equal(f.elements.save.textContent,'连接中断，正在重试');
+  assert.deepEqual(JSON.parse(f.storage.get(key)),{id:'job1'});
+  await f.tick();
+  release(response(row('encoding')));await flush();
+  assert.equal(f.elements.save.textContent,'⤓ 下载 MP4');
+  assert.equal(f.timers.size,0);
+  assert.equal(f.calls.filter(call=>call.method==='POST').length,1);
+});
+
+test('pagehide aborts a pending status read without UI changes or deleting the saved job, and pageshow resumes it',async()=>{
+  let release,polls=0;
+  const f=setup(()=>++polls===1?new Promise(resolve=>release=resolve):response(row('encoding')),'job1');
+  const before=f.elements.save.textContent;
+  f.events.pagehide({persisted:true});
+  assert.equal(f.timers.size,0);assert.equal(f.calls[0].options.signal.aborted,true);
+  release(response(row('ready',{download:'api/video/job1/file'})));await flush();
+  assert.equal(f.elements.save.textContent,before);
+  assert.deepEqual(JSON.parse(f.storage.get(key)),{id:'job1'});
+  f.events.pageshow({persisted:true});await flush();
+  assert.equal(f.elements.save.textContent,'生成 50%');
+  assert.equal(f.calls.length,2);assert.ok(f.calls.every(call=>call.method==='GET'));
+});
+
+test('a creation response after pagehide saves its new task id without updating the hidden UI',async()=>{
+  let release;
+  const f=setup(()=>new Promise(resolve=>release=resolve));
+  const creation=f.elements.save.onclick();
+  f.events.pagehide({persisted:false});
+  const before=f.elements.save.textContent;
+  release(response(row('encoding'),202));await creation;
+  assert.equal(f.elements.save.textContent,before);
+  assert.deepEqual(JSON.parse(f.storage.get(key)),{id:'job1'});
+  assert.equal(f.timers.size,0);
+});
+
+test('a hung cancellation times out and resumes polling without forgetting the original task',async()=>{
+  let release;
+  const f=setup(call=>{
+    if(call.method==='DELETE')return new Promise(resolve=>release=resolve);
+    return response(row('encoding'));
+  });
+  await f.elements.save.onclick();
+  const cancellation=f.elements.cancel.onclick();await flush();
+  assert.equal(f.elements.cancel.disabled,true);
+  assert.deepEqual([...f.delays.values()],[15000]);
+  await f.tick();await cancellation;
+  assert.equal(f.elements.cancel.disabled,false);
+  assert.deepEqual(JSON.parse(f.storage.get(key)),{id:'job1'});
+  await f.tick();
+  release(response(row('cancelled')));await flush();
+  assert.equal(f.elements.save.textContent,'生成 50%','A timed-out DELETE response must not override its later status query');
+  assert.ok(f.calls.filter(call=>call.method!=='POST').every(call=>call.url.href===base+'api/video/job1'));
+  assert.equal(f.calls.filter(call=>call.method==='POST').length,1);
+});
+
+test('pageshow restores a ready creation result that arrived while the page was hidden',async()=>{
+  let release;
+  const f=setup(()=>new Promise(resolve=>release=resolve));
+  const creation=f.elements.save.onclick();
+  f.events.pagehide({persisted:true});
+  release(response(row('ready',{download:'api/video/job1/file'})));await creation;
+  assert.equal(f.elements.save.textContent,'提交中');
+  f.events.pageshow({persisted:true});
+  assert.equal(f.elements.save.disabled,false);
+  assert.equal(f.elements.save.textContent,'⤓ 下载 MP4');
+  await f.elements.save.onclick();
+  assert.deepEqual(f.downloads,[base+'api/video/job1/file']);
+});
+
+test('pageshow restores an idle button if creation failed while the page was hidden',async()=>{
+  let reject;
+  const f=setup(()=>new Promise((_,fail)=>reject=fail));
+  const creation=f.elements.save.onclick();f.events.pagehide({persisted:true});
+  reject(new TypeError('offline'));await creation;
+  assert.equal(f.elements.save.textContent,'提交中');
+  f.events.pageshow({persisted:true});
+  assert.equal(f.elements.save.disabled,false);assert.equal(f.elements.save.textContent,'⤓ MP4');
+  assert.equal(f.storage.size,0);assert.equal(f.timers.size,0);
 });

--- a/server/test_video_export_ui.js
+++ b/server/test_video_export_ui.js
@@ -270,3 +270,51 @@ test('pageshow restores an idle button if creation failed while the page was hid
   assert.equal(f.elements.save.disabled,false);assert.equal(f.elements.save.textContent,'⤓ MP4');
   assert.equal(f.storage.size,0);assert.equal(f.timers.size,0);
 });
+
+const invalidReplies={
+  'truncated JSON':()=>({...response(null),json:async()=>{throw new TypeError('response body interrupted');}}),
+  'missing id':()=>response({state:'cancelled'}),
+  'wrong id':()=>response(row('cancelled',{id:'another-job'})),
+  'unknown state':()=>response(row('not-a-real-state')),
+};
+for(const [label,invalid] of Object.entries(invalidReplies)){
+  test(`DELETE 200 with ${label} retains the original id and permits cancelling it after recovery`,async()=>{
+    let deletes=0;
+    const f=setup(call=>{
+      if(call.method==='DELETE')return ++deletes===1?invalid():response(row('cancelled'));
+      return response(row('encoding'));
+    });
+    await f.elements.save.onclick();await f.elements.cancel.onclick();
+    assert.deepEqual(JSON.parse(f.storage.get(key)),{id:'job1'});
+    assert.equal(f.elements.save.textContent,'连接中断，正在重试');
+    assert.equal(f.elements.save.disabled,true);assert.equal(f.elements.cancel.hidden,false);
+    assert.equal(f.elements.cancel.disabled,false);assert.equal(f.timers.size,1);
+    await f.elements.save.onclick();assert.equal(f.calls.filter(call=>call.method==='POST').length,1);
+    await f.tick();
+    assert.equal(f.elements.save.textContent,'生成 50%');
+    await f.elements.cancel.onclick();
+    assert.ok(f.calls.filter(call=>call.method!=='POST').every(call=>call.url.href===base+'api/video/job1'));
+    assert.equal(f.elements.cancel.hidden,true);assert.equal(f.storage.size,0);assert.equal(f.timers.size,0);
+  });
+  test(`GET 200 with ${label} retains the original id until a valid status arrives`,async()=>{
+    let polls=0;
+    const f=setup(()=>++polls===1?invalid():response(row('ready',{download:'api/video/job1/file'})),'job1');
+    await flush();
+    assert.deepEqual(JSON.parse(f.storage.get(key)),{id:'job1'});
+    assert.equal(f.elements.save.disabled,true);assert.equal(f.elements.cancel.hidden,false);
+    assert.equal(f.elements.save.textContent,'连接中断，正在重试');
+    await f.tick();
+    assert.equal(f.elements.save.textContent,'⤓ 下载 MP4');
+    assert.ok(f.calls.every(call=>call.method==='GET'&&call.url.href===base+'api/video/job1'));
+  });
+}
+
+for(const status of [404,410]){
+  for(const method of ['GET','DELETE'])test(`${method} ${status} expires a job even with a non-JSON error response`,async()=>{
+    const f=setup(call=>call.method===method?{...response(null,status),json:async()=>{throw new SyntaxError('not JSON');}}:response(row('encoding')));
+    await f.elements.save.onclick();
+    if(method==='GET')await f.tick();else await f.elements.cancel.onclick();
+    assert.equal(f.storage.size,0);assert.equal(f.timers.size,0);
+    assert.equal(f.elements.save.disabled,false);assert.equal(f.elements.cancel.hidden,true);
+  });
+}

--- a/server/test_video_export_ui.js
+++ b/server/test_video_export_ui.js
@@ -100,6 +100,32 @@ test('a pending request token survives reload and is reused by the next submit',
   assert.equal(JSON.parse(reloaded.calls[0].options.body).requestId,token);
   assert.deepEqual(JSON.parse(reloaded.storage.get(key)),{id:'job1'});
 });
+
+for(const timeoutWhileHidden of [false,true])test(`a hung creation retains its deadline across pagehide and pageshow (timeout while hidden: ${timeoutWhileHidden})`,async()=>{
+  let releaseFirst,posts=0;
+  const firstBody=new Promise(resolve=>releaseFirst=resolve);
+  const f=setup(()=>++posts===1?{...response(null,202),json:async()=>firstBody}:response(row('encoding'),202));
+  const first=f.elements.save.onclick();await flush();
+  const token=JSON.parse(f.storage.get(key)).requestId;
+  f.events.pagehide({persisted:true});
+  assert.deepEqual([...f.delays.values()],[15000]);
+  if(!timeoutWhileHidden)f.events.pageshow({persisted:true});
+  await f.tick();await first;
+  assert.equal(f.calls[0].options.signal.aborted,true);
+  if(timeoutWhileHidden){
+    assert.equal(f.elements.save.textContent,'提交中','A hidden timeout must not update the hidden UI');
+    f.events.pageshow({persisted:true});
+  }
+  assert.equal(f.elements.save.disabled,false);
+  assert.deepEqual(JSON.parse(f.storage.get(key)),{requestId:token});
+  await f.elements.save.onclick();
+  assert.equal(posts,2);
+  assert.equal(f.calls[1].options.headers['X-Video-Request-Id'],token);
+  assert.deepEqual(JSON.parse(f.storage.get(key)),{id:'job1'});
+  releaseFirst(row('ready',{id:'stale-job',download:'api/video/stale-job/file'}));await flush();
+  assert.equal(f.elements.save.textContent,'生成 50%');
+  assert.deepEqual(JSON.parse(f.storage.get(key)),{id:'job1'});
+});
 test('cancel wins against an older status response and allows another export',async()=>{
   let release;
   const f=setup(call=>call.method==='POST'?response(row('encoding'),202):call.method==='DELETE'?response(row('cancelled')):new Promise(resolve=>release=resolve));

--- a/server/test_video_export_ui.js
+++ b/server/test_video_export_ui.js
@@ -11,13 +11,15 @@ const response = (body,status=200) => ({ok:status<400,status,json:async()=>body}
 const row = (state,extra={}) => ({id:'job1',state,completed:2,total:4,...extra});
 const flush = () => new Promise(resolve=>setImmediate(resolve));
 function setup(handle, saved=null) {
-  const storage = new Map(saved ? [[key,JSON.stringify({id:saved})]] : []);
+  const savedValue = saved && typeof saved === 'object' ? saved : (saved ? {id:saved} : null);
+  const storage = new Map(savedValue ? [[key,JSON.stringify(savedValue)]] : []);
   const elements = {save:{disabled:false},play:{disabled:false}};
-  const calls=[],downloads=[],timers=new Map(),delays=new Map(),events={};let sequence=0;
+  const calls=[],downloads=[],timers=new Map(),delays=new Map(),events={};let sequence=0,requestSequence=0;
   const sandbox={URL,AbortController,location:{href:base},document:{
     getElementById:id=>elements[id],
     createElement:tag=>({style:{},click(){if(tag==='a')downloads.push(String(this.href));}}),
   },sessionStorage:{setItem:(k,v)=>storage.set(k,v),getItem:k=>storage.get(k),removeItem:k=>storage.delete(k)},
+  crypto:{randomUUID:()=>`request-${++requestSequence}`},
   setTimeout:(fn,delay)=>{timers.set(++sequence,fn);delays.set(sequence,delay);return sequence;},
   clearTimeout:id=>{timers.delete(id);delays.delete(id);},
   addEventListener:(name,fn)=>events[name]=fn,
@@ -33,11 +35,44 @@ test('starts a backend job, preserves Play, reports packaging, then downloads at
   await f.elements.save.onclick();assert.equal(f.elements.play.disabled,false);
   assert.equal(f.elements.save.disabled,true);assert.equal(f.elements.cancel.hidden,false);
   assert.equal(f.calls[0].url.href,base+'api/video');
-  assert.deepEqual(JSON.parse(f.calls[0].options.body),{recording:'current',speed:4});
+  assert.deepEqual(JSON.parse(f.calls[0].options.body),{recording:'current',speed:4,requestId:'request-1'});
+  assert.equal(f.calls[0].options.headers['X-Video-Request-Id'],'request-1');
   await f.tick();assert.equal(f.elements.save.textContent,'封装 50%');
   state='ready';await f.tick();assert.equal(f.elements.save.disabled,false);
   await f.elements.save.onclick();assert.deepEqual(f.downloads,[base+'api/video/job1/file']);
   assert.equal(f.storage.size,0);assert.equal(f.elements.save.textContent,'⤓ MP4');
+});
+
+test('a truncated creation response retries with the same idempotency token',async()=>{
+  let posts=0;
+  const f=setup(call=>{
+    if(call.method!=='POST')return response(row('encoding'));
+    if(++posts===1)return {...response(null,202),json:async()=>{throw new TypeError('response body interrupted');}};
+    return response(row('encoding'),202);
+  });
+  await f.elements.save.onclick();
+  assert.equal(f.elements.save.textContent,'重试导出');
+  assert.deepEqual(JSON.parse(f.storage.get(key)),{requestId:'request-1'});
+  const first=f.calls[0];
+  await f.elements.save.onclick();
+  assert.equal(posts,2);
+  const second=f.calls[1];
+  assert.equal(first.options.headers['X-Video-Request-Id'],'request-1');
+  assert.equal(second.options.headers['X-Video-Request-Id'],'request-1');
+  assert.equal(JSON.parse(first.options.body).requestId,JSON.parse(second.options.body).requestId);
+  assert.equal(f.elements.save.textContent,'生成 50%');
+  assert.deepEqual(JSON.parse(f.storage.get(key)),{id:'job1'});
+});
+
+test('a pending request token survives reload and is reused by the next submit',async()=>{
+  const original=setup(call=>({...response(null,202),json:async()=>{throw new TypeError('response body interrupted');}}));
+  await original.elements.save.onclick();
+  const token=JSON.parse(original.storage.get(key)).requestId;
+  const reloaded=setup(call=>response(row('encoding'),202),{requestId:token});
+  await reloaded.elements.save.onclick();
+  assert.equal(reloaded.calls[0].options.headers['X-Video-Request-Id'],token);
+  assert.equal(JSON.parse(reloaded.calls[0].options.body).requestId,token);
+  assert.deepEqual(JSON.parse(reloaded.storage.get(key)),{id:'job1'});
 });
 test('cancel wins against an older status response and allows another export',async()=>{
   let release;
@@ -268,7 +303,7 @@ test('pageshow restores an idle button if creation failed while the page was hid
   assert.equal(f.elements.save.textContent,'提交中');
   f.events.pageshow({persisted:true});
   assert.equal(f.elements.save.disabled,false);assert.equal(f.elements.save.textContent,'⤓ MP4');
-  assert.equal(f.storage.size,0);assert.equal(f.timers.size,0);
+  assert.deepEqual(JSON.parse(f.storage.get(key)),{requestId:'request-1'});assert.equal(f.timers.size,0);
 });
 
 const invalidReplies={

--- a/server/test_video_export_ui.js
+++ b/server/test_video_export_ui.js
@@ -64,6 +64,32 @@ test('a truncated creation response retries with the same idempotency token',asy
   assert.deepEqual(JSON.parse(f.storage.get(key)),{id:'job1'});
 });
 
+test('a hung creation body times out, retries with the same token, and ignores the late first body',async()=>{
+  let releaseFirst, posts=0;
+  const firstBody=new Promise(resolve=>releaseFirst=resolve);
+  const f=setup(call=>{
+    if(call.method!=='POST')return response(row('encoding',{id:'job2'}));
+    if(++posts===1)return {...response(null,202),json:async()=>firstBody};
+    return response(row('encoding',{id:'job2'}),202);
+  });
+  const first=f.elements.save.onclick();
+  await flush();
+  assert.deepEqual([...f.delays.values()],[15000]);
+  await f.tick();
+  await first;
+  assert.equal(f.elements.save.textContent,'重试导出');
+  const token=JSON.parse(f.storage.get(key)).requestId;
+  await f.elements.save.onclick();
+  assert.equal(posts,2);
+  assert.equal(f.calls[1].options.headers['X-Video-Request-Id'],token);
+  assert.equal(f.elements.save.textContent,'生成 50%');
+  assert.deepEqual(JSON.parse(f.storage.get(key)),{id:'job2'});
+  releaseFirst(row('ready',{id:'job1',download:'api/video/job1/file'}));
+  await flush();
+  assert.equal(f.elements.save.textContent,'生成 50%');
+  assert.deepEqual(JSON.parse(f.storage.get(key)),{id:'job2'});
+});
+
 test('a pending request token survives reload and is reused by the next submit',async()=>{
   const original=setup(call=>({...response(null,202),json:async()=>{throw new TypeError('response body interrupted');}}));
   await original.elements.save.onclick();

--- a/server/video-export.js
+++ b/server/video-export.js
@@ -10,7 +10,7 @@
   cancel.style.cssText = 'font:inherit;font-size:10px;padding:3px 6px;background:#17171b;color:#ccc;border:1px solid #2e2e36;border-radius:4px;cursor:pointer';
   button.after(cancel);
   let job = null, requestId = null, timer = null, requesting = false, cancelling = false, closed = false, revision = 0;
-  let postRevision = 0, activePost = null;
+  let postRevision = 0;
   let activePoll = null, activeCancel = null, failures = 0;
   const states = new Set(['queued','indexing','rendering','encoding','finalizing','ready','cancelled','error','failed']);
   const terminal = state => ['ready','cancelled','error','failed'].includes(state);
@@ -112,7 +112,6 @@
     storage({requestId});
     const currentPost=++postRevision;
     const pending={controller:new AbortController()};
-    activePost=pending;
     try {
       const row=await timedCall(pending,new URL('api/video',page),{method:'POST',headers:{'Content-Type':'application/json','X-Video-Request-Id':requestId},body:JSON.stringify({recording:'current',speed:4,requestId})});
       // A timed-out request can still deliver its body after a retry. Once a
@@ -129,8 +128,6 @@
       if ([404,410].includes(error.status)) { requestId=null; storage(null); }
       if(closed)return;
       button.disabled=false;button.textContent='重试导出';button.title=error.message;
-    } finally {
-      if (activePost===pending) activePost=null;
     }
   };
   cancel.onclick=async()=>{
@@ -144,9 +141,6 @@
   };
   addEventListener('pagehide',()=>{
     closed=true;++revision;clearTimeout(timer);timer=null;stopPoll();cancelling=false;
-    // Keep an in-flight creation alive so a response received while the page
-    // is hidden can still be persisted, but remove its visible deadline.
-    if (activePost) clearTimeout(activePost.timeout);
     if(activeCancel){clearTimeout(activeCancel.timeout);activeCancel.controller.abort();activeCancel=null;}
   });
   addEventListener('pageshow',event=>{

--- a/server/video-export.js
+++ b/server/video-export.js
@@ -11,6 +11,7 @@
   button.after(cancel);
   let job = null, timer = null, requesting = false, cancelling = false, closed = false, revision = 0;
   let activePoll = null, activeCancel = null, failures = 0;
+  const states = new Set(['queued','indexing','rendering','encoding','finalizing','ready','cancelled','error','failed']);
   const terminal = state => ['ready','cancelled','error','failed'].includes(state);
   const storage = value => { try { value ? sessionStorage.setItem(key,JSON.stringify(value)) : sessionStorage.removeItem(key); } catch {} };
   function schedule(delay=700) {
@@ -37,13 +38,20 @@
   }
   async function call(url,options={}) {
     const response = await fetch(url,{cache:'no-store',...options});
-    const body = await response.json().catch(()=>({}));
     if (!response.ok) {
-      const error=Error(body.error || ([404,410].includes(response.status) ? '后台任务已失效，请重新生成' : `导出请求失败（${response.status}）`));
+      // HTTP expiry remains authoritative even when the error body is not JSON.
+      const body = await response.json().catch(()=>({}));
+      const error=Error(body?.error || ([404,410].includes(response.status) ? '后台任务已失效，请重新生成' : `导出请求失败（${response.status}）`));
       error.status=response.status;
       throw error;
     }
-    return body;
+    // A truncated successful response cannot stand in for a real job status.
+    return response.json();
+  }
+  function validate(row,id) {
+    if (!row || typeof row.id!=='string' || !row.id || (id!==undefined && row.id!==id) || !states.has(row.state))
+      throw Error('无法读取后台任务状态');
+    return row;
   }
   async function timedCall(pending,url,options={}) {
     const signal=pending.controller.signal;
@@ -79,8 +87,7 @@
     try {
       const row = await timedCall(pending,new URL(id,api));
       if (current !== revision || closed) return;
-      if (row.id !== id || typeof row.state !== 'string') throw Error('无法读取后台任务状态');
-      show(row);
+      show(validate(row,id));
     } catch(error) { if (current === revision && !closed) unavailable(error); }
     finally {if (activePoll===pending) activePoll=null;}
   }
@@ -95,6 +102,7 @@
     requesting=true;button.disabled=true;button.textContent='提交中';
     try {
       const row=await call(new URL('api/video',page),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({recording:'current',speed:4})});
+      validate(row);
       requesting=false;
       if (closed) {job=row;storage(!terminal(row.state)||row.state==='ready'?{id:row.id}:null);return;}
       show(row);
@@ -102,10 +110,10 @@
   };
   cancel.onclick=async()=>{
     if (!job || closed || cancelling) return;
-    const current=++revision;clearTimeout(timer);timer=null;stopPoll();cancelling=true;
+    const current=++revision,id=job.id;clearTimeout(timer);timer=null;stopPoll();cancelling=true;
     const pending={controller:new AbortController()};activeCancel=pending;
     cancel.disabled=true;
-    try { const row=await timedCall(pending,new URL(job.id,api),{method:'DELETE'});if(current===revision&&!closed){cancelling=false;show(row);} }
+    try { const row=await timedCall(pending,new URL(id,api),{method:'DELETE'});if(current===revision&&!closed){validate(row,id);cancelling=false;show(row);} }
     catch(error) { if(current!==revision||closed)return;cancelling=false;unavailable(error); }
     finally {if(current===revision)cancelling=false;if(activeCancel===pending)activeCancel=null;}
   };

--- a/server/video-export.js
+++ b/server/video-export.js
@@ -9,11 +9,15 @@
   cancel.id = 'video-cancel'; cancel.textContent = '取消'; cancel.hidden = true;
   cancel.style.cssText = 'font:inherit;font-size:10px;padding:3px 6px;background:#17171b;color:#ccc;border:1px solid #2e2e36;border-radius:4px;cursor:pointer';
   button.after(cancel);
-  let job = null, timer = null, requesting = false, cancelling = false, closed = false, revision = 0;
+  let job = null, requestId = null, timer = null, requesting = false, cancelling = false, closed = false, revision = 0;
   let activePoll = null, activeCancel = null, failures = 0;
   const states = new Set(['queued','indexing','rendering','encoding','finalizing','ready','cancelled','error','failed']);
   const terminal = state => ['ready','cancelled','error','failed'].includes(state);
   const storage = value => { try { value ? sessionStorage.setItem(key,JSON.stringify(value)) : sessionStorage.removeItem(key); } catch {} };
+  function newRequestId() {
+    try { if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID(); } catch {}
+    return `video-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  }
   function schedule(delay=700) {
     clearTimeout(timer); timer=null;
     if (job && !terminal(job.state) && !closed && !cancelling) timer=setTimeout(poll,delay);
@@ -100,13 +104,24 @@
       job=null;storage(null);button.textContent='⤓ MP4';return;
     }
     requesting=true;button.disabled=true;button.textContent='提交中';
+    if (!requestId) requestId=newRequestId();
+    // Persist the token before sending. If the response body is truncated after
+    // the backend creates a job, retrying this exact token is safe and returns
+    // the original job instead of creating a duplicate.
+    storage({requestId});
     try {
-      const row=await call(new URL('api/video',page),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({recording:'current',speed:4})});
+      const row=await call(new URL('api/video',page),{method:'POST',headers:{'Content-Type':'application/json','X-Video-Request-Id':requestId},body:JSON.stringify({recording:'current',speed:4,requestId})});
       validate(row);
+      requestId=null;
       requesting=false;
       if (closed) {job=row;storage(!terminal(row.state)||row.state==='ready'?{id:row.id}:null);return;}
       show(row);
-    } catch(error) { requesting=false;if(closed)return;button.disabled=false;button.textContent='重试导出';button.title=error.message; }
+    } catch(error) {
+      requesting=false;
+      if ([404,410].includes(error.status)) { requestId=null; storage(null); }
+      if(closed)return;
+      button.disabled=false;button.textContent='重试导出';button.title=error.message;
+    }
   };
   cancel.onclick=async()=>{
     if (!job || closed || cancelling) return;
@@ -127,5 +142,9 @@
     if(job){if(job.state)show(job);if(!terminal(job.state))poll();}
     else if(!requesting){button.disabled=false;button.textContent='⤓ MP4';cancel.hidden=true;}
   });
-  try { const saved=JSON.parse(sessionStorage.getItem(key)||'null');if(saved?.id){job=saved;button.disabled=true;button.textContent='读取任务';poll();} } catch {}
+  try {
+    const saved=JSON.parse(sessionStorage.getItem(key)||'null');
+    if (typeof saved?.requestId==='string' && saved.requestId) requestId=saved.requestId;
+    if(saved?.id){job=saved;button.disabled=true;button.textContent='读取任务';poll();}
+  } catch {}
 })();

--- a/server/video-export.js
+++ b/server/video-export.js
@@ -1,0 +1,62 @@
+// Background action-video export. No realtime waiting and no browser frame log.
+(() => {
+  const button = document.getElementById('save');
+  if (!button) return;
+  const api = new URL('api/video/', location.href);
+  const page = new URL('.', location.href);
+  const key = 'qunxia-video-job:' + page.pathname;
+  const cancel = document.createElement('button');
+  cancel.id = 'video-cancel'; cancel.textContent = '取消'; cancel.hidden = true;
+  cancel.style.cssText = 'font:inherit;font-size:10px;padding:3px 6px;background:#17171b;color:#ccc;border:1px solid #2e2e36;border-radius:4px;cursor:pointer';
+  button.after(cancel);
+  let job = null, timer = null, requesting = false, closed = false, revision = 0;
+  const terminal = state => ['ready','cancelled','error','failed'].includes(state);
+  const storage = value => { try { value ? sessionStorage.setItem(key,JSON.stringify(value)) : sessionStorage.removeItem(key); } catch {} };
+  function show(row) {
+    job = row;
+    const busy = !terminal(row.state);
+    button.disabled = requesting || busy;
+    cancel.hidden = !busy; cancel.disabled = false;
+    const percent = row.total > 0 ? ' ' + Math.floor(100 * row.completed / row.total) + '%' : '';
+    button.textContent = ({queued:'排队中',indexing:'读取历史',rendering:'生成',encoding:'生成',finalizing:'封装',ready:'⤓ 下载 MP4',cancelled:'⤓ MP4',error:'重试导出',failed:'重试导出'})[row.state] + (busy ? percent : '');
+    button.title = row.error || (busy ? `后台处理 ${row.completed || 0} / ${row.total || '?'}，可以继续回放` : '后台生成动作视频，跳过空闲等待');
+    storage(busy || row.state === 'ready' ? {id:row.id} : null);
+    clearTimeout(timer);
+    if (busy && !closed) timer = setTimeout(poll,700);
+  }
+  async function call(url,options={}) {
+    const response = await fetch(url,{cache:'no-store',...options});
+    const body = await response.json().catch(()=>({}));
+    if (!response.ok) throw Error(body.error || (response.status===404 ? '后台任务不可用，请重新生成' : `导出请求失败（${response.status}）`));
+    return body;
+  }
+  async function poll() {
+    if (!job || closed) return;
+    const current = ++revision;
+    try { const row = await call(new URL(job.id,api)); if (current === revision && !closed) show(row); }
+    catch(error) { if (current !== revision || closed) return; clearTimeout(timer); storage(null); job=null; cancel.hidden=true; button.disabled=false; button.textContent='重试导出'; button.title=error.message; }
+  }
+  button.textContent='⤓ MP4';
+  button.title='后台生成动作视频，跳过空闲等待';
+  button.onclick=async()=>{
+    if (requesting) return;
+    if (job?.state==='ready' && job.download) {
+      const link=document.createElement('a');link.href=new URL(job.download,page);link.download='';link.click();
+      job=null;storage(null);button.textContent='⤓ MP4';return;
+    }
+    requesting=true;button.disabled=true;button.textContent='提交中';
+    try {
+      const row=await call(new URL('api/video',page),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({recording:'current',speed:4})});
+      requesting=false;show(row);
+    } catch(error) { requesting=false;button.disabled=false;button.textContent='重试导出';button.title=error.message; }
+  };
+  cancel.onclick=async()=>{
+    if (!job) return;
+    const current=++revision;clearTimeout(timer);
+    cancel.disabled=true;
+    try { const row=await call(new URL(job.id,api),{method:'DELETE'});if(current===revision&&!closed)show(row); }
+    catch(error) { if(current!==revision||closed)return;cancel.disabled=false;button.title=error.message;timer=setTimeout(poll,700); }
+  };
+  addEventListener('pagehide',()=>{closed=true;++revision;clearTimeout(timer);});
+  try { const saved=JSON.parse(sessionStorage.getItem(key)||'null');if(saved?.id){job=saved;button.disabled=true;button.textContent='读取任务';poll();} } catch {}
+})();

--- a/server/video-export.js
+++ b/server/video-export.js
@@ -10,6 +10,7 @@
   cancel.style.cssText = 'font:inherit;font-size:10px;padding:3px 6px;background:#17171b;color:#ccc;border:1px solid #2e2e36;border-radius:4px;cursor:pointer';
   button.after(cancel);
   let job = null, requestId = null, timer = null, requesting = false, cancelling = false, closed = false, revision = 0;
+  let postRevision = 0, activePost = null;
   let activePoll = null, activeCancel = null, failures = 0;
   const states = new Set(['queued','indexing','rendering','encoding','finalizing','ready','cancelled','error','failed']);
   const terminal = state => ['ready','cancelled','error','failed'].includes(state);
@@ -109,18 +110,27 @@
     // the backend creates a job, retrying this exact token is safe and returns
     // the original job instead of creating a duplicate.
     storage({requestId});
+    const currentPost=++postRevision;
+    const pending={controller:new AbortController()};
+    activePost=pending;
     try {
-      const row=await call(new URL('api/video',page),{method:'POST',headers:{'Content-Type':'application/json','X-Video-Request-Id':requestId},body:JSON.stringify({recording:'current',speed:4,requestId})});
+      const row=await timedCall(pending,new URL('api/video',page),{method:'POST',headers:{'Content-Type':'application/json','X-Video-Request-Id':requestId},body:JSON.stringify({recording:'current',speed:4,requestId})});
+      // A timed-out request can still deliver its body after a retry. Once a
+      // newer submit exists, that late response must not replace its state.
+      if (currentPost !== postRevision) return;
       validate(row);
       requestId=null;
       requesting=false;
       if (closed) {job=row;storage(!terminal(row.state)||row.state==='ready'?{id:row.id}:null);return;}
       show(row);
     } catch(error) {
+      if (currentPost !== postRevision) return;
       requesting=false;
       if ([404,410].includes(error.status)) { requestId=null; storage(null); }
       if(closed)return;
       button.disabled=false;button.textContent='重试导出';button.title=error.message;
+    } finally {
+      if (activePost===pending) activePost=null;
     }
   };
   cancel.onclick=async()=>{
@@ -134,6 +144,9 @@
   };
   addEventListener('pagehide',()=>{
     closed=true;++revision;clearTimeout(timer);timer=null;stopPoll();cancelling=false;
+    // Keep an in-flight creation alive so a response received while the page
+    // is hidden can still be persisted, but remove its visible deadline.
+    if (activePost) clearTimeout(activePost.timeout);
     if(activeCancel){clearTimeout(activeCancel.timeout);activeCancel.controller.abort();activeCancel=null;}
   });
   addEventListener('pageshow',event=>{

--- a/server/video-export.js
+++ b/server/video-export.js
@@ -9,11 +9,23 @@
   cancel.id = 'video-cancel'; cancel.textContent = '取消'; cancel.hidden = true;
   cancel.style.cssText = 'font:inherit;font-size:10px;padding:3px 6px;background:#17171b;color:#ccc;border:1px solid #2e2e36;border-radius:4px;cursor:pointer';
   button.after(cancel);
-  let job = null, timer = null, requesting = false, closed = false, revision = 0;
+  let job = null, timer = null, requesting = false, cancelling = false, closed = false, revision = 0;
+  let activePoll = null, activeCancel = null, failures = 0;
   const terminal = state => ['ready','cancelled','error','failed'].includes(state);
   const storage = value => { try { value ? sessionStorage.setItem(key,JSON.stringify(value)) : sessionStorage.removeItem(key); } catch {} };
+  function schedule(delay=700) {
+    clearTimeout(timer); timer=null;
+    if (job && !terminal(job.state) && !closed && !cancelling) timer=setTimeout(poll,delay);
+  }
+  function stopPoll() {
+    if (!activePoll) return;
+    clearTimeout(activePoll.timeout);
+    activePoll.controller.abort();
+    activePoll=null;
+  }
   function show(row) {
     job = row;
+    failures = 0;
     const busy = !terminal(row.state);
     button.disabled = requesting || busy;
     cancel.hidden = !busy; cancel.disabled = false;
@@ -21,25 +33,61 @@
     button.textContent = ({queued:'排队中',indexing:'读取历史',rendering:'生成',encoding:'生成',finalizing:'封装',ready:'⤓ 下载 MP4',cancelled:'⤓ MP4',error:'重试导出',failed:'重试导出'})[row.state] + (busy ? percent : '');
     button.title = row.error || (busy ? `后台处理 ${row.completed || 0} / ${row.total || '?'}，可以继续回放` : '后台生成动作视频，跳过空闲等待');
     storage(busy || row.state === 'ready' ? {id:row.id} : null);
-    clearTimeout(timer);
-    if (busy && !closed) timer = setTimeout(poll,700);
+    schedule();
   }
   async function call(url,options={}) {
     const response = await fetch(url,{cache:'no-store',...options});
     const body = await response.json().catch(()=>({}));
-    if (!response.ok) throw Error(body.error || (response.status===404 ? '后台任务不可用，请重新生成' : `导出请求失败（${response.status}）`));
+    if (!response.ok) {
+      const error=Error(body.error || ([404,410].includes(response.status) ? '后台任务已失效，请重新生成' : `导出请求失败（${response.status}）`));
+      error.status=response.status;
+      throw error;
+    }
     return body;
   }
+  async function timedCall(pending,url,options={}) {
+    const signal=pending.controller.signal;
+    let aborted;
+    const cancelled=new Promise((_,reject)=>{
+      aborted=()=>reject(signal.reason);
+      signal.addEventListener('abort',aborted,{once:true});
+    });
+    pending.timeout=setTimeout(()=>pending.controller.abort(Error('后台任务请求超时')),15000);
+    try { return await Promise.race([call(url,{...options,signal}),cancelled]); }
+    finally {clearTimeout(pending.timeout);signal.removeEventListener('abort',aborted);}
+  }
+  function unavailable(error) {
+    if ([404,410].includes(error.status)) {
+      clearTimeout(timer); timer=null;
+      storage(null); job=null; failures=0; cancel.hidden=true;
+      button.disabled=false; button.textContent='重试导出'; button.title=error.message;
+      return;
+    }
+    // A lost status response says nothing about the backend job's lifetime.
+    // Retain its id and cancellation controls; never create a replacement.
+    storage({id:job.id});
+    button.disabled=true; button.textContent='连接中断，正在重试'; button.title=error.message;
+    cancel.hidden=false; cancel.disabled=false;
+    schedule(Math.min(15000,700 * 2 ** Math.min(failures++,5)));
+  }
   async function poll() {
-    if (!job || closed) return;
-    const current = ++revision;
-    try { const row = await call(new URL(job.id,api)); if (current === revision && !closed) show(row); }
-    catch(error) { if (current !== revision || closed) return; clearTimeout(timer); storage(null); job=null; cancel.hidden=true; button.disabled=false; button.textContent='重试导出'; button.title=error.message; }
+    if (!job || terminal(job.state) || closed || cancelling || activePoll) return;
+    clearTimeout(timer); timer=null;
+    const current = ++revision, id=job.id;
+    const pending={controller:new AbortController()};
+    activePoll=pending;
+    try {
+      const row = await timedCall(pending,new URL(id,api));
+      if (current !== revision || closed) return;
+      if (row.id !== id || typeof row.state !== 'string') throw Error('无法读取后台任务状态');
+      show(row);
+    } catch(error) { if (current === revision && !closed) unavailable(error); }
+    finally {if (activePoll===pending) activePoll=null;}
   }
   button.textContent='⤓ MP4';
   button.title='后台生成动作视频，跳过空闲等待';
   button.onclick=async()=>{
-    if (requesting) return;
+    if (requesting || closed || (job && !terminal(job.state))) return;
     if (job?.state==='ready' && job.download) {
       const link=document.createElement('a');link.href=new URL(job.download,page);link.download='';link.click();
       job=null;storage(null);button.textContent='⤓ MP4';return;
@@ -47,16 +95,29 @@
     requesting=true;button.disabled=true;button.textContent='提交中';
     try {
       const row=await call(new URL('api/video',page),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({recording:'current',speed:4})});
-      requesting=false;show(row);
-    } catch(error) { requesting=false;button.disabled=false;button.textContent='重试导出';button.title=error.message; }
+      requesting=false;
+      if (closed) {job=row;storage(!terminal(row.state)||row.state==='ready'?{id:row.id}:null);return;}
+      show(row);
+    } catch(error) { requesting=false;if(closed)return;button.disabled=false;button.textContent='重试导出';button.title=error.message; }
   };
   cancel.onclick=async()=>{
-    if (!job) return;
-    const current=++revision;clearTimeout(timer);
+    if (!job || closed || cancelling) return;
+    const current=++revision;clearTimeout(timer);timer=null;stopPoll();cancelling=true;
+    const pending={controller:new AbortController()};activeCancel=pending;
     cancel.disabled=true;
-    try { const row=await call(new URL(job.id,api),{method:'DELETE'});if(current===revision&&!closed)show(row); }
-    catch(error) { if(current!==revision||closed)return;cancel.disabled=false;button.title=error.message;timer=setTimeout(poll,700); }
+    try { const row=await timedCall(pending,new URL(job.id,api),{method:'DELETE'});if(current===revision&&!closed){cancelling=false;show(row);} }
+    catch(error) { if(current!==revision||closed)return;cancelling=false;unavailable(error); }
+    finally {if(current===revision)cancelling=false;if(activeCancel===pending)activeCancel=null;}
   };
-  addEventListener('pagehide',()=>{closed=true;++revision;clearTimeout(timer);});
+  addEventListener('pagehide',()=>{
+    closed=true;++revision;clearTimeout(timer);timer=null;stopPoll();cancelling=false;
+    if(activeCancel){clearTimeout(activeCancel.timeout);activeCancel.controller.abort();activeCancel=null;}
+  });
+  addEventListener('pageshow',event=>{
+    if(!event.persisted||!closed)return;
+    closed=false;
+    if(job){if(job.state)show(job);if(!terminal(job.state))poll();}
+    else if(!requesting){button.disabled=false;button.textContent='⤓ MP4';cancel.hidden=true;}
+  });
   try { const saved=JSON.parse(sessionStorage.getItem(key)||'null');if(saved?.id){job=saved;button.disabled=true;button.textContent='读取任务';poll();} } catch {}
 })();


### PR DESCRIPTION
Play current and archived recordings as saved actions, skipping idle gaps. Playback progress and original JSONL time are displayed separately; recorded_t retains milliseconds, does not wrap after 24 hours, and does not change with playback speed. Pause/resume, bidirectional seeking, bounded prefetch, actor labels and keyboard isolation are retained. More recordings uses #37 for safe original journal downloads.

MP4 export uses the background API in #39. Before submitting, the page persists a client requestId; a failed or truncated POST response can be retried with the same token, including after page reload, so the backend returns the original job even after the recording grows. Creation, status and cancellation requests have 15-second deadlines. Late responses cannot replace newer state, and a creation deadline remains active across page hiding/restoration.

Temporary status failures preserve the original task and cancellation controls with bounded retries. Only confirmed 404/410 expiry clears a task. Response IDs and states are validated before replacing UI state. Exporting keeps Play available.

Validation: 35 export-UI regressions, 27 player/source/menu tests and 5 keyboard-routing tests pass. A real browser against the copied game backend discarded the first successful POST body, then retried: both HTTP responses identified the same job and requestId, and cancellation succeeded. The earlier GET/DELETE failure regressions remain covered. The same-token guarantee requires the #39 backend and lasts for its retained in-process job record; process restart or expiry can begin a new job, while completed MP4 caching remains persistent.