### PR TITLE
server: restore disk history and add action video export

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,25 @@ appended to a JSONL journal on disk. The activity panel replays at 4x and
 exports an MP4 in the browser; the benchmark renders the same journal with
 ffmpeg.
 
+### Saved-action video API
+
+`POST /api/video` accepts `{"recording":"current","speed":4}` and returns a
+background job. Poll `GET /api/video/{id}`, cancel with `DELETE /api/video/{id}`,
+and download the ready file from `GET /api/video/{id}/file`. Speeds are 1, 2, 4
+or 8. When the recording archive provider is installed, its safe archive names
+are also accepted by video export and `/api/replay?recording=...`.
+
+Exports use the same action index and screenshot cutoff rules as disk history,
+including failed actions and explicit after-action frames. Each action occupies
+`0.6 / speed` seconds; ffmpeg encodes off the event loop without waiting through
+idle recording time. Source snapshots remain pinned through reset. Completed
+MP4s are cached under the recording directory's `.video-cache`, including across
+server restarts, and settled idle appends do not invalidate them. Disposable
+cache files are pruned after 30 days or above a 2 GiB budget; the latest result
+is retained even if it alone exceeds the budget, and active downloads are
+protected. Interrupted partial files are removed on startup. ffmpeg must be
+available on the server. These endpoints remain disabled in benchmark mode.
+
 ## Emulated CPU speed
 
 The x86 code is JIT compiled by the DOSBox Pure recompiler. CPU cost is the

--- a/README.md
+++ b/README.md
@@ -475,7 +475,11 @@ or 8. When the recording archive provider is installed, its safe archive names
 are also accepted by video export and `/api/replay?recording=...`.
 
 Exports use the same action index and screenshot cutoff rules as disk history,
-including failed actions and explicit after-action frames. Each action occupies
+including failed actions and explicit after-action frames. Each action retains
+its original journal timestamp as `recorded_t`, separately from the normalized
+history and compressed playback clocks. Playback and MP4 captions show original
+time to the millisecond without wrapping at 24 hours. Existing sparse indexes
+backfill only action timestamps without rescanning frame payloads. Each action occupies
 `0.6 / speed` seconds; ffmpeg encodes off the event loop without waiting through
 idle recording time. Source snapshots remain pinned through reset. Completed
 MP4s are cached under the recording directory's `.video-cache`, including across

--- a/bench/render.py
+++ b/bench/render.py
@@ -67,6 +67,19 @@ def apply_delta(canvas, raw):
 MAX_VIDEO_SECONDS = float(os.environ.get("QUNXIA_MAX_VIDEO_SECONDS", "600"))
 
 
+def action_fields(event, ordinal):
+    """Normalize viewer labels without changing numbered benchmark actions."""
+    action = event['act']
+    if isinstance(action, str):
+        label = event.get('label')
+        if not isinstance(label, str) or not label:
+            label = f"{action} {event.get('on') or ''}".rstrip()
+        # Interactive GET/KEY markers have no benchmark action number. This
+        # ordinal identifies their position in the offline viewer only.
+        return ordinal, label
+    return action, event.get('label', '')
+
+
 def render(recording, out_path, agent="", speed=4.0, width=960, timeline_extra=None):
     events = recording.get("events") or []
     first_frame = next((e for e in events if "d" in e), None)
@@ -97,16 +110,18 @@ def render(recording, out_path, agent="", speed=4.0, width=960, timeline_extra=N
                 size=[GAME_W, GAME_H + BAR], bar=BAR, **(timeline_extra or {}))
     with timeline.open('w') as stream:
         stream.write(json.dumps(meta)[:-1] + ',"marks":[')
-        mark, held, first = None, {}, True
+        mark, held, first, ordinal = None, {}, True, 0
         for e in events:
             vt = round((e['t'] - t_start) / speed, 3)
             if vt < 0:
                 continue
             if e.get('act') is not None:
+                ordinal += 1
                 if mark is not None:
                     stream.write(('' if first else ',') + json.dumps(mark))
                     first = False
-                mark = {'n': e['act'], 't': vt, 'do': e.get('label', ''), 'keys': []}
+                number, label = action_fields(e, ordinal)
+                mark = {'n': number, 't': vt, 'do': label, 'keys': []}
             elif e.get('key'):
                 if e.get('down'):
                     held[e['key']] = e['t']
@@ -172,7 +187,7 @@ def render(recording, out_path, agent="", speed=4.0, width=960, timeline_extra=N
          "-pix_fmt", "yuv420p", "-movflags", "+faststart", str(out_path)],
         stdin=subprocess.PIPE)
 
-    down, actor, act = [], agent, None
+    down, actor, act, ordinal = [], agent, None, 0
     cursor = iter(events)
     pending = next(cursor, None)
     total_frames = max(1, int(duration * FPS))
@@ -186,7 +201,8 @@ def render(recording, out_path, agent="", speed=4.0, width=960, timeline_extra=N
                 if "d" in e:
                     canvas = apply_delta(canvas, base64.b64decode(e["d"]))
                 elif e.get("act") is not None:
-                    act = e["act"]
+                    ordinal += 1
+                    act, _ = action_fields(e, ordinal)
                     if e.get("who"):
                         actor = e["who"]
                 elif e.get("key"):
@@ -216,8 +232,9 @@ def render(recording, out_path, agent="", speed=4.0, width=960, timeline_extra=N
     try:
         subprocess.run(
             ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
-             "-ss", "1", "-i", str(out_path), "-frames:v", "1",
-             "-q:v", "4", str(poster)],
+             "-i", str(out_path), "-vf",
+             f"select=eq(n\\,{min(FPS, total_frames - 1)}),format=yuvj420p",
+             "-frames:v", "1", "-q:v", "4", str(poster)],
             check=True, timeout=60)
     except Exception as exc:
         print(f"poster failed: {exc}", flush=True)

--- a/bench/test_recording_renderer.py
+++ b/bench/test_recording_renderer.py
@@ -6,10 +6,12 @@ import struct
 import sys
 import tempfile
 import unittest
+from unittest import mock
 import zlib
 sys.path.insert(0,str(Path(__file__).resolve().parent.parent/'server'))
 from recording import Snapshot
 from recording_store import RecordingStore
+import render as renderer
 from render import render
 
 
@@ -29,8 +31,78 @@ class DiskRendererTest(unittest.TestCase):
                 out=root/'run.mp4'
                 result=render({'events':snapshot,'duration':snapshot.duration},out,'test',timeline_extra={'id':'run'})
                 self.assertIn(b'ftyp',out.read_bytes()[:40])
+                self.assertIsNotNone(result['poster'])
+                self.assertTrue(Path(result['poster']).read_bytes().startswith(b'\xff\xd8'))
                 timeline=json.loads(Path(result['timeline']).read_text())
                 self.assertEqual(timeline['id'],'run')
                 self.assertEqual(timeline['marks'],[{'n':1,'t':0.0,'do':'KEY right','keys':[['right',.1]]}])
             finally:
                 snapshot.close();store.close()
+
+
+class RendererMarkerCompatibilityTest(unittest.TestCase):
+    def rendered_annotations(self, events):
+        """Exercise the actual streamed render loop, without running ffmpeg."""
+        labels = []
+        original_draw = renderer.ImageDraw.Draw
+
+        def draw(image):
+            result = original_draw(image)
+            original_text = result.text
+
+            def text(position, value, *args, **kwargs):
+                labels.append(value)
+                return original_text(position, value, *args, **kwargs)
+
+            result.text = text
+            return result
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = RecordingStore(root / 'run.jsonl', started=10)
+            raw = struct.pack('<BHHBBHHH', 1, 2, 2, 2, 2, 1, 1, 1) + struct.pack('<H', 0) + b'\x7f' * 12
+            store.append({'t': 0, 'd': base64.b64encode(zlib.compress(raw)).decode(), 'k': 1})
+            for event in events:
+                store.append(event)
+            original = store.path.read_bytes()
+            snapshot = Snapshot(**store.pin())
+            try:
+                with mock.patch.object(renderer.subprocess, 'Popen') as process, \
+                     mock.patch.object(renderer.subprocess, 'run'), \
+                     mock.patch.object(renderer.ImageDraw, 'Draw', side_effect=draw):
+                    process.return_value.wait.return_value = 0
+                    result = render({'events': snapshot, 'duration': .8}, root / 'fake.mp4', speed=1)
+                    self.assertTrue(process.return_value.stdin.write.called)
+                self.assertEqual(store.path.read_bytes(), original)
+                return json.loads(Path(result['timeline']).read_text())['marks'], labels
+            finally:
+                snapshot.close()
+                store.close()
+
+    def test_string_actions_have_viewer_ordinals_and_descriptive_labels(self):
+        marks, labels = self.rendered_annotations([
+            {'t': .1, 'act': 'KEY', 'who': 'agent', 'on': 'right', 'history': 1},
+            {'t': .1, 'key': 'right', 'down': True},
+            {'t': .2, 'key': 'right', 'down': False},
+            {'t': .3, 'act': 'GET', 'who': 'agent', 'on': 'screen', 'history': 1},
+            {'t': .4, 'act': 'WAIT', 'who': 'agent', 'on': '1500ms', 'history': 1},
+        ])
+        self.assertEqual(marks, [
+            {'n': 1, 't': 0.0, 'do': 'KEY right', 'keys': [['right', .1]]},
+            {'n': 2, 't': .2, 'do': 'GET screen', 'keys': []},
+            {'n': 3, 't': .3, 'do': 'WAIT 1500ms', 'keys': []},
+        ])
+        self.assertEqual({value for value in labels if value.startswith('#')}, {'#1', '#2', '#3'})
+
+    def test_numbered_benchmark_actions_and_labels_are_unchanged(self):
+        marks, labels = self.rendered_annotations([
+            {'t': .1, 'act': 7, 'label': 'KEY right'},
+            {'t': .1, 'key': 'right', 'down': True},
+            {'t': .2, 'key': 'right', 'down': False},
+            {'t': .3, 'act': 9, 'label': 'WAIT 1000ms'},
+        ])
+        self.assertEqual(marks, [
+            {'n': 7, 't': 0.0, 'do': 'KEY right', 'keys': [['right', .1]]},
+            {'n': 9, 't': .2, 'do': 'WAIT 1000ms', 'keys': []},
+        ])
+        self.assertEqual({value for value in labels if value.startswith('#')}, {'#7', '#9'})

--- a/server/README.md
+++ b/server/README.md
@@ -197,5 +197,19 @@ This is disabled by default and always disabled in warden/benchmark mode.
 Each server must have its own save directory. An explicit game reset clears
 the retained activity as well. Writes replace a bounded snapshot atomically;
 failed writes keep the prior file and report an error. An invalid snapshot is
-left intact and persistence is disabled for that process. Past entries lost
-before this option was enabled cannot be recovered from this file.
+left intact and persistence is disabled for that process. This snapshot cannot recover entries it never received. Legacy recordings may
+contain action markers that can be imported as described below.
+
+To recover activity from an older local `recording.jsonl`, stop the server and
+run the following, then restart with persistence enabled:
+
+```sh
+python server/import_activity.py --recording /path/recording.jsonl --history /path/saves/activity.json
+```
+
+ The importer scans the recording once with bounded memory,
+merges its latest action markers with existing activity, and keeps the newest
+300 entries. It never changes the recording or scans it during normal startup.
+Imported markers retain timestamps, actors, verbs and targets; unavailable
+results are marked unknown. Original thumbnail/detail fields cannot be recovered
+from action markers. Re-importing the same recording does not duplicate rows.

--- a/server/README.md
+++ b/server/README.md
@@ -198,12 +198,18 @@ clients poll the returned token until ready, then read bounded `/steps` pages
 and individual `/frame` PNGs. Later opens incrementally index appended data.
 Tokens expire and release their file handles. Normal game startup does not
 scan the recording. The endpoints are absent in benchmark mode.
+The benchmark observer page uses the realtime log directly. Reset or a server
+session change invalidates an open history page before loading the new snapshot.
+Version 2 of the disposable index preserves unknown action results instead of
+treating them as failures. The first history open after this upgrade rebuilds
+that index once; the source JSONL and the previous version 1 index are retained.
 
 Legacy agent GET/KEY records and older key-only recordings remain readable.
 Numbered action markers from newer recordings are supported too. A historical
 image is reconstructed from recorded frames, not claimed to be the exact API
 response: GET uses the preceding frame, while old key steps wait up to one
-second or until the next action. Corrupt frame windows report an error instead
+second or until the next action. Failed actions show their failure and reason,
+and use the frame before their marker. Corrupt frame windows report an error instead
 of manufacturing an image. Source JSONL files are never rewritten by readers.
 
 For long-lived play, enable `QUNXIA_PERSIST_HISTORY=1`. New interactive actions

--- a/server/README.md
+++ b/server/README.md
@@ -66,10 +66,16 @@ Needs `../cores/dosbox_pure_libretro.so` (libretro buildbot) and `../game/`.
   It uses ffmpeg on the server, with progress, cancellation and a completed MP4
   download. Encoding does not wait through original recording timestamps and
   does not disable playback. Temporary status-query failures retain the job and
-  retry it; a confirmed missing or expired job allows a new export. ffmpeg must
-  be installed on the server. Cached results are bounded by a 2 GiB / 30-day
-  policy, retaining the latest result and active downloads. The source recording
-  and benchmark counters are unaffected by export.
+  retry it. An `X-Video-Request-Id` header or JSON `requestId` makes submission
+  idempotent while its in-process job record is retained: retries return the
+  same queued/active job, or replay cancelled/error terminal state with HTTP
+  200. Reusing a token with a different recording or speed is HTTP 409. If a
+  ready MP4 has been evicted while its job record remains, the token returns
+  HTTP 410 so the caller can submit a new token instead of silently creating a
+  second export. ffmpeg must be installed on the server. Cached results are
+  bounded by a 2 GiB / 30-day policy, retaining the latest result and active
+  downloads. The source recording and benchmark counters are unaffected by
+  export.
 - `/api/history?limit=100` the bounded action log. Every REST call and every key pressed in a
   browser is recorded and pushed to all connected pages over the same
   WebSocket, so the activity panel shows an agent and a human acting on the

--- a/server/README.md
+++ b/server/README.md
@@ -184,35 +184,42 @@ be scored as valid. Input/environment failures remain invalid. The broker
 stores diagnostics under `<result-dir>/<session-id>.diagnostics` and archives
 the last heartbeat, fault and exit status before reclaiming worker scratch.
 
-### Persistent activity history
+### Disk-backed screenshot history and realtime activity
 
-For a long-lived local game, set `QUNXIA_PERSIST_HISTORY=1` to retain the
-latest 300 activity entries in `QUNXIA_SAVES/activity.json`. Restarting restores
-the list and continues its entry IDs; reconnecting clients receive the retained
-backlog. The most recent 40 small WebP thumbnails are retained (64 KiB each).
-Hover a timestamp to see its full date. Session action counts still start at
-zero after restart; saved activity does not restore scoring or game state.
+The page separates two views: **historical screenshots** page through the full
+recording, eight images at a time, while **realtime activity** keeps a small
+reconnect cache. The 300-entry/40-thumbnail cache does not limit historical
+browsing. The history pane can jump to the oldest or latest page and move in
+both directions. Only one page of image blobs is held by the browser.
 
-This is disabled by default and always disabled in warden/benchmark mode.
-Each server must have its own save directory. An explicit game reset clears
-the retained activity as well. Writes replace a bounded snapshot atomically;
-failed writes keep the prior file and report an error. An invalid snapshot is
-left intact and persistence is disabled for that process. This snapshot cannot recover entries it never received. Legacy recordings may
-contain action markers that can be imported as described below.
+`/api/replay` pins the recording's committed file prefix and builds a disposable
+SQLite index in the background. An initial `202` reports indexing progress;
+clients poll the returned token until ready, then read bounded `/steps` pages
+and individual `/frame` PNGs. Later opens incrementally index appended data.
+Tokens expire and release their file handles. Normal game startup does not
+scan the recording. The endpoints are absent in benchmark mode.
 
-To recover activity from an older local `recording.jsonl`, stop the server and
-run the following, then restart with persistence enabled:
+Legacy agent GET/KEY records and older key-only recordings remain readable.
+Numbered action markers from newer recordings are supported too. A historical
+image is reconstructed from recorded frames, not claimed to be the exact API
+response: GET uses the preceding frame, while old key steps wait up to one
+second or until the next action. Corrupt frame windows report an error instead
+of manufacturing an image. Source JSONL files are never rewritten by readers.
 
-```sh
-python server/import_activity.py --recording /path/recording.jsonl --history /path/saves/activity.json
-```
+For long-lived play, enable `QUNXIA_PERSIST_HISTORY=1`. New interactive actions
+and GET markers are then appended to the full recording, including screen
+reads that later leave the realtime cache. Session counters still start fresh
+on restart. An explicit game reset clears the cache and rotates the recording
+through the existing recording lifecycle. Formal benchmark accounting is
+unchanged.
 
- The importer scans the recording once with bounded memory,
-merges its latest action markers with existing activity, and keeps the newest
-300 entries. It never changes the recording or scans it during normal startup.
-Imported markers retain timestamps, actors, verbs and targets; unavailable
-results are marked unknown. For the latest 40 screen reads, the importer reconstructs a thumbnail from the
-last recorded frame preceding each action marker. Hover a thumbnail to see its
-recorded time and origin. These replay previews may differ from the original
-API screenshot; unavailable frame data stays without an image. Original extra
-detail and execution outcomes cannot be recovered from action markers. Re-importing the same recording does not duplicate rows.
+The optional `QUNXIA_SAVES/activity.json` snapshot retains the latest 300 entries
+and 40 small WebP thumbnails (64 KiB each) for fast reconnects. Atomic writes
+preserve the prior file on failure; invalid snapshots are left intact and
+snapshot persistence is disabled for that process. The independent full-disk
+history reader remains available.
+
+The optional `server/import_activity.py` command can seed that **realtime
+cache** while the server is stopped. This import is optional and not needed to browse complete disk history.
+It preserves the recording and labels reconstructed previews with their source
+and frame time; existing original thumbnails take priority.

--- a/server/README.md
+++ b/server/README.md
@@ -183,3 +183,19 @@ execution lock. A time-limit ending still validates core health before it can
 be scored as valid. Input/environment failures remain invalid. The broker
 stores diagnostics under `<result-dir>/<session-id>.diagnostics` and archives
 the last heartbeat, fault and exit status before reclaiming worker scratch.
+
+### Persistent activity history
+
+For a long-lived local game, set `QUNXIA_PERSIST_HISTORY=1` to retain the
+latest 300 activity entries in `QUNXIA_SAVES/activity.json`. Restarting restores
+the list and continues its entry IDs; reconnecting clients receive the retained
+backlog. The most recent 40 small WebP thumbnails are retained (64 KiB each).
+Hover a timestamp to see its full date. Session action counts still start at
+zero after restart; saved activity does not restore scoring or game state.
+
+This is disabled by default and always disabled in warden/benchmark mode.
+Each server must have its own save directory. An explicit game reset clears
+the retained activity as well. Writes replace a bounded snapshot atomically;
+failed writes keep the prior file and report an error. An invalid snapshot is
+left intact and persistence is disabled for that process. Past entries lost
+before this option was enabled cannot be recovered from this file.

--- a/server/README.md
+++ b/server/README.md
@@ -52,16 +52,24 @@ Needs `../cores/dosbox_pure_libretro.so` (libretro buildbot) and `../game/`.
   without the token from `QUNXIA_RESET_TOKEN` rather than 403, so the path
   cannot be confirmed by probing. Pauses the emulation thread first, since
   `retro_reset` underneath a running `retro_run` is a race.
-- `/api/recording` the session as tile deltas plus key presses, for playback.
-  Recording restarts with the game, keeps every frame while anyone is acting,
-  and once idle keeps only the last 30 seconds so an untouched game still shows
-  its own animation without growing forever. A whole picture is forced every 30
-  seconds so a pruned recording always has somewhere to start replaying from.
-  The page plays it back at 4x from a button in the activity header, and can
-  export it as a video from another. Export composites the frames with the keys
-  that were held and encodes in the browser with MediaRecorder, so the server
-  spends nothing on it. MediaRecorder captures in real time, so an export takes
-  the length of the recording divided by four.
+- `/api/recording` streams the original recording journal; `?format=jsonl`
+  downloads its tile deltas, input events and action markers as JSONL. Readers
+  pin a committed file prefix, so later appends or reset do not change an open
+  snapshot. The source journal remains on disk.
+  With the saved-history backend, the page plays current and archived recordings
+  as saved actions, skipping idle gaps. Each action occupies 0.6 / speed seconds;
+  pause/resume and both seek directions retain the selected picture. Original
+  JSONL timestamps (`recorded_t`) are shown separately to the millisecond and do
+  not wrap after 24 hours. There is no continuous-recording fallback; an
+  unavailable action source can be retried.
+- `/api/video` submits a background action-video job to the saved-history backend.
+  It uses ffmpeg on the server, with progress, cancellation and a completed MP4
+  download. Encoding does not wait through original recording timestamps and
+  does not disable playback. Temporary status-query failures retain the job and
+  retry it; a confirmed missing or expired job allows a new export. ffmpeg must
+  be installed on the server. Cached results are bounded by a 2 GiB / 30-day
+  policy, retaining the latest result and active downloads. The source recording
+  and benchmark counters are unaffected by export.
 - `/api/history?limit=100` the bounded action log. Every REST call and every key pressed in a
   browser is recorded and pushed to all connected pages over the same
   WebSocket, so the activity panel shows an agent and a human acting on the
@@ -70,8 +78,8 @@ Needs `../cores/dosbox_pure_libretro.so` (libretro buildbot) and `../game/`.
   (about 2 KB). Attaching one to every keypress buried the log. Only the
   newest 40 entries keep their image.
 
-The live canvas uses the small `zlib` tile encoder. Pillow is used only for
-on-demand PNG/WebP observations and activity thumbnails.
+The live canvas uses the small `zlib` tile encoder. Pillow is used for on-demand PNG/WebP observations, activity thumbnails,
+history reconstruction and background video captions.
 
 ## Several agents on one session
 

--- a/server/README.md
+++ b/server/README.md
@@ -72,10 +72,12 @@ Needs `../cores/dosbox_pure_libretro.so` (libretro buildbot) and `../game/`.
   200. Reusing a token with a different recording or speed is HTTP 409. If a
   ready MP4 has been evicted while its job record remains, the token returns
   HTTP 410 so the caller can submit a new token instead of silently creating a
-  second export. ffmpeg must be installed on the server. Cached results are
-  bounded by a 2 GiB / 30-day policy, retaining the latest result and active
-  downloads. The source recording and benchmark counters are unaffected by
-  export.
+  second export. Request-token mappings are not persisted: the same-job-ID
+  guarantee ends when the job record is reaped or the service restarts. The
+  completed MP4 cache remains persistent. ffmpeg must be installed on the
+  server. Cached results are bounded by a 2 GiB / 30-day policy, retaining the
+  latest result and active downloads. The source recording and benchmark
+  counters are unaffected by export.
 - `/api/history?limit=100` the bounded action log. Every REST call and every key pressed in a
   browser is recorded and pushed to all connected pages over the same
   WebSocket, so the activity panel shows an agent and a human acting on the

--- a/server/README.md
+++ b/server/README.md
@@ -211,5 +211,8 @@ python server/import_activity.py --recording /path/recording.jsonl --history /pa
 merges its latest action markers with existing activity, and keeps the newest
 300 entries. It never changes the recording or scans it during normal startup.
 Imported markers retain timestamps, actors, verbs and targets; unavailable
-results are marked unknown. Original thumbnail/detail fields cannot be recovered
-from action markers. Re-importing the same recording does not duplicate rows.
+results are marked unknown. For the latest 40 screen reads, the importer reconstructs a thumbnail from the
+last recorded frame preceding each action marker. Hover a thumbnail to see its
+recorded time and origin. These replay previews may differ from the original
+API screenshot; unavailable frame data stays without an image. Original extra
+detail and execution outcomes cannot be recovered from action markers. Re-importing the same recording does not duplicate rows.

--- a/server/activity.py
+++ b/server/activity.py
@@ -1,0 +1,82 @@
+"""Bounded, atomic activity snapshots for an opt-in, single-owner session."""
+import json
+import math
+import os
+from pathlib import Path
+import tempfile
+
+MAX_ENTRIES = 300
+MAX_BYTES = 4 * 1024 * 1024
+MAX_THUMB = 64 * 1024
+
+
+def clean_entries(entries):
+    if not isinstance(entries, list) or len(entries) > MAX_ENTRIES:
+        raise ValueError("invalid activity history length")
+    result = []
+    last_id = 0
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("invalid activity entry")
+        seq, at = entry.get("id"), entry.get("at")
+        if type(seq) is not int or seq <= last_id:
+            raise ValueError("invalid activity sequence")
+        if type(at) not in (int, float) or not math.isfinite(at):
+            raise ValueError("invalid activity timestamp")
+        row = {"id": seq, "at": at, "ok": entry.get("ok") is True}
+        for key in ("src", "verb", "target", "detail"):
+            value = entry.get(key, "")
+            if not isinstance(value, str):
+                raise ValueError("invalid activity text")
+            row[key] = value[:256]
+        thumb = entry.get("thumb")
+        if isinstance(thumb, str) and len(thumb) <= MAX_THUMB and thumb.startswith("data:image/webp;base64,"):
+            row["thumb"] = thumb
+        result.append(row)
+        last_id = seq
+    # Match the live panel's thumbnail budget.
+    thumbs = [row for row in result if "thumb" in row]
+    for row in thumbs[:-40]:
+        row.pop("thumb")
+    return result
+
+
+class ActivityStore:
+    """Keep the last 300 entries, independent of benchmark/session counters.
+
+    The caller owns this path exclusively (one save directory per server).
+    A failed write leaves the previous complete snapshot intact.
+    """
+    def __init__(self, path):
+        self.path = Path(path)
+
+    def load(self):
+        try:
+            with self.path.open("rb") as stream:
+                raw = stream.read(MAX_BYTES + 1)
+        except FileNotFoundError:
+            return []
+        if len(raw) > MAX_BYTES:
+            raise ValueError("activity snapshot exceeds size limit")
+        data = json.loads(raw)
+        if not isinstance(data, dict) or data.get("version") != 1:
+            raise ValueError("unsupported activity snapshot")
+        return clean_entries(data.get("entries"))
+
+    def save(self, entries):
+        rows = clean_entries(list(entries)[-MAX_ENTRIES:])
+        raw = json.dumps({"version": 1, "entries": rows}, ensure_ascii=True).encode()
+        if len(raw) > MAX_BYTES:
+            raise ValueError("activity snapshot exceeds size limit")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        name = None
+        try:
+            with tempfile.NamedTemporaryFile(dir=self.path.parent, prefix=".activity-", delete=False) as stream:
+                name = stream.name
+                stream.write(raw)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(name, self.path)
+        finally:
+            if name is not None:
+                Path(name).unlink(missing_ok=True)

--- a/server/activity.py
+++ b/server/activity.py
@@ -23,7 +23,7 @@ def clean_entries(entries):
             raise ValueError("invalid activity sequence")
         if type(at) not in (int, float) or not math.isfinite(at):
             raise ValueError("invalid activity timestamp")
-        row = {"id": seq, "at": at, "ok": entry.get("ok") is True}
+        row = {"id": seq, "at": at, "ok": entry.get("ok") if type(entry.get("ok")) is bool else None}
         for key in ("src", "verb", "target", "detail"):
             value = entry.get(key, "")
             if not isinstance(value, str):

--- a/server/activity.py
+++ b/server/activity.py
@@ -32,6 +32,14 @@ def clean_entries(entries):
         thumb = entry.get("thumb")
         if isinstance(thumb, str) and len(thumb) <= MAX_THUMB and thumb.startswith("data:image/webp;base64,"):
             row["thumb"] = thumb
+            if entry.get("thumb_source") == "recording":
+                row["thumb_source"] = "recording"
+                at_frame = entry.get("thumb_at")
+                if type(at_frame) in (int, float) and math.isfinite(at_frame):
+                    row["thumb_at"] = at_frame
+        offset, started = entry.get("recording_offset"), entry.get("recording_started")
+        if type(offset) is int and offset >= 0 and type(started) in (int, float) and math.isfinite(started):
+            row.update(recording_offset=offset, recording_started=started)
         result.append(row)
         last_id = seq
     # Match the live panel's thumbnail budget.

--- a/server/activity_thumbnails.py
+++ b/server/activity_thumbnails.py
@@ -1,0 +1,97 @@
+"""Rebuild bounded previews from frames preceding a legacy action marker."""
+import base64
+from contextlib import nullcontext
+import io
+import json
+import math
+import struct
+import zlib
+
+from PIL import Image
+
+MAX_DELTA = 4 * 1024 * 1024
+MAX_PIXELS = 1024 * 1024
+
+
+class RecordedScreen:
+    def __init__(self):
+        self.image = None
+        self.geometry = None
+
+    def apply(self, encoded):
+        compressed = base64.b64decode(encoded, validate=True)
+        decoder = zlib.decompressobj()
+        raw = decoder.decompress(compressed, MAX_DELTA + 1)
+        if len(raw) > MAX_DELTA or not decoder.eof or decoder.unconsumed_tail or decoder.unused_data:
+            raise ValueError('invalid or oversized compressed frame')
+        if len(raw) < 13:
+            raise ValueError('truncated frame header')
+        key, width, height, tw, th, cols, rows, count = struct.unpack_from('<BHHBBHHH', raw)
+        if not all((width, height, tw, th, cols, rows)) or width * height > MAX_PIXELS:
+            raise ValueError('invalid or oversized frame geometry')
+        if cols != (width + tw - 1) // tw or rows != (height + th - 1) // th:
+            raise ValueError('invalid frame grid')
+        span, offset = tw * th * 3, 13 + count * 2
+        if len(raw) != offset + count * span:
+            raise ValueError('invalid frame payload length')
+        tiles = struct.unpack_from(f'<{count}H', raw, 13)
+        if len(set(tiles)) != count or any(tile >= cols * rows for tile in tiles):
+            raise ValueError('invalid frame tile indices')
+        geometry = width, height, tw, th, cols, rows
+        if key:
+            if count != cols * rows:
+                raise ValueError('incomplete keyframe')
+            self.image = Image.new('RGB', (width, height))
+            self.geometry = geometry
+        elif self.image is None or self.geometry != geometry:
+            raise ValueError('frame requires a matching keyframe')
+        for index, tile in enumerate(tiles):
+            begin = offset + index * span
+            pixels = Image.frombytes('RGB', (tw, th), raw[begin:begin + span])
+            self.image.paste(pixels, ((tile % cols) * tw, (tile // cols) * th))
+
+    def thumbnail(self):
+        if self.image is None:
+            return None
+        preview = self.image.copy()
+        preview.thumbnail((160, 160), Image.Resampling.NEAREST)
+        output = io.BytesIO()
+        preview.save(output, 'WEBP', quality=72, method=0)
+        return 'data:image/webp;base64,' + base64.b64encode(output.getvalue()).decode()
+
+
+def restore_thumbnails(path, entries):
+    restored = 0
+    # Do not replace original thumbnails. Never use a frame after the marker,
+    # including frames with an equal (millisecond-rounded) timestamp.
+    candidates = [r for r in entries if r['verb'] == 'GET'][-40:]
+    with (nullcontext(path) if hasattr(path, 'read') else open(path, 'rb')) as stream:
+        for row in candidates:
+            start, end = row.get('_keyframe_offset'), row.get('recording_offset')
+            if row.get('thumb') or start is None or end is None:
+                continue
+            stream.seek(start)
+            screen, last_time = RecordedScreen(), None
+            try:
+                while stream.tell() < end:
+                    line = stream.readline(min(end - stream.tell(), MAX_DELTA))
+                    if not line.endswith(b'\n'):
+                        raise ValueError('truncated or oversized recording frame')
+                    if b'"d"' not in line:
+                        continue
+                    event = json.loads(line)
+                    if not event.get('d'):
+                        continue
+                    timestamp = event.get('t')
+                    if type(timestamp) not in (int, float) or not math.isfinite(timestamp):
+                        raise ValueError('invalid frame timestamp')
+                    screen.apply(event['d'])
+                    last_time = row['recording_started'] + timestamp
+                thumb = screen.thumbnail()
+                if thumb:
+                    row.update(thumb=thumb, thumb_source='recording', thumb_at=last_time)
+                    restored += 1
+            except (ValueError, TypeError, KeyError, struct.error, zlib.error):
+                # A missing/corrupt frame is not a license to fabricate a shot.
+                continue
+    return restored

--- a/server/history_frames.py
+++ b/server/history_frames.py
@@ -74,3 +74,81 @@ def render_frame(index, step):
     output = io.BytesIO()
     screen.image.save(output, 'PNG')
     return output.getvalue(), last_time
+
+
+def iter_frames(index, steps=None):
+    """Yield action pictures without repeatedly decoding the same deltas.
+
+    Each result is ``(step, image, last_time, frame_end)``. The original step
+    metadata, including its private precision and offset bounds, is retained.
+    Images belong to this iterator and can change on its next advance; callers
+    retaining an image must copy it. ``frame_end`` is the byte immediately after
+    the last applied frame, so unchanged pictures have the same disk identity.
+    """
+    if steps is None:
+        rows = index.db.execute('SELECT data FROM steps ORDER BY seq')
+        steps = (json.loads(data) for (data,) in rows)
+    screen = None
+    pending = lines = None
+    pending_event = pending_time = None
+    position = last_cutoff = last_boundary = None
+    last_time = frame_end = monotonic_time = None
+    for step in steps:
+        if index.cancelled.is_set():
+            return
+        cutoff = step.get('_cutoff', step['cutoff'] + index.base)
+        boundary = step.get('_end', index.source.end)
+        anchor = index.db.execute(
+            'SELECT off,t FROM frames WHERE t<=? AND off<? ORDER BY t DESC,off DESC LIMIT 1',
+            (cutoff, boundary)).fetchone()
+        if anchor is None:
+            raise ValueError('no complete recorded frame before this action')
+        # A later complete frame replaces every pixel. Jump directly to it
+        # instead of decoding idle footage between the requested actions.
+        # Rich immediate markers can move either bound backwards; those need
+        # the same fresh reconstruction as a standalone frame request.
+        if (screen is None or cutoff < last_cutoff or boundary < last_boundary
+                or anchor[0] >= position):
+            screen = RecordedScreen()
+            lines = index.source.lines(anchor[0])
+            pending = None
+            pending_event = pending_time = None
+            position, monotonic_time = anchor
+            last_time = frame_end = None
+        while True:
+            if index.cancelled.is_set():
+                return
+            if pending is None:
+                pending = next(lines, None)
+            if pending is None:
+                break
+            offset, line = pending
+            if offset >= boundary:
+                break
+            if pending_event is None:
+                try:
+                    event = json.loads(line)
+                    when = float(event['t'])
+                    if not isinstance(event, dict) or not math.isfinite(when) or when < 0:
+                        raise ValueError('invalid recorded timestamp')
+                except (ValueError, TypeError, KeyError) as error:
+                    raise ValueError('damaged recording in the requested frame window') from error
+                pending_event, pending_time = event, max(monotonic_time, when)
+            event, when = pending_event, pending_time
+            if when > cutoff:
+                break
+            if event.get('d'):
+                try:
+                    screen.apply(event['d'])
+                except (ValueError, TypeError, struct.error, zlib.error) as error:
+                    raise ValueError('damaged frame in the requested recording window') from error
+                last_time = when
+                frame_end = offset + len(line)
+            position = offset + len(line)
+            monotonic_time = when
+            pending = None
+            pending_event = pending_time = None
+        if screen.image is None:
+            raise ValueError('no recorded picture for this action')
+        last_cutoff, last_boundary = cutoff, boundary
+        yield step, screen.image, last_time, frame_end

--- a/server/history_frames.py
+++ b/server/history_frames.py
@@ -1,0 +1,76 @@
+"""Reconstruct one action's recorded picture from a bounded disk window."""
+import base64
+import io
+import json
+import math
+import struct
+import zlib
+
+from activity_thumbnails import MAX_DELTA, MAX_PIXELS, RecordedScreen
+
+
+def complete_frame(event):
+    """Check the payload, since old JSON k markers were only timer hints."""
+    encoded = event.get('d')
+    if not isinstance(encoded, str):
+        return False
+    try:
+        prefix = base64.b64decode(encoded[:4096], validate=True)
+        header = zlib.decompressobj().decompress(prefix, 13)
+        if len(header) != 13:
+            return False
+        flag, width, height, tw, th, cols, rows, count = struct.unpack('<BHHBBHHH', header)
+        if not (flag and width and height and tw and th and cols and rows
+                and width * height <= MAX_PIXELS
+                and cols == (width + tw - 1) // tw
+                and rows == (height + th - 1) // th
+                and count == cols * rows
+                and 13 + count * (2 + tw * th * 3) <= MAX_DELTA):
+            return False
+        decoder = zlib.decompressobj()
+        raw = decoder.decompress(base64.b64decode(encoded, validate=True), MAX_DELTA + 1)
+        if (len(raw) != 13 + count * (2 + tw * th * 3) or not decoder.eof
+                or decoder.unconsumed_tail or decoder.unused_data):
+            return False
+        tiles = struct.unpack_from(f'<{count}H', raw, 13)
+        return len(set(tiles)) == count and all(tile < count for tile in tiles)
+    except (ValueError, TypeError, struct.error, zlib.error):
+        return False
+
+
+def render_frame(index, step):
+    """GET ends before its marker; old KEY waits for its recorded result."""
+    cutoff = step.get('_cutoff', step['cutoff'] + index.base)
+    boundary = step.get('_end', index.source.end)
+    row = index.db.execute(
+        'SELECT off,t FROM frames WHERE t<=? AND off<? ORDER BY t DESC,off DESC LIMIT 1',
+        (cutoff, boundary)).fetchone()
+    if row is None:
+        raise ValueError('no complete recorded frame before this action')
+    screen = RecordedScreen()
+    last_time = None
+    monotonic_time = row[1]
+    for offset, line in index.source.lines(row[0]):
+        if offset >= boundary:
+            break
+        try:
+            event = json.loads(line)
+            when = float(event['t'])
+            if not isinstance(event, dict) or not math.isfinite(when) or when < 0:
+                raise ValueError('invalid recorded timestamp')
+        except (ValueError, TypeError, KeyError) as error:
+            raise ValueError('damaged recording in the requested frame window') from error
+        when = monotonic_time = max(monotonic_time, when)
+        if when > cutoff:
+            break
+        if event.get('d'):
+            try:
+                screen.apply(event['d'])
+            except (ValueError, TypeError, struct.error, zlib.error) as error:
+                raise ValueError('damaged frame in the requested recording window') from error
+            last_time = when
+    if screen.image is None:
+        raise ValueError('no recorded picture for this action')
+    output = io.BytesIO()
+    screen.image.save(output, 'PNG')
+    return output.getvalue(), last_time

--- a/server/history_index.py
+++ b/server/history_index.py
@@ -14,7 +14,7 @@ import sqlite3
 import threading
 
 from history_frames import complete_frame
-from recording import Snapshot
+from recording import MAX_LINE, Snapshot
 
 INDEX_LOCK = threading.Lock()
 SCHEMA = 2
@@ -112,6 +112,9 @@ class HistoryIndex:
             last = state.get('last', 0.0)
             events, damaged = state.get('events', 0), state.get('damaged', 0)
             checkpoint = start
+            if not self._backfill_recorded_times(min(start, self.total)):
+                db.execute('ROLLBACK')
+                return
             if start < self.total:
                 for offset, line in source.lines(start):
                     if self.cancelled.is_set():
@@ -137,6 +140,7 @@ class HistoryIndex:
                     mark = normalize(event)
                     if mark:
                         kind, data = mark
+                        data['recorded_t'] = when
                         db.execute('INSERT OR REPLACE INTO marks VALUES (?,?,?,?)',
                                    (offset, last, kind, json.dumps(data, ensure_ascii=False)))
                     if self.scanned - checkpoint >= 1 << 20:
@@ -170,6 +174,52 @@ class HistoryIndex:
                 except (ValueError, TypeError, KeyError):
                     damaged += 1
         self.summary.update(events=events, damaged_lines=damaged)
+
+    def _recorded_time(self, offset):
+        """Read one cached action using small chunks from its pinned prefix."""
+        fd, end, line = self.source.fd, self.source.end, bytearray()
+        while offset + len(line) < end:
+            if self.cancelled.is_set():
+                return None
+            chunk = os.pread(fd, min(512, end - offset - len(line),
+                                    MAX_LINE + 1 - len(line)), offset + len(line))
+            if not chunk:
+                raise ValueError('recording was truncated')
+            newline = chunk.find(b'\n')
+            line.extend(chunk if newline < 0 else chunk[:newline + 1])
+            if len(line) > MAX_LINE:
+                raise ValueError('recording event is too large')
+            if newline >= 0:
+                event = json.loads(line)
+                when = float(event['t'])
+                if not math.isfinite(when) or when < 0:
+                    raise ValueError('invalid recording event')
+                return when
+        raise ValueError('recording has an incomplete trailing event')
+
+    def _backfill_recorded_times(self, end):
+        """Upgrade existing v2 action metadata in place, keeping the frame index."""
+        offset = self.source.begin - 1
+        while True:
+            if self.cancelled.is_set():
+                return False
+            rows = self.db.execute('SELECT off,data FROM marks WHERE off>? AND off<? '
+                                   'ORDER BY off LIMIT 256', (offset, end)).fetchall()
+            if not rows:
+                return True
+            updates = []
+            for offset, payload in rows:
+                if self.cancelled.is_set():
+                    return False
+                data = json.loads(payload)
+                if 'recorded_t' not in data:
+                    when = self._recorded_time(offset)
+                    if when is None:
+                        return False
+                    data['recorded_t'] = when
+                    updates.append((json.dumps(data, ensure_ascii=False), offset))
+            if updates:
+                self.db.executemany('UPDATE marks SET data=? WHERE off=?', updates)
 
     def _steps(self):
         db, end = self.db, self.source.end

--- a/server/history_index.py
+++ b/server/history_index.py
@@ -17,7 +17,7 @@ from history_frames import complete_frame
 from recording import Snapshot
 
 INDEX_LOCK = threading.Lock()
-SCHEMA = 1
+SCHEMA = 2
 SETTLE = 1.0
 
 
@@ -44,9 +44,10 @@ def normalize(event):
         result['detail'] = str(event['detail'])[:4096]
     if 'phase' in event:
         result['phase'] = str(event['phase'])[:32]
-    for name in ('ok', 'history'):
-        if name in event:
-            result[name] = bool(event[name])
+    if 'ok' in event:
+        result['ok'] = event['ok'] if type(event['ok']) is bool else None
+    if 'history' in event:
+        result['history'] = bool(event['history'])
     return kind, result
 
 
@@ -193,7 +194,8 @@ class HistoryIndex:
             for following in itertools.chain(marks, (None,)):
                 if self.cancelled.is_set():
                     return
-                immediate = current['act'] == 'GET' or current.get('phase') == 'after'
+                immediate = (current['act'] == 'GET' or current.get('phase') == 'after'
+                             or current.get('ok') is False)
                 absolute_cutoff = current['_when'] if immediate else min(current['_when'] + SETTLE,
                                   following['_when'] if following is not None else math.inf)
                 cutoff = absolute_cutoff - self.base

--- a/server/history_index.py
+++ b/server/history_index.py
@@ -1,0 +1,238 @@
+"""Disposable sparse disk indexes over immutable recording prefixes.
+
+The original JSONL remains the source of truth. Only action metadata and
+validated complete-frame offsets are indexed; neither frames nor the whole
+event list are loaded into memory. Steps are a per-reader disk-backed table.
+"""
+from collections import Counter
+import hashlib
+import itertools
+import json
+import math
+import os
+import sqlite3
+import threading
+
+from history_frames import complete_frame
+from recording import Snapshot
+
+INDEX_LOCK = threading.Lock()
+SCHEMA = 1
+SETTLE = 1.0
+
+
+def normalize(event):
+    """Preserve old agent actions and newer numbered action labels."""
+    who = event.get('who')
+    if not event.get('history') and (not who or who == 'web'):
+        return None
+    act = event.get('act')
+    if isinstance(act, str) and act:
+        result = {'act': act[:32], 'on': str(event.get('on', ''))[:4096]}
+        kind = 1
+    elif type(act) in (int, float) and isinstance(event.get('label'), str):
+        verb, _, target = event['label'][:4128].partition(' ')
+        result = {'act': verb or 'KEY', 'on': target}
+        kind = 1
+    elif event.get('key') and event.get('down'):
+        result = {'act': 'KEY', 'on': str(event['key'])[:4096]}
+        kind = 2
+    else:
+        return None
+    result['who'] = str(who or '')[:256]
+    if 'detail' in event:
+        result['detail'] = str(event['detail'])[:4096]
+    if 'phase' in event:
+        result['phase'] = str(event['phase'])[:32]
+    for name in ('ok', 'history'):
+        if name in event:
+            result[name] = bool(event[name])
+    return kind, result
+
+
+class HistoryIndex:
+    def __init__(self, pin):
+        self.source = Snapshot(**pin)
+        self.cancelled = threading.Event()
+        self.db = None
+        self.closed = False
+        self.scanned = self.source.begin
+        self.total = self.source.end
+        self.steps = 0
+        self.base = 0.0
+        self.summary = {}
+
+    def build(self):
+        acquired = False
+        try:
+            while not self.cancelled.is_set():
+                if INDEX_LOCK.acquire(timeout=.1):
+                    acquired = True
+                    break
+            if not acquired:
+                return
+            self._index()
+        finally:
+            if acquired:
+                INDEX_LOCK.release()
+
+    def _index(self):
+        source = self.source
+        stat = os.fstat(source.fd)
+        signature = hashlib.sha256(json.dumps(source.header, sort_keys=True).encode()).hexdigest()[:20]
+        folder = source.path.parent / '.history-index'
+        folder.mkdir(exist_ok=True)
+        self.path = folder / f'v{SCHEMA}-{stat.st_dev}-{stat.st_ino}-{signature}.sqlite3'
+        self.db = db = sqlite3.connect(self.path, timeout=30, check_same_thread=False,
+                                       isolation_level=None)
+        db.execute('PRAGMA journal_mode=WAL')
+        db.execute('PRAGMA cache_size=-2048')
+        db.execute('PRAGMA temp_store=FILE')
+        db.execute('PRAGMA temp.cache_size=-2048')
+        db.executescript('''
+            CREATE TABLE IF NOT EXISTS frames (off INTEGER PRIMARY KEY, t REAL);
+            CREATE INDEX IF NOT EXISTS frame_time ON frames(t,off);
+            CREATE TABLE IF NOT EXISTS marks (off INTEGER PRIMARY KEY, t REAL, kind INTEGER, data TEXT);
+            CREATE INDEX IF NOT EXISTS mark_kind ON marks(kind,off);
+            CREATE TABLE IF NOT EXISTS state (id INTEGER PRIMARY KEY, data TEXT);
+            CREATE TABLE IF NOT EXISTS prefixes (end INTEGER PRIMARY KEY, events INTEGER, damaged INTEGER);
+        ''')
+        db.execute('BEGIN IMMEDIATE')
+        try:
+            row = db.execute('SELECT data FROM state WHERE id=1').fetchone()
+            state = json.loads(row[0]) if row else {}
+            if state.get('end', 0) > stat.st_size:
+                db.execute('DELETE FROM frames')
+                db.execute('DELETE FROM marks')
+                db.execute('DELETE FROM prefixes')
+                state = {}
+            start = state.get('end', source.begin)
+            self.scanned = min(start, self.total)
+            last = state.get('last', 0.0)
+            events, damaged = state.get('events', 0), state.get('damaged', 0)
+            checkpoint = start
+            if start < self.total:
+                for offset, line in source.lines(start):
+                    if self.cancelled.is_set():
+                        db.execute('ROLLBACK')
+                        return
+                    self.scanned = offset + len(line)
+                    try:
+                        event = json.loads(line)
+                        when = float(event['t'])
+                        if not isinstance(event, dict) or not math.isfinite(when) or when < 0:
+                            raise ValueError('invalid recording event')
+                    except (ValueError, TypeError, KeyError):
+                        damaged += 1
+                        if self.scanned - checkpoint >= 1 << 20:
+                            db.execute('INSERT OR REPLACE INTO prefixes VALUES (?,?,?)',
+                                       (self.scanned, events, damaged))
+                            checkpoint = self.scanned
+                        continue
+                    events += 1
+                    last = max(last, when)
+                    if complete_frame(event):
+                        db.execute('INSERT OR REPLACE INTO frames VALUES (?,?)', (offset, last))
+                    mark = normalize(event)
+                    if mark:
+                        kind, data = mark
+                        db.execute('INSERT OR REPLACE INTO marks VALUES (?,?,?,?)',
+                                   (offset, last, kind, json.dumps(data, ensure_ascii=False)))
+                    if self.scanned - checkpoint >= 1 << 20:
+                        db.execute('INSERT OR REPLACE INTO prefixes VALUES (?,?,?)',
+                                   (self.scanned, events, damaged))
+                        checkpoint = self.scanned
+                state = dict(end=self.scanned, last=last, events=events, damaged=damaged)
+                db.execute('INSERT OR REPLACE INTO state VALUES (1,?)', (json.dumps(state),))
+                db.execute('INSERT OR REPLACE INTO prefixes VALUES (?,?,?)', (self.scanned, events, damaged))
+            db.execute('COMMIT')
+        except BaseException:
+            if db.in_transaction:
+                db.execute('ROLLBACK')
+            raise
+        if self.cancelled.is_set():
+            return
+        self._steps()
+        # Concurrent readers can build a longer prefix before this one starts.
+        # Recover exact counters from the nearest bounded checkpoint.
+        if state.get('end') != self.total:
+            row = db.execute('SELECT end,events,damaged FROM prefixes WHERE end<=? ORDER BY end DESC LIMIT 1',
+                             (self.total,)).fetchone()
+            start, events, damaged = row or (source.begin, 0, 0)
+            for _, line in source.lines(start):
+                try:
+                    event = json.loads(line)
+                    when = float(event['t'])
+                    if not isinstance(event, dict) or not math.isfinite(when) or when < 0:
+                        raise ValueError('invalid recording event')
+                    events += 1
+                except (ValueError, TypeError, KeyError):
+                    damaged += 1
+        self.summary.update(events=events, damaged_lines=damaged)
+
+    def _steps(self):
+        db, end = self.db, self.source.end
+        origin = db.execute('SELECT off,t FROM frames WHERE off<? ORDER BY off LIMIT 1', (end,)).fetchone()
+        db.execute('CREATE TEMP TABLE steps (seq INTEGER PRIMARY KEY, data TEXT)')
+        if origin is None:
+            self.summary = {'actors': [], 'verbs': {}}
+            return
+        first_offset, self.base = origin
+        first_act = db.execute(
+            'SELECT t FROM marks WHERE kind=1 AND off>? AND off<? ORDER BY off LIMIT 1',
+            (first_offset, end)).fetchone()
+        boundary = first_act[0] if first_act else math.inf
+        rows = db.execute('SELECT off,t,data FROM marks WHERE off>? AND off<? '
+                          'AND (kind=1 OR (kind=2 AND t<?)) ORDER BY off',
+                          (first_offset, end, boundary))
+        marks = (dict(json.loads(data), t=max(0.0, when-self.base), _when=when, _offset=offset)
+                 for offset, when, data in rows)
+        current = next(marks, None)
+        verbs, actors, shown, batch = Counter(), [], -1.0, []
+        if current is not None:
+            for following in itertools.chain(marks, (None,)):
+                if self.cancelled.is_set():
+                    return
+                immediate = current['act'] == 'GET' or current.get('phase') == 'after'
+                absolute_cutoff = current['_when'] if immediate else min(current['_when'] + SETTLE,
+                                  following['_when'] if following is not None else math.inf)
+                cutoff = absolute_cutoff - self.base
+                # Rich history deliberately retains repeated/failed actions.
+                if not self.steps or cutoff > shown or current.get('history'):
+                    step = dict(current, cutoff=round(cutoff, 3), _cutoff=absolute_cutoff)
+                    step['t'] = round(step['t'], 3)
+                    if immediate:
+                        step['_end'] = current['_offset']
+                    elif following is not None and absolute_cutoff == following['_when']:
+                        step['_end'] = following['_offset']
+                    self.steps += 1
+                    batch.append((self.steps, json.dumps(step, ensure_ascii=False)))
+                    verbs[step['act']] += 1
+                    if step['who'] not in actors and len(actors) < 8:
+                        actors.append(step['who'])
+                    shown = cutoff
+                    if len(batch) >= 256:
+                        db.executemany('INSERT INTO steps VALUES (?,?)', batch)
+                        batch.clear()
+                current = following
+        if batch:
+            db.executemany('INSERT INTO steps VALUES (?,?)', batch)
+        self.summary = {'actors': actors, 'verbs': dict(verbs)}
+
+    def step(self, index):
+        if not 0 <= index < self.steps:
+            raise ValueError('invalid step')
+        return json.loads(self.db.execute('SELECT data FROM steps WHERE seq=?', (index + 1,)).fetchone()[0])
+
+    def page(self, start, count):
+        rows = self.db.execute('SELECT data FROM steps WHERE seq>? AND seq<=? ORDER BY seq',
+                               (start, min(start + count, self.steps))).fetchall()
+        return [{key: value for key, value in json.loads(data).items() if not key.startswith('_')}
+                for (data,) in rows]
+
+    def close(self):
+        if not self.closed:
+            self.closed = True
+            if self.db is not None:
+                self.db.close()
+            self.source.close()

--- a/server/import_activity.py
+++ b/server/import_activity.py
@@ -1,0 +1,65 @@
+"""Import legacy recording action markers while the target server is stopped."""
+import argparse
+from collections import deque
+import json
+import math
+from pathlib import Path
+
+from activity import ActivityStore, MAX_ENTRIES
+
+
+def read_actions(path):
+    """Scan a fixed file prefix with bounded memory, without decoding frames."""
+    rows = deque(maxlen=MAX_ENTRIES)
+    count = 0
+    with Path(path).open('rb') as stream:
+        end = stream.seek(0, 2)
+        stream.seek(0)
+        header = json.loads(stream.readline())
+        started = header.get('started')
+        if type(started) not in (int, float) or not math.isfinite(started):
+            raise ValueError('recording has no valid start time')
+        while stream.tell() < end:
+            line = stream.readline(min(end - stream.tell(), 4 * 1024 * 1024))
+            if not line.endswith(b'\n'):
+                if stream.tell() == end:
+                    break  # an uncommitted final append
+                raise ValueError('recording line exceeds size limit')
+            if b'"act"' not in line:
+                continue
+            event = json.loads(line)
+            if not event.get('act'):
+                continue
+            timestamp = event.get('t')
+            if type(timestamp) not in (int, float) or not math.isfinite(timestamp) or timestamp < 0:
+                raise ValueError('invalid action timestamp')
+            count += 1
+            rows.append(dict(id=count, at=started + timestamp,
+                             src=event.get('who', ''), verb=event['act'],
+                             target=event.get('on', ''),
+                             detail='from recording; result unknown', ok=None))
+    return list(rows), count
+
+
+def import_recording(recording, history):
+    if Path(recording).resolve() == Path(history).resolve():
+        raise ValueError('recording and history must be different files')
+    rows, count = read_actions(recording)
+    store = ActivityStore(history)
+    existing = store.load()
+    # Existing richer entries win if the same marker was imported previously.
+    merged = {(r['at'], r['src'], r['verb'], r['target']): r for r in rows + existing}
+    retained = sorted(merged.values(), key=lambda r: r['at'])[-MAX_ENTRIES:]
+    for seq, row in enumerate(retained, 1):
+        row['id'] = seq
+    store.save(retained)
+    return {'recording_actions': count, 'existing_entries': len(existing),
+            'retained_entries': len(retained)}
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--recording', required=True)
+    parser.add_argument('--history', required=True)
+    args = parser.parse_args()
+    print(json.dumps(import_recording(args.recording, args.history)))

--- a/server/import_activity.py
+++ b/server/import_activity.py
@@ -1,30 +1,41 @@
 """Import legacy recording action markers while the target server is stopped."""
 import argparse
-from collections import deque
+from contextlib import nullcontext
+from collections import deque, defaultdict
 import json
 import math
 from pathlib import Path
 
 from activity import ActivityStore, MAX_ENTRIES
+from activity_thumbnails import restore_thumbnails
 
 
 def read_actions(path):
-    """Scan a fixed file prefix with bounded memory, without decoding frames."""
+    """Scan a fixed prefix and retain offsets for the latest action markers."""
     rows = deque(maxlen=MAX_ENTRIES)
     count = 0
-    with Path(path).open('rb') as stream:
+    with (nullcontext(path) if hasattr(path, 'read') else Path(path).open('rb')) as stream:
         end = stream.seek(0, 2)
         stream.seek(0)
-        header = json.loads(stream.readline())
+        header_line = stream.readline(65537)
+        if len(header_line) > 65536 or not header_line.endswith(b'\n'):
+            raise ValueError('invalid recording header')
+        header = json.loads(header_line)
         started = header.get('started')
         if type(started) not in (int, float) or not math.isfinite(started):
             raise ValueError('recording has no valid start time')
+        keyframe = None
         while stream.tell() < end:
+            offset = stream.tell()
             line = stream.readline(min(end - stream.tell(), 4 * 1024 * 1024))
             if not line.endswith(b'\n'):
                 if stream.tell() == end:
                     break  # an uncommitted final append
                 raise ValueError('recording line exceeds size limit')
+            if b'"d"' in line and b'"k"' in line:
+                event = json.loads(line)
+                if event.get('d') and event.get('k'):
+                    keyframe = offset
             if b'"act"' not in line:
                 continue
             event = json.loads(line)
@@ -37,24 +48,46 @@ def read_actions(path):
             rows.append(dict(id=count, at=started + timestamp,
                              src=event.get('who', ''), verb=event['act'],
                              target=event.get('on', ''),
-                             detail='from recording; result unknown', ok=None))
+                             detail='from recording; result unknown', ok=None,
+                             recording_offset=offset, recording_started=started,
+                             _keyframe_offset=keyframe))
     return list(rows), count
 
 
 def import_recording(recording, history):
     if Path(recording).resolve() == Path(history).resolve():
         raise ValueError('recording and history must be different files')
-    rows, count = read_actions(recording)
-    store = ActivityStore(history)
-    existing = store.load()
-    # Existing richer entries win if the same marker was imported previously.
-    merged = {(r['at'], r['src'], r['verb'], r['target']): r for r in rows + existing}
-    retained = sorted(merged.values(), key=lambda r: r['at'])[-MAX_ENTRIES:]
-    for seq, row in enumerate(retained, 1):
-        row['id'] = seq
-    store.save(retained)
+    with Path(recording).open('rb') as source:
+        rows, count = read_actions(source)
+        store = ActivityStore(history)
+        existing = store.load()
+        # Use the action's byte offset, not its rounded timestamp, as identity.
+        # Upgrade earlier imports without this identity by matching each old row once.
+        by_origin = {(r['recording_started'], r['recording_offset']): i for i, r in enumerate(rows)}
+        by_content = defaultdict(deque)
+        for i, row in enumerate(rows):
+            by_content[(row['at'], row['src'], row['verb'], row['target'])].append(i)
+        used = set()
+        for old in existing:
+            origin = old.get('recording_started'), old.get('recording_offset')
+            index = by_origin.get(origin)
+            if origin == (None, None):
+                matches = by_content[(old['at'], old['src'], old['verb'], old['target'])]
+                while matches and matches[0] in used:
+                    matches.popleft()
+                index = matches.popleft() if matches else None
+            if index is None:
+                rows.append(old)
+            else:
+                rows[index].update(old)
+                used.add(index)
+        retained = sorted(rows, key=lambda r: r['at'])[-MAX_ENTRIES:]
+        thumbnails = restore_thumbnails(source, retained)
+        for seq, row in enumerate(retained, 1):
+            row['id'] = seq
+        store.save(retained)
     return {'recording_actions': count, 'existing_entries': len(existing),
-            'retained_entries': len(retained)}
+            'retained_entries': len(retained), 'restored_thumbnails': thumbnails}
 
 
 if __name__ == '__main__':

--- a/server/import_activity.py
+++ b/server/import_activity.py
@@ -10,6 +10,9 @@ from activity import ActivityStore, MAX_ENTRIES
 from activity_thumbnails import restore_thumbnails
 
 
+LEGACY_TIME_TOLERANCE = 0.001
+
+
 def read_actions(path):
     """Scan a fixed prefix and retain offsets for the latest action markers."""
     rows = deque(maxlen=MAX_ENTRIES)
@@ -64,18 +67,28 @@ def import_recording(recording, history):
         # Use the action's byte offset, not its rounded timestamp, as identity.
         # Upgrade earlier imports without this identity by matching each old row once.
         by_origin = {(r['recording_started'], r['recording_offset']): i for i, r in enumerate(rows)}
-        by_content = defaultdict(deque)
+        by_content = defaultdict(list)
         for i, row in enumerate(rows):
-            by_content[(row['at'], row['src'], row['verb'], row['target'])].append(i)
+            by_content[(row['src'], row['verb'], row['target'])].append(i)
         used = set()
         for old in existing:
-            origin = old.get('recording_started'), old.get('recording_offset')
-            index = by_origin.get(origin)
-            if origin == (None, None):
-                matches = by_content[(old['at'], old['src'], old['verb'], old['target'])]
-                while matches and matches[0] in used:
-                    matches.popleft()
-                index = matches.popleft() if matches else None
+            offset = old.get('recording_offset')
+            started = old.get('recording_started')
+            index = None
+            if type(offset) is int and offset >= 0:
+                index = by_origin.get((started, offset))
+            else:
+                # Early imports had no byte identity and the recording stores
+                # timestamps rounded to milliseconds. Consume candidates in
+                # recording order so equal-time actions cannot be reused or
+                # paired with a later duplicate.
+                candidates = by_content[(old['src'], old['verb'], old['target'])]
+                for candidate in candidates:
+                    if candidate in used:
+                        continue
+                    if abs(rows[candidate]['at'] - old['at']) <= LEGACY_TIME_TOLERANCE:
+                        index = candidate
+                        break
             if index is None:
                 rows.append(old)
             else:

--- a/server/index.html
+++ b/server/index.html
@@ -1032,7 +1032,7 @@ function addLog(e) {
   }
   else if (e.verb === "TEXT") tgt.textContent = JSON.stringify(e.target);
   else tgt.textContent = e.target + (e.detail ? " " + e.detail : "");
-  if (!e.ok) row.style.color = "#ff6b6b";
+  if (e.ok === false) row.style.color = "#ff6b6b";
   rows.appendChild(row);
   if (e.thumb) {
     const box = document.createElement("div");

--- a/server/index.html
+++ b/server/index.html
@@ -333,7 +333,7 @@
   </h2>
   <div id="meter">
     <span>played <b id="m-time">0:00</b></span>
-    <span>actions <b id="m-acts">0</b></span>
+    <span title="Actions since this server session started">session actions <b id="m-acts">0</b></span>
     <span>agent <b id="m-api">0</b></span>
     <span>web <b id="m-web">0</b></span>
   </div>
@@ -1008,6 +1008,7 @@ function addLog(e) {
     `<span class="ts"></span><span class="src"></span>` +
     `<span class="vbwrap"><span class="vb"></span></span><span class="tg"></span>`;
   row.children[0].textContent = ts;
+  row.children[0].title = d.toLocaleString();
   row.children[1].textContent = e.src;
   row.children[1].style.color = e.src === "web" ? "#7c7c8a" : colorOf(e.src);
   row.children[1].title = e.src;

--- a/server/index.html
+++ b/server/index.html
@@ -52,7 +52,6 @@
   #vcrkeys { display: flex; gap: 4px; min-height: 20px; align-items: center; }
   #vcrtrack { width: 260px; height: 4px; background: #26262c; border-radius: 2px; overflow: hidden; }
   #vcrfill { display: block; height: 4px; width: 0; background: #6cb6ff; }
-  #image-jump { margin: 0 12px 8px; align-self: flex-start; font: inherit; font-size: 11px; padding: 4px 8px; }
   #logrows { overflow-y: auto; padding: 6px 0 10px; flex: 1; }
   .r { display: flex; gap: 7px; padding: 2px 12px; font-size: 11px; line-height: 1.5; white-space: nowrap; }
   .r:hover { background: #17171c; }
@@ -247,6 +246,7 @@
   #side [hidden] { display: none !important; }
   #side h2 { flex: none; }
   #meter { color: #8b8b99; }
+  #image-jump { margin: 0 12px 8px; align-self: flex-start; font: inherit; font-size: 11px; padding: 4px 8px; }
   #activitytabs { display: flex; gap: 14px; padding: 0 12px; border-bottom: 1px solid #26262c; flex: none; }
   #activitytabs button { padding: 9px 0; font-size: 11px; border: 0; border-radius: 0; background: none; color: #7e7e8e; }
   #activitytabs button[aria-selected=true] { color: #a6d5ff; box-shadow: inset 0 -2px #7fc7ff; }
@@ -269,6 +269,7 @@
   .history-empty { padding: 15px 12px; color: #9292a0; font-size: 11px; }
 
 </style>
+<script defer src="saved-history.js" data-history-enabled="auto"></script>
 
 <div id="app">
 <div id="main">
@@ -1199,5 +1200,3 @@ document.getElementById("open").onclick = () => window.open("/api/help?lang=" + 
 fit();
 connect();
 </script>
-
-<script src="saved-history.js" data-history-enabled="auto"></script>

--- a/server/index.html
+++ b/server/index.html
@@ -243,6 +243,29 @@
   #books div.got { color: #74d99f; border-color: #2e5c42; background: #17241d; }
   #copied { color: #64b47a; font-size: 11px; opacity: 0; transition: opacity .2s; }
   #copied.on { opacity: 1; }
+  #side { position: relative; }
+  #side [hidden] { display: none !important; }
+  #side h2 { flex: none; }
+  #meter { color: #8b8b99; }
+  #activitytabs { display: flex; gap: 14px; padding: 0 12px; border-bottom: 1px solid #26262c; flex: none; }
+  #activitytabs button { padding: 9px 0; font-size: 11px; border: 0; border-radius: 0; background: none; color: #7e7e8e; }
+  #activitytabs button[aria-selected=true] { color: #a6d5ff; box-shadow: inset 0 -2px #7fc7ff; }
+  #historyinfo { margin-left: 5px; font-size: 10px; color: #818190; }
+  #historypane { display: flex; flex-direction: column; flex: 1; min-height: 0; }
+  #historyrows { overflow-y: auto; flex: 1; min-height: 0; padding: 3px 0; }
+  #historynav { display: flex; align-items: center; justify-content: space-between; gap: 6px; padding: 8px 12px; border-top: 1px solid #26262c; flex: none; }
+  #historynav button { padding: 4px 7px; font-size: 10px; }
+  #historyrange { color: #818190; font-size: 10px; }
+  .saved-row { padding: 8px 12px 10px; border-bottom: 1px solid #202028; }
+  .saved-meta { display: flex; justify-content: space-between; gap: 5px; font-size: 10px; color: #707080; margin-bottom: 4px; }
+  .saved-who { color: #8ecdf7; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 160px; }
+  .saved-action { display: flex; align-items: center; flex-wrap: wrap; gap: 3px; font-size: 11px; min-height: 22px; margin-bottom: 5px; }
+  .saved-action .verb { color: #9ba3b5; margin-right: 5px; }
+  .saved-action .k { font-size: 13px; min-width: 25px; padding: 1px 5px; border-radius: 3px; }
+  .saved-shot { display: block; }
+  .saved-shot img { width: 220px; max-width: 100%; display: block; border: 1px solid #2a2a32; border-radius: 3px; image-rendering: pixelated; }
+  .history-empty { padding: 15px 12px; color: #9292a0; font-size: 11px; }
+
 </style>
 
 <div id="app">
@@ -339,8 +362,16 @@
     <span>web <b id="m-web">0</b></span>
   </div>
   <div id="bars"></div>
+  <div id="activitytabs" role="tablist" aria-label="活动记录">
+    <button id="historytab" role="tab" aria-selected="true" aria-controls="historypane">历史截图<span id="historyinfo"></span></button>
+    <button id="livetab" role="tab" aria-selected="false" aria-controls="logrows">实时活动</button>
+  </div>
+  <div id="historypane" role="tabpanel" aria-labelledby="historytab">
+    <div id="historyrows"><div class="history-empty">正在读取截图…</div></div>
+    <div id="historynav"><button id="historyfirst" title="最早的截图" disabled>«</button><button id="historyprev" disabled>← 更早</button><span id="historyrange"></span><button id="historynext" disabled>更晚 →</button><button id="historylatest" title="最新 / 刷新" disabled>↻</button></div>
+  </div>
   <button id="image-jump" hidden>Show latest image</button>
-  <div id="logrows"><div id="empty">nothing yet. keys you press here, and calls
+  <div id="logrows" role="tabpanel" aria-labelledby="livetab" hidden><div id="empty">nothing yet. keys you press here, and calls
     to /api/*, both show up.</div></div>
 </aside>
 </div>
@@ -681,7 +712,7 @@ imageJump.onclick = () => {
 };
 function updateImageJump() {
   const count = rows.querySelectorAll(".shot").length;
-  imageJump.hidden = !count;
+  imageJump.hidden = !count || document.getElementById("historypane")?.hidden === false;
   imageJump.textContent = `Show latest image (${count})`;
 }
 let logged = 0, lastId = 0;
@@ -1140,3 +1171,5 @@ document.getElementById("open").onclick = () => window.open("/api/help?lang=" + 
 fit();
 connect();
 </script>
+
+<script src="saved-history.js"></script>

--- a/server/index.html
+++ b/server/index.html
@@ -261,6 +261,8 @@
   .saved-who { color: #8ecdf7; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 160px; }
   .saved-action { display: flex; align-items: center; flex-wrap: wrap; gap: 3px; font-size: 11px; min-height: 22px; margin-bottom: 5px; }
   .saved-action .verb { color: #9ba3b5; margin-right: 5px; }
+  .saved-result { color: #ff9b94; font-size: 11px; margin-bottom: 6px; }
+  .saved-detail { color: #9292a0; font-size: 11px; margin-bottom: 6px; }
   .saved-action .k { font-size: 13px; min-width: 25px; padding: 1px 5px; border-radius: 3px; }
   .saved-shot { display: block; }
   .saved-shot img { width: 220px; max-width: 100%; display: block; border: 1px solid #2a2a32; border-radius: 3px; image-rendering: pixelated; }
@@ -1030,6 +1032,7 @@ setInterval(() => {
 }, 1000);
 
 function clearLog() {
+  dispatchEvent(new Event("historyinvalidate"));
   rows.textContent = "";
   awaitingHold = [];
   downAt.clear();
@@ -1107,25 +1110,50 @@ const MAP = {
   ArrowUp: "up", ArrowDown: "down", ArrowLeft: "left", ArrowRight: "right",
   Enter: "enter", Escape: "esc", " ": "space", Backspace: "backspace", Tab: "tab",
 };
+// Game keyboard routing. UI controls own their keys and never steer the game.
 const held = new Set();
+function uiOwnsKeyboard(target) {
+  if (slotOpen() || document.getElementById("vcr")?.classList.contains("on")) return true;
+  return !!(target?.isContentEditable || target?.closest?.(
+    "input,textarea,select,button:not([data-k]),a,summary,[role=tab],[role=slider]"));
+}
+function releaseGameKeys() {
+  for (const k of held) send({t:"key", k, down:false});
+  held.clear();
+}
 addEventListener("keydown", e => {
   if (e.key === "Escape" && escSwallow) { escSwallow = false; return; }
-  if (slotOpen()) return;           // reading the save is not playing
+  if (e.isComposing || e.metaKey || e.ctrlKey || e.altKey || uiOwnsKeyboard(e.target)) {
+    releaseGameKeys();
+    return;
+  }
   const k = MAP[e.key] || (e.key.length === 1 ? e.key.toLowerCase() : null);
   if (!k) return;
   e.preventDefault();
-  if (held.has(k)) return;          // ignore auto-repeat, the game does its own
+  if (held.has(k)) return;
   held.add(k);
-  send({ t: "key", k, down: true });
+  send({t:"key", k, down:true});
 });
 addEventListener("keyup", e => {
-  if (slotOpen() && !held.size) return;
   const k = MAP[e.key] || (e.key.length === 1 ? e.key.toLowerCase() : null);
-  if (!k) return;
+  if (!held.has(k)) return;
+  // Release a game-owned key even if focus moved into a control meanwhile.
   e.preventDefault();
   held.delete(k);
-  send({ t: "key", k, down: false });
+  send({t:"key", k, down:false});
 });
+addEventListener("blur", releaseGameKeys);
+document.addEventListener("visibilitychange", () => { if (document.hidden) releaseGameKeys(); });
+document.addEventListener("focusin", e => { if (uiOwnsKeyboard(e.target)) releaseGameKeys(); });
+document.addEventListener("pointerdown", e => { if (uiOwnsKeyboard(e.target)) releaseGameKeys(); });
+if (typeof MutationObserver !== "undefined") {
+  const observer = new MutationObserver(() => { if (uiOwnsKeyboard(null)) releaseGameKeys(); });
+  for (const id of ["vcr", "slot"]) {
+    const modal = document.getElementById(id);
+    if (modal) observer.observe(modal, {attributes:true, attributeFilter:["class"]});
+  }
+}
+// End game keyboard routing.
 
 for (const b of document.querySelectorAll("button[data-k]")) {
   const k = b.dataset.k;
@@ -1172,4 +1200,4 @@ fit();
 connect();
 </script>
 
-<script src="saved-history.js"></script>
+<script src="saved-history.js" data-history-enabled="auto"></script>

--- a/server/index.html
+++ b/server/index.html
@@ -52,6 +52,7 @@
   #vcrkeys { display: flex; gap: 4px; min-height: 20px; align-items: center; }
   #vcrtrack { width: 260px; height: 4px; background: #26262c; border-radius: 2px; overflow: hidden; }
   #vcrfill { display: block; height: 4px; width: 0; background: #6cb6ff; }
+  #image-jump { margin: 0 12px 8px; align-self: flex-start; font: inherit; font-size: 11px; padding: 4px 8px; }
   #logrows { overflow-y: auto; padding: 6px 0 10px; flex: 1; }
   .r { display: flex; gap: 7px; padding: 2px 12px; font-size: 11px; line-height: 1.5; white-space: nowrap; }
   .r:hover { background: #17171c; }
@@ -338,6 +339,7 @@
     <span>web <b id="m-web">0</b></span>
   </div>
   <div id="bars"></div>
+  <button id="image-jump" hidden>Show latest image</button>
   <div id="logrows"><div id="empty">nothing yet. keys you press here, and calls
     to /api/*, both show up.</div></div>
 </aside>
@@ -672,6 +674,16 @@ function connect() {
 const rows = document.getElementById("logrows");
 const empty = document.getElementById("empty");
 const logcount = document.getElementById("logcount");
+const imageJump = document.getElementById("image-jump");
+imageJump.onclick = () => {
+  const shots = rows.querySelectorAll(".shot");
+  shots[shots.length - 1]?.scrollIntoView({block: "center"});
+};
+function updateImageJump() {
+  const count = rows.querySelectorAll(".shot").length;
+  imageJump.hidden = !count;
+  imageJump.textContent = `Show latest image (${count})`;
+}
 let logged = 0, lastId = 0;
 
 const GLYPH = { up: "↗", down: "↙", left: "↖", right: "↘", enter: "⏎",
@@ -993,6 +1005,7 @@ function clearLog() {
   lastId = 0;                 // ids restart after a reset, so the dedupe must too
   logged = 0;
   logcount.textContent = "";
+  updateImageJump();
 }
 
 function addLog(e) {
@@ -1039,7 +1052,9 @@ function addLog(e) {
     box.className = "shot";
     const img = new Image();
     img.src = e.thumb;
-    img.title = "what the API returned";
+    img.title = e.thumb_source === "recording"
+      ? "Nearest recorded frame before this action" + (e.thumb_at ? " · " + new Date(e.thumb_at * 1000).toLocaleString() : "")
+      : "what the API returned";
     img.onclick = () => window.open(e.thumb, "_blank");
     img.onload = () => { rows.scrollTop = rows.scrollHeight; };
     box.append(img);
@@ -1048,6 +1063,7 @@ function addLog(e) {
   while (rows.children.length > 400) rows.firstChild.remove();
   rows.scrollTop = rows.scrollHeight;
   logcount.textContent = ++logged;
+  updateImageJump();
 }
 
 const send = o => {

--- a/server/saved-history.js
+++ b/server/saved-history.js
@@ -1,0 +1,103 @@
+// Complete disk-backed screenshot history. The realtime log's 40-image cache
+// is separate; each page owns only eight images and releases its snapshot.
+(() => {
+  const PAGE = 8;
+  const get = id => document.getElementById(id);
+  const endpoint = path => new URL(path, location.href);
+  let start = 0, total = 0, origin = null, busy = false, urls = [], controller = null;
+  const box = get('historyrows'), info = get('historyinfo');
+  function selectHistory(selected) {
+    get('historypane').hidden = !selected;
+    get('logrows').hidden = selected;
+    get('historytab').setAttribute('aria-selected', String(selected));
+    get('livetab').setAttribute('aria-selected', String(!selected));
+    if (typeof updateImageJump === 'function') updateImageJump();
+  }
+  get('historytab').onclick = () => selectHistory(true);
+  get('livetab').onclick = () => selectHistory(false);
+  function buttons() {
+    get('historyfirst').disabled = get('historyprev').disabled = busy || start <= 0;
+    get('historynext').disabled = busy || start + PAGE >= total;
+    get('historylatest').disabled = busy;
+  }
+  function releaseImages() { urls.forEach(url => URL.revokeObjectURL(url)); urls = []; }
+  async function request(path, signal) {
+    const response = await fetch(endpoint(path), {cache:'no-store', signal});
+    if (!response.ok) throw Error(response.status === 404 ? '历史截图暂不可用，请重试。' : '读取历史失败，请重试。');
+    return {response, data:await response.json()};
+  }
+  async function load(requested = null) {
+    if (busy) return;
+    busy = true; buttons();
+    controller = new AbortController();
+    const signal = controller.signal;
+    let token = null;
+    info.textContent = ' · 读取中';
+    try {
+      let result = await request('api/replay?recording=current', signal);
+      token = result.data.token;
+      if (!token) throw Error('历史读取未能开始，请重试。');
+      while (result.response.status === 202 || result.data.indexing) {
+        const progress = result.data.total ? Math.min(100, Math.floor(100 * result.data.scanned / result.data.total)) : null;
+        info.textContent = ' · 正在读取磁盘历史' + (progress !== null ? ` ${progress}%` : '');
+        await new Promise(resolve => setTimeout(resolve, 600));
+        result = await request(`api/replay/${encodeURIComponent(token)}`, signal);
+      }
+      const meta = result.data;
+      if (!Number.isSafeInteger(meta.steps) || meta.steps < 0) throw Error('历史记录数量无法识别。');
+      if (origin !== null && origin !== meta.started) requested = null;
+      origin = meta.started; total = meta.steps;
+      start = Math.max(0, Math.min(requested ?? Math.max(0, total - PAGE), Math.max(0, total - 1)));
+      const path = `api/replay/${encodeURIComponent(token)}/steps?start=${start}&count=${PAGE}`;
+      const {data:page} = await request(path, signal);
+      if (!Array.isArray(page.steps)) throw Error('历史截图列表无法读取。');
+      releaseImages(); box.textContent = '';
+      info.textContent = ' · ' + total.toLocaleString();
+      get('historyrange').textContent = total ? `${start+1}–${start+page.steps.length} / ${total} 张` : '0 张';
+      const imageRows = [];
+      for (let offset = page.steps.length - 1; offset >= 0; offset--) {
+        const step = page.steps[offset], index = start + offset;
+        const row = document.createElement('article'); row.className = 'saved-row'; row.dataset.step = index;
+        const details = document.createElement('div'); details.className = 'saved-meta';
+        const who = document.createElement('span'); who.className = 'saved-who'; who.textContent = step.who || 'agent'; who.title = who.textContent; who.style.color = colorOf(who.textContent);
+        const when = document.createElement('span'); when.textContent = `#${index+1} · ${fmt(step.t)}`;
+        details.append(who, when);
+        const action = document.createElement('div'); action.className = 'saved-action';
+        const verb = document.createElement('span'); verb.className = 'verb';
+        verb.textContent = ({GET:'截图',KEY:'按键',KEYS:'按键',WAIT:'等待'})[step.act] || step.act;
+        action.append(verb);
+        if (step.act === 'KEY' || step.act === 'KEYS') action.append(keySpans(step.on || ''));
+        else if (step.act !== 'GET') action.append(document.createTextNode(step.on || ''));
+        row.append(details, action); box.append(row); imageRows.push({row, index});
+      }
+      if (!page.steps.length) { const text = document.createElement('div'); text.className = 'history-empty'; text.textContent = '暂无已保存的历史截图'; box.append(text); }
+      for (let i = 0; i < imageRows.length; i += 2) {
+        await Promise.all(imageRows.slice(i,i+2).map(async ({row,index}) => {
+          try {
+            const response = await fetch(endpoint(`api/replay/${encodeURIComponent(token)}/frame?step=${index}`), {cache:'no-store',signal});
+            if (!response.ok) throw Error();
+            const url = URL.createObjectURL(await response.blob()); urls.push(url);
+            const link = document.createElement('a'); link.className = 'saved-shot'; link.href = url; link.target = '_blank'; link.rel = 'noopener'; link.title = '打开完整画面 · 从磁盘录像按步骤还原';
+            const image = new Image(); image.src = url; image.alt = `历史截图 ${index+1}`; image.dataset.step = index;
+            link.append(image); row.append(link); await image.decode();
+          } catch(error) {
+            if (signal.aborted) throw error;
+            const text = document.createElement('div'); text.className = 'history-empty'; text.textContent = '截图暂时无法加载，请重试'; row.append(text);
+          }
+        }));
+      }
+      box.scrollTop = 0;
+    } catch(error) {
+      if (!signal.aborted) { info.textContent=''; box.textContent=''; const text=document.createElement('div'); text.className='history-empty'; text.textContent=error.message; box.append(text); }
+    } finally {
+      if (token) await fetch(endpoint(`api/replay/${encodeURIComponent(token)}`), {method:'DELETE',keepalive:true}).catch(()=>{});
+      busy = false; buttons();
+    }
+  }
+  get('historyfirst').onclick = () => load(0);
+  get('historyprev').onclick = () => load(Math.max(0,start-PAGE));
+  get('historynext').onclick = () => load(start+PAGE);
+  get('historylatest').onclick = () => load();
+  addEventListener('pagehide', event => { if (!event.persisted) { controller?.abort(); releaseImages(); } });
+  selectHistory(true); load();
+})();

--- a/server/saved-history.js
+++ b/server/saved-history.js
@@ -4,7 +4,9 @@
   const PAGE = 8;
   const get = id => document.getElementById(id);
   const endpoint = path => new URL(path, location.href);
-  let start = 0, total = 0, origin = null, busy = false, urls = [], controller = null;
+  const enabled = document.currentScript?.dataset.historyEnabled !== 'false';
+  let start = 0, total = 0, origin = null, busy = false, urls = [];
+  let generation = 0, active = null, reload = false, disposed = false;
   const box = get('historyrows'), info = get('historyinfo');
   function selectHistory(selected) {
     get('historypane').hidden = !selected;
@@ -13,7 +15,7 @@
     get('livetab').setAttribute('aria-selected', String(!selected));
     if (typeof updateImageJump === 'function') updateImageJump();
   }
-  get('historytab').onclick = () => selectHistory(true);
+  get('historytab').onclick = () => { if (enabled) selectHistory(true); };
   get('livetab').onclick = () => selectHistory(false);
   function buttons() {
     get('historyfirst').disabled = get('historyprev').disabled = busy || start <= 0;
@@ -27,21 +29,30 @@
     return {response, data:await response.json()};
   }
   async function load(requested = null) {
-    if (busy) return;
+    if (active || disposed || !enabled) return;
     busy = true; buttons();
-    controller = new AbortController();
-    const signal = controller.signal;
+    const run = {generation, controller:new AbortController()};
+    active = run;
+    const signal = run.controller.signal;
+    const current = () => active === run && generation === run.generation && !signal.aborted && !disposed;
+    const check = () => { if (!current()) throw new DOMException('History changed', 'AbortError'); };
     let token = null;
     info.textContent = ' · 读取中';
     try {
-      let result = await request('api/replay?recording=current', signal);
+      // Keep the opening response even after invalidation: it owns the token
+      // we must close before opening the replacement snapshot. Later reads
+      // can be aborted because their token is already known.
+      let result = await request('api/replay?recording=current');
       token = result.data.token;
+      check();
       if (!token) throw Error('历史读取未能开始，请重试。');
       while (result.response.status === 202 || result.data.indexing) {
         const progress = result.data.total ? Math.min(100, Math.floor(100 * result.data.scanned / result.data.total)) : null;
         info.textContent = ' · 正在读取磁盘历史' + (progress !== null ? ` ${progress}%` : '');
         await new Promise(resolve => setTimeout(resolve, 600));
+        check();
         result = await request(`api/replay/${encodeURIComponent(token)}`, signal);
+        check();
       }
       const meta = result.data;
       if (!Number.isSafeInteger(meta.steps) || meta.steps < 0) throw Error('历史记录数量无法识别。');
@@ -50,6 +61,7 @@
       start = Math.max(0, Math.min(requested ?? Math.max(0, total - PAGE), Math.max(0, total - 1)));
       const path = `api/replay/${encodeURIComponent(token)}/steps?start=${start}&count=${PAGE}`;
       const {data:page} = await request(path, signal);
+      check();
       if (!Array.isArray(page.steps)) throw Error('历史截图列表无法读取。');
       releaseImages(); box.textContent = '';
       info.textContent = ' · ' + total.toLocaleString();
@@ -68,36 +80,69 @@
         action.append(verb);
         if (step.act === 'KEY' || step.act === 'KEYS') action.append(keySpans(step.on || ''));
         else if (step.act !== 'GET') action.append(document.createTextNode(step.on || ''));
-        row.append(details, action); box.append(row); imageRows.push({row, index});
+        row.append(details, action);
+        if (step.ok === false || step.detail) {
+          const result = document.createElement('div');
+          result.className = step.ok === false ? 'saved-result' : 'saved-detail';
+          result.textContent = (step.ok === false ? '未执行 / 失败' : '')
+            + (step.detail ? (step.ok === false ? ' · ' : '') + step.detail : '');
+          row.append(result);
+        }
+        box.append(row); imageRows.push({row, index});
       }
       if (!page.steps.length) { const text = document.createElement('div'); text.className = 'history-empty'; text.textContent = '暂无已保存的历史截图'; box.append(text); }
       for (let i = 0; i < imageRows.length; i += 2) {
         await Promise.all(imageRows.slice(i,i+2).map(async ({row,index}) => {
           try {
             const response = await fetch(endpoint(`api/replay/${encodeURIComponent(token)}/frame?step=${index}`), {cache:'no-store',signal});
+            check();
             if (!response.ok) throw Error();
-            const url = URL.createObjectURL(await response.blob()); urls.push(url);
+            const blob = await response.blob();
+            check();
+            const url = URL.createObjectURL(blob); urls.push(url);
             const link = document.createElement('a'); link.className = 'saved-shot'; link.href = url; link.target = '_blank'; link.rel = 'noopener'; link.title = '打开完整画面 · 从磁盘录像按步骤还原';
             const image = new Image(); image.src = url; image.alt = `历史截图 ${index+1}`; image.dataset.step = index;
             link.append(image); row.append(link); await image.decode();
+            check();
           } catch(error) {
-            if (signal.aborted) throw error;
+            if (!current()) throw error;
             const text = document.createElement('div'); text.className = 'history-empty'; text.textContent = '截图暂时无法加载，请重试'; row.append(text);
           }
         }));
       }
+      check();
       box.scrollTop = 0;
     } catch(error) {
-      if (!signal.aborted) { info.textContent=''; box.textContent=''; const text=document.createElement('div'); text.className='history-empty'; text.textContent=error.message; box.append(text); }
+      if (current()) { releaseImages(); info.textContent=''; box.textContent=''; const text=document.createElement('div'); text.className='history-empty'; text.textContent=error.message; box.append(text); }
     } finally {
       if (token) await fetch(endpoint(`api/replay/${encodeURIComponent(token)}`), {method:'DELETE',keepalive:true}).catch(()=>{});
-      busy = false; buttons();
+      active = null; busy = false;
+      if (reload && !disposed) { reload = false; load(); }
+      else buttons();
     }
+  }
+  function invalidate() {
+    if (!enabled || disposed) return;
+    generation++;
+    active?.controller.abort();
+    releaseImages(); box.textContent = '';
+    start = total = 0; origin = null;
+    info.textContent = ' · 读取中'; get('historyrange').textContent = '';
+    if (active) reload = true;
+    else load();
   }
   get('historyfirst').onclick = () => load(0);
   get('historyprev').onclick = () => load(Math.max(0,start-PAGE));
   get('historynext').onclick = () => load(start+PAGE);
   get('historylatest').onclick = () => load();
-  addEventListener('pagehide', event => { if (!event.persisted) { controller?.abort(); releaseImages(); } });
-  selectHistory(true); load();
+  addEventListener('historyinvalidate', invalidate);
+  addEventListener('pagehide', event => {
+    if (!event.persisted) {
+      disposed = true; reload = false; generation++;
+      active?.controller.abort(); releaseImages();
+    }
+  });
+  get('historytab').hidden = !enabled;
+  selectHistory(enabled);
+  if (enabled) load();
 })();

--- a/server/saved_history.py
+++ b/server/saved_history.py
@@ -1,0 +1,180 @@
+"""Paged screenshots of every saved action, independent of the live log tail."""
+import asyncio
+from collections import OrderedDict
+import contextlib
+import secrets
+import time
+
+from aiohttp import web
+
+from history_frames import render_frame
+from history_index import HistoryIndex
+
+
+async def finish(function, *args):
+    """Wait for file users even when a client disconnects or a task is cancelled."""
+    task = asyncio.create_task(asyncio.to_thread(function, *args))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        with contextlib.suppress(Exception):
+            await task
+        raise
+
+
+class SavedHistory:
+    MAX_OPEN = 2
+    TTL = 300
+
+    def __init__(self, store):
+        self.store = store
+        self.states = OrderedDict()
+        self.lock = asyncio.Lock()
+        self.reaper = None
+        self.closed = False
+
+    async def _close(self, state):
+        state['index'].cancelled.set()
+        try:
+            with contextlib.suppress(Exception):
+                await asyncio.shield(state['task'])
+        except asyncio.CancelledError:
+            with contextlib.suppress(Exception):
+                await state['task']
+            raise
+        finally:
+            state['index'].close()
+
+    async def _expire(self):
+        now = time.monotonic()
+        for token, state in list(self.states.items()):
+            if now - state['used'] > self.TTL:
+                del self.states[token]
+                await self._close(state)
+
+    async def _get(self, token):
+        await self._expire()
+        state = self.states.get(token)
+        if state is None:
+            raise web.HTTPGone(reason='history expired; reopen the recording')
+        state['used'] = time.monotonic()
+        self.states.move_to_end(token)
+        return state
+
+    @staticmethod
+    def metadata(token, state):
+        index, task = state['index'], state['task']
+        if not task.done():
+            return {'token': token, 'indexing': True, 'scanned': index.scanned, 'total': index.total}
+        error = task.exception()
+        if error:
+            raise web.HTTPUnprocessableEntity(reason='saved recording cannot be indexed: ' + str(error))
+        return dict(token=token, indexing=False, steps=index.steps,
+                    started=index.source.header.get('started'),
+                    duration=max(0.0, index.source.duration-index.base),
+                    beat=.6, speeds=[.5, 1, 2, 4, 8], **index.summary)
+
+    async def open(self, request):
+        # No user-supplied filesystem paths, including archived filenames.
+        if request.query.get('recording', 'current') != 'current':
+            raise web.HTTPNotFound()
+        async with self.lock:
+            if self.closed:
+                raise web.HTTPServiceUnavailable(reason='history service is closing')
+            await self._expire()
+            while len(self.states) >= self.MAX_OPEN:
+                _, state = self.states.popitem(last=False)
+                await self._close(state)
+            try:
+                index = HistoryIndex(self.store.pin())
+            except (ValueError, TypeError, KeyError, OSError) as error:
+                raise web.HTTPUnprocessableEntity(reason='saved recording cannot be opened: ' + str(error))
+            token = secrets.token_urlsafe(18)
+            state = {'index': index, 'used': time.monotonic(),
+                     'task': asyncio.create_task(asyncio.to_thread(index.build))}
+            self.states[token] = state
+            meta = self.metadata(token, state)
+            return web.json_response(meta, status=202 if meta['indexing'] else 200)
+
+    async def info(self, request):
+        async with self.lock:
+            token = request.match_info['token']
+            meta = self.metadata(token, await self._get(token))
+            return web.json_response(meta, status=202 if meta['indexing'] else 200)
+
+    async def steps(self, request):
+        async with self.lock:
+            token = request.match_info['token']
+            state = await self._get(token)
+            meta = self.metadata(token, state)
+            if meta['indexing']:
+                return web.json_response(meta, status=202)
+            try:
+                start = max(0, int(request.query.get('start', '0')))
+                count = min(128, max(1, int(request.query.get('count', '128'))))
+            except ValueError:
+                raise web.HTTPBadRequest(reason='invalid step range')
+            index = state['index']
+            return web.json_response({'start': start, 'steps': index.page(start, count), 'total': index.steps})
+
+    async def frame(self, request):
+        async with self.lock:
+            token = request.match_info['token']
+            state = await self._get(token)
+            meta = self.metadata(token, state)
+            if meta['indexing']:
+                return web.json_response(meta, status=202)
+            try:
+                number = int(request.query.get('step', '0'))
+                step = state['index'].step(number)
+            except ValueError:
+                raise web.HTTPBadRequest(reason='invalid step')
+            try:
+                data, when = await finish(render_frame, state['index'], step)
+            except (ValueError, OSError) as error:
+                raise web.HTTPUnprocessableEntity(reason=str(error))
+            return web.Response(body=data, content_type='image/png', headers={
+                'Cache-Control': 'no-store', 'X-Replay-Step': str(number),
+                'X-Replay-Time': str(step['t']), 'X-Replay-Frame-Time': str(when),
+                'X-Replay-Source': 'recording',
+            })
+
+    async def close(self, request):
+        async with self.lock:
+            state = self.states.pop(request.match_info['token'], None)
+            if state:
+                await self._close(state)
+            return web.json_response({'ok': True})
+
+    async def _reap(self):
+        while True:
+            await asyncio.sleep(min(30, self.TTL))
+            async with self.lock:
+                await self._expire()
+
+    async def startup(self, app):
+        self.reaper = asyncio.create_task(self._reap())
+
+    async def cleanup(self, app):
+        self.closed = True
+        if self.reaper:
+            self.reaper.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self.reaper
+        async with self.lock:
+            for state in self.states.values():
+                await self._close(state)
+            self.states.clear()
+
+    def install(self, app, enabled=True):
+        if not enabled:
+            return
+        app.add_routes([
+            web.get('/api/replay', self.open),
+            web.get('/api/replay/{token}', self.info),
+            web.get('/api/replay/{token}/steps', self.steps),
+            web.get('/api/replay/{token}/frame', self.frame),
+            web.delete('/api/replay/{token}', self.close),
+        ])
+        app.on_startup.append(self.startup)
+        app.on_cleanup.append(self.cleanup)

--- a/server/saved_history.py
+++ b/server/saved_history.py
@@ -3,6 +3,7 @@ import asyncio
 from collections import OrderedDict
 import contextlib
 import secrets
+import re
 import time
 
 from aiohttp import web
@@ -26,8 +27,9 @@ class SavedHistory:
     MAX_OPEN = 2
     TTL = 300
 
-    def __init__(self, store):
+    def __init__(self, store, pin_provider=None):
         self.store = store
+        self.pin_provider = pin_provider
         self.states = OrderedDict()
         self.lock = asyncio.Lock()
         self.reaper = None
@@ -76,7 +78,8 @@ class SavedHistory:
 
     async def open(self, request):
         # No user-supplied filesystem paths, including archived filenames.
-        if request.query.get('recording', 'current') != 'current':
+        recording = request.query.get('recording', 'current')
+        if recording != 'current' and (self.pin_provider is None or not re.fullmatch(r'[0-9]{8}-[0-9]{6}-[a-f0-9]{12}\.jsonl', recording)):
             raise web.HTTPNotFound()
         async with self.lock:
             if self.closed:
@@ -86,7 +89,10 @@ class SavedHistory:
                 _, state = self.states.popitem(last=False)
                 await self._close(state)
             try:
-                index = HistoryIndex(self.store.pin())
+                pin = self.pin_provider(recording) if self.pin_provider else self.store.pin()
+                index = HistoryIndex(pin)
+            except FileNotFoundError:
+                raise web.HTTPNotFound()
             except (ValueError, TypeError, KeyError, OSError) as error:
                 raise web.HTTPUnprocessableEntity(reason='saved recording cannot be opened: ' + str(error))
             token = secrets.token_urlsafe(18)

--- a/server/server.py
+++ b/server/server.py
@@ -30,6 +30,7 @@ from PIL import Image
 import warden
 from state_reader import decode_inventory, inventory_gained
 import save_state
+from activity import ActivityStore
 
 from prompt import system_prompt
 from health import Health, EnvironmentFailure
@@ -202,6 +203,33 @@ STATE_DIR = os.environ.get("QUNXIA_STATE_DIR", str(ROOT.parent / "saves" / "stat
 # what. The game is shared, so this doubles as "why did the screen just move".
 history: collections.deque = collections.deque(maxlen=300)
 _seq = [0]
+activity_store = None
+
+
+def restore_activity():
+    global activity_store
+    # Persistent UI history is explicitly opt-in and never enters formal runs.
+    if warden.ON or os.environ.get("QUNXIA_PERSIST_HISTORY", "0") != "1":
+        return
+    store = ActivityStore(pathlib.Path(SAVES) / "activity.json")
+    try:
+        entries = store.load()
+    except (OSError, ValueError) as exc:
+        # Preserve malformed/unreadable snapshots for inspection, not overwrite.
+        print(f"activity history disabled: {exc}", flush=True)
+        return
+    history.extend(entries)
+    _seq[0] = entries[-1]["id"] if entries else 0
+    activity_store = store
+
+
+def persist_activity():
+    if activity_store is not None:
+        try:
+            activity_store.save(history)
+        except (OSError, ValueError) as exc:
+            print(f"activity history write failed: {exc}", flush=True)
+
 # Counted per game, so a reset starts a fresh session rather than continuing one.
 session = {"started": time.time(), "actions": 0, "key_events": 0,
            "input_frames": 0, "wait_calls": 0, "by_api": 0, "by_web": 0}
@@ -722,6 +750,7 @@ def log_action(src, verb, target, detail="", ok=True, thumb=False,
         session["by_web" if src == "web" else "by_api"] += 1
         agents[src] += 1
     history.append(entry)
+    persist_activity()
     try:
         asyncio.get_running_loop()
     except RuntimeError:
@@ -1053,7 +1082,7 @@ async def ws_handler(request):
     except BaseException:
         peers[ws].drop()
         raise
-    peers[ws].put(json.dumps({"t": "log", "e": list(history)[-80:],
+    peers[ws].put(json.dumps({"t": "log", "e": list(history),
                                   "s": session_summary(), "c": list(curve)}), text=True)
     # code -> (name, core tick at keydown). Browser automation can emit keydown
     # and keyup within one emulated frame, so remember when each press reached
@@ -1980,6 +2009,7 @@ async def api_reset(request):
         finally:
             resume_emulator()
         history.clear()
+        persist_activity()
         _seq[0] = 0
         session.update(started=time.time(), actions=0, key_events=0,
                        input_frames=0, wait_calls=0, by_api=0, by_web=0)
@@ -2303,6 +2333,7 @@ async def cleanup(app):
 
 def main():
     global health, recording_store, recording_api
+    restore_activity()
     directory = os.environ.get("QUNXIA_RECORDING_DIR", str(ROOT.parent / "recordings"))
     validate_recording_directory(directory)
     path = pathlib.Path(os.environ.get("QUNXIA_RECORDING_FILE", str(pathlib.Path(directory) / f"{PORT}.jsonl")))

--- a/server/server.py
+++ b/server/server.py
@@ -31,6 +31,7 @@ import warden
 from state_reader import decode_inventory, inventory_gained
 import save_state
 from activity import ActivityStore
+from saved_history import SavedHistory
 
 from prompt import system_prompt
 from health import Health, EnvironmentFailure
@@ -724,6 +725,32 @@ def make_thumb():
     return "data:image/webp;base64," + base64.b64encode(out.getvalue()).decode()
 
 
+def disk_history_enabled():
+    return (not warden.ON and recording_store is not None
+            and os.environ.get("QUNXIA_PERSIST_HISTORY", "0") == "1")
+
+
+def record_activity(entry):
+    # The JSONL retains every marker; the deque and activity.json are only a
+    # small reconnect cache. GETs must survive after their cache entries age out.
+    if not disk_history_enabled() or entry["verb"] not in ("GET", "KEY", "KEYS", "WAIT", "TEXT"):
+        return
+    event = {"t": round(entry["at"] - rec["started"], 3),
+             "act": entry["verb"], "who": entry["src"], "on": entry["target"],
+             "detail": entry["detail"], "ok": entry["ok"], "history": 1}
+    if entry.get("thumb"):
+        event["thumb"] = entry["thumb"]
+    try:
+        ok = recording_store.append(event)
+    except (OSError, BufferError) as exc:
+        recording_store.error = str(exc)
+        ok = False
+    if not ok:
+        block_recording()
+        raise RecordingUnavailable(recording_store.error)
+    rec["bytes"] = recording_store.committed_size
+
+
 def log_action(src, verb, target, detail="", ok=True, thumb=False,
                key_events=None, input_frames=0, wait_call=False):
     _seq[0] += 1
@@ -749,6 +776,7 @@ def log_action(src, verb, target, detail="", ok=True, thumb=False,
         session["wait_calls"] += int(wait_call or verb == "WAIT")
         session["by_web" if src == "web" else "by_api"] += 1
         agents[src] += 1
+    record_activity(entry)
     history.append(entry)
     persist_activity()
     try:
@@ -1471,7 +1499,8 @@ async def run_action(request, steps, note, verb="KEY"):
         log_action(rec["actor"], verb, note, detail=held_note(steps),
                    key_events=len(key_steps), input_frames=input_frames,
                    wait_call=not key_steps)
-        rec_add("a", key=session["actions"], down=f"{verb} {note}"[:32])
+        if not disk_history_enabled():
+            rec_add("a", key=session["actions"], down=f"{verb} {note}"[:32])
         if warden.ON:
             # Only key steps carry a name at index 2; "wait" and "frames" are
             # pairs. Filtering by kind broke the moment a new pause kind was
@@ -2154,6 +2183,10 @@ async def api_help(request):
                         content_type="text/plain", charset="utf-8")
 
 
+async def saved_history_script(_request):
+    return web.FileResponse(ROOT / "saved-history.js", headers={"Cache-Control": "no-store"})
+
+
 async def recording_script(_request):
     return web.FileResponse(ROOT / "recording.js")
 
@@ -2362,6 +2395,7 @@ def main():
     app.add_routes([
         web.get("/", index),
         web.get("/recording.js", recording_script),
+        web.get("/saved-history.js", saved_history_script),
         web.get("/ws", ws_handler),
         web.get("/status", status),
         web.get("/progress", progress),
@@ -2381,6 +2415,7 @@ def main():
     ])
     # Startup handlers are awaited, so the workers are detached tasks rather
     # than returned, or startup would block on loops that never end.
+    SavedHistory(recording_store).install(app, enabled=not warden.ON)
     app.on_startup.append(startup)
     app.on_cleanup.append(cleanup)
     web.run_app(app, host="0.0.0.0", port=PORT, access_log=None)

--- a/server/server.py
+++ b/server/server.py
@@ -32,6 +32,7 @@ from state_reader import decode_inventory, inventory_gained
 import save_state
 from activity import ActivityStore
 from saved_history import SavedHistory
+from video_export import VideoExports
 
 from prompt import system_prompt
 from health import Health, EnvironmentFailure
@@ -2421,7 +2422,9 @@ def main():
     ])
     # Startup handlers are awaited, so the workers are detached tasks rather
     # than returned, or startup would block on loops that never end.
-    SavedHistory(recording_store).install(app, enabled=not warden.ON)
+    pin_provider = getattr(recording_api, "pin", None)
+    SavedHistory(recording_store, pin_provider=pin_provider).install(app, enabled=not warden.ON)
+    VideoExports(recording_store, pin_provider=pin_provider).install(app, enabled=not warden.ON)
     app.on_startup.append(startup)
     app.on_cleanup.append(cleanup)
     web.run_app(app, host="0.0.0.0", port=PORT, access_log=None)

--- a/server/server.py
+++ b/server/server.py
@@ -2399,10 +2399,10 @@ def main():
     threading.Thread(target=emulate, daemon=True).start()
 
     app = web.Application(middlewares=[json_errors])
+    app.router.add_get("/saved-history.js", saved_history_script)
     app.add_routes([
         web.get("/", index),
         web.get("/recording.js", recording_script),
-        web.get("/saved-history.js", saved_history_script),
         web.get("/ws", ws_handler),
         web.get("/status", status),
         web.get("/progress", progress),

--- a/server/server.py
+++ b/server/server.py
@@ -2192,7 +2192,13 @@ async def recording_script(_request):
 
 
 async def index(_request):
-    return web.FileResponse(ROOT / "index.html")
+    # The benchmark deliberately has no saved-history endpoints. Let its
+    # observer page choose the available live log without probing a 404.
+    page = (ROOT / "index.html").read_text(encoding="utf-8").replace(
+        'data-history-enabled="auto"',
+        f'data-history-enabled="{str(not warden.ON).lower()}"')
+    return web.Response(text=page, content_type="text/html",
+                        headers={"Cache-Control": "no-store"})
 
 
 async def progress(request):

--- a/server/test_activity.py
+++ b/server/test_activity.py
@@ -1,0 +1,122 @@
+import collections
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+from activity import ActivityStore, MAX_BYTES
+
+
+def entry(seq, **extra):
+    return dict(id=seq, at=1700000000 + seq, src='agent', verb='KEY',
+                target='up', detail='', ok=True, **extra)
+
+
+class ActivityStoreTests(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.path = Path(tmp.name) / 'activity.json'
+        self.store = ActivityStore(self.path)
+
+    def test_restart_retains_order_timestamps_and_thumbnails(self):
+        rows = [entry(1), entry(2, thumb='data:image/webp;base64,AAAA')]
+        self.store.save(rows)
+        self.assertEqual(ActivityStore(self.path).load(), rows)
+
+    def test_retention_and_thumbnail_budget(self):
+        self.store.save([entry(i, thumb='data:image/webp;base64,AAAA') for i in range(1, 502)])
+        rows = self.store.load()
+        self.assertEqual([r['id'] for r in rows], list(range(202, 502)))
+        self.assertEqual(sum('thumb' in r for r in rows), 40)
+        self.assertLess(self.path.stat().st_size, MAX_BYTES)
+
+    def test_failed_replace_keeps_old_snapshot_and_cleans_temp(self):
+        self.store.save([entry(1)])
+        before = self.path.read_bytes()
+        with mock.patch('activity.os.replace', side_effect=OSError('disk error')):
+            with self.assertRaises(OSError):
+                self.store.save([entry(2)])
+        self.assertEqual(self.path.read_bytes(), before)
+        self.assertEqual(list(self.path.parent.iterdir()), [self.path])
+
+    def test_failed_fsync_keeps_old_snapshot(self):
+        self.store.save([entry(1)])
+        with mock.patch('activity.os.fsync', side_effect=OSError('disk full')):
+            with self.assertRaises(OSError):
+                self.store.save([entry(2)])
+        self.assertEqual(self.store.load(), [entry(1)])
+
+    def test_reset_and_missing_snapshot(self):
+        self.assertEqual(self.store.load(), [])
+        self.store.save([entry(1)])
+        self.store.save([])
+        self.assertEqual(ActivityStore(self.path).load(), [])
+
+    def test_rejects_corrupt_oversized_and_nonmonotonic_files(self):
+        for raw in [b'{', b'x' * (MAX_BYTES + 1),
+                    json.dumps({'version': 1, 'entries': [entry(2), entry(1)]}).encode(),
+                    json.dumps({'version': 2, 'entries': []}).encode()]:
+            with self.subTest(size=len(raw)):
+                self.path.write_bytes(raw)
+                with self.assertRaises(ValueError):
+                    self.store.load()
+                self.assertEqual(self.path.read_bytes(), raw)
+
+
+class ServerActivityTests(unittest.TestCase):
+    def setUp(self):
+        with mock.patch('ctypes.CDLL', return_value=mock.MagicMock()):
+            import server
+        self.server = server
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.path = Path(tmp.name) / 'activity.json'
+        for patch in [mock.patch.object(server, 'SAVES', tmp.name),
+                      mock.patch.object(server, 'history', collections.deque(maxlen=300)),
+                      mock.patch.object(server, '_seq', [0]),
+                      mock.patch.object(server, 'activity_store', None),
+                      mock.patch.object(server.warden, 'ON', False),
+                      mock.patch.dict(os.environ, QUNXIA_PERSIST_HISTORY='1')]:
+            patch.start()
+            self.addCleanup(patch.stop)
+
+    def test_real_log_hook_restores_ids_without_changing_session_counters(self):
+        s = self.server
+        counters = dict(s.session)
+        ActivityStore(self.path).save([entry(123)])
+        s.restore_activity()
+        self.assertEqual(s.session, counters)
+        new = s.log_action('agent', 'GET', 'screen')
+        self.assertEqual(new['id'], 124)
+        self.assertEqual(ActivityStore(self.path).load()[-1], new)
+        s.history.clear()
+        s.activity_store = None
+        s.restore_activity()
+        self.assertEqual([e['id'] for e in s.history], [123, 124])
+        s.history.clear()
+        s.persist_activity()
+        self.assertEqual(ActivityStore(self.path).load(), [])
+
+    def test_benchmark_and_default_do_not_load_or_write(self):
+        s = self.server
+        for bench, flag in [(True, '1'), (False, '0')]:
+            with mock.patch.object(s.warden, 'ON', bench), mock.patch.dict(os.environ, QUNXIA_PERSIST_HISTORY=flag):
+                s.restore_activity()
+                s.log_action('agent', 'GET', 'screen')
+                self.assertIsNone(s.activity_store)
+                self.assertFalse(self.path.exists())
+
+    def test_corruption_is_preserved_and_game_logging_continues(self):
+        self.path.write_text('{broken')
+        self.server.restore_activity()
+        self.server.log_action('web', 'GET', 'screen')
+        self.assertIsNone(self.server.activity_store)
+        self.assertEqual(self.path.read_text(), '{broken')
+        self.assertEqual(len(self.server.history), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/test_activity.py
+++ b/server/test_activity.py
@@ -117,6 +117,38 @@ class ServerActivityTests(unittest.TestCase):
         self.assertEqual(self.path.read_text(), '{broken')
         self.assertEqual(len(self.server.history), 1)
 
+class LegacyImportTests(unittest.TestCase):
+    def test_import_merges_deduplicates_and_leaves_recording_unchanged(self):
+        from import_activity import import_recording
+        with tempfile.TemporaryDirectory() as tmp:
+            recording, history = Path(tmp) / 'recording.jsonl', Path(tmp) / 'activity.json'
+            raw = json.dumps({'version': 1, 'started': 1700000000}) + '\n'
+            raw += '\n'.join(json.dumps({'t': i, 'act': 'GET', 'who': 'old-agent', 'on': 'screen'}) for i in range(1, 305)) + '\n'
+            raw += '{"t": 305, "d":"frame"}\n{"t":306'
+            recording.write_text(raw)
+            ActivityStore(history).save([entry(1, thumb='data:image/webp;base64,AAAA') | {'at': 1700000400}])
+            report = import_recording(recording, history)
+            self.assertEqual(report['recording_actions'], 304)
+            rows = ActivityStore(history).load()
+            self.assertEqual(len(rows), 300)
+            self.assertEqual(rows[0]['at'], 1700000006)
+            self.assertIsNone(rows[0]['ok'])
+            self.assertEqual(rows[-1]['src'], 'agent')
+            import_recording(recording, history)
+            self.assertEqual(ActivityStore(history).load(), rows)
+            self.assertEqual(recording.read_text(), raw)
+
+    def test_import_rejects_invalid_time_without_overwriting(self):
+        from import_activity import import_recording
+        with tempfile.TemporaryDirectory() as tmp:
+            recording, history = Path(tmp) / 'recording.jsonl', Path(tmp) / 'activity.json'
+            recording.write_text('{"started":0}\n{"t":-1,"act":"KEY"}\n')
+            ActivityStore(history).save([entry(1)])
+            before = history.read_bytes()
+            with self.assertRaises(ValueError):
+                import_recording(recording, history)
+            self.assertEqual(history.read_bytes(), before)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/server/test_activity.py
+++ b/server/test_activity.py
@@ -118,6 +118,55 @@ class ServerActivityTests(unittest.TestCase):
         self.assertEqual(len(self.server.history), 1)
 
 class LegacyImportTests(unittest.TestCase):
+    def test_import_matches_legacy_timestamp_precision(self):
+        from import_activity import import_recording
+        with tempfile.TemporaryDirectory() as tmp:
+            recording, history = Path(tmp) / 'recording.jsonl', Path(tmp) / 'activity.json'
+            events = [{'t': 1.358, 'act': 'GET', 'who': 'agent', 'on': 'screen'}]
+            raw = '\n'.join(json.dumps(x) for x in [{'version': 1, 'started': 1700000000}, *events]) + '\n'
+            recording.write_text(raw)
+            old = entry(1)
+            old['detail'] = 'legacy'
+            old['ok'] = True
+            old['verb'] = 'GET'
+            old['target'] = 'screen'
+            old['at'] = 1700000001.358023
+            ActivityStore(history).save([old])
+            report = import_recording(recording, history)
+            rows = ActivityStore(history).load()
+            self.assertEqual(report['recording_actions'], 1)
+            self.assertEqual(report['retained_entries'], 1)
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]['at'], 1700000001.358023)
+            self.assertEqual(rows[0]['detail'], 'legacy')
+            import_recording(recording, history)
+            self.assertEqual(ActivityStore(history).load(), rows)
+            self.assertEqual(recording.read_text(), raw)
+
+    def test_import_capacity_keeps_new_entries_when_recording_is_full(self):
+        from import_activity import import_recording
+        with tempfile.TemporaryDirectory() as tmp:
+            recording, history = Path(tmp) / 'recording.jsonl', Path(tmp) / 'activity.json'
+            events = [{'t': i, 'act': 'GET', 'who': 'old-agent', 'on': 'screen'}
+                      for i in range(300)]
+            raw = '\n'.join(json.dumps(x) for x in [{'version': 1, 'started': 1700000000}, *events]) + '\n'
+            recording.write_text(raw)
+            newer = []
+            for i in range(1, 301):
+                row = entry(i)
+                row['src'] = 'new-agent'
+                row['detail'] = 'new'
+                row['at'] = 1700001000 + i
+                newer.append(row)
+            ActivityStore(history).save(newer)
+            report = import_recording(recording, history)
+            rows = ActivityStore(history).load()
+            self.assertEqual(report['recording_actions'], 300)
+            self.assertEqual(report['retained_entries'], 300)
+            self.assertEqual([row['src'] for row in rows], ['new-agent'] * 300)
+            self.assertEqual(rows[-1]['at'], 1700001300)
+            self.assertEqual(recording.read_text(), raw)
+
     def test_import_merges_deduplicates_and_leaves_recording_unchanged(self):
         from import_activity import import_recording
         with tempfile.TemporaryDirectory() as tmp:

--- a/server/test_activity_thumbnails.py
+++ b/server/test_activity_thumbnails.py
@@ -1,0 +1,104 @@
+import base64
+import io
+import json
+from pathlib import Path
+import struct
+import tempfile
+import unittest
+import zlib
+
+from PIL import Image
+
+from activity import ActivityStore
+from activity_thumbnails import RecordedScreen
+from import_activity import import_recording
+
+
+def frame(color, key=True, width=2, height=1):
+    header = struct.pack('<BHHBBHHH', int(key), width, height, 1, 1, width, height, width*height)
+    payload = header + struct.pack(f'<{width*height}H', *range(width*height)) + bytes(color) * width*height
+    return base64.b64encode(zlib.compress(payload)).decode()
+
+
+def image_pixel(row):
+    return Image.open(io.BytesIO(base64.b64decode(row['thumb'].split(',')[1]))).convert('RGB').getpixel((0,0))
+
+
+class ThumbnailImportTests(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.recording = Path(tmp.name)/'recording.jsonl'
+        self.history = Path(tmp.name)/'activity.json'
+
+    def run_import(self, events):
+        self.recording.write_text('\n'.join(json.dumps(x) for x in [{'started':1700000000}, *events])+'\n')
+        import_recording(self.recording,self.history)
+        return ActivityStore(self.history).load()
+
+    def test_frame_after_marker_with_same_timestamp_is_excluded(self):
+        rows=self.run_import([{'t':1,'d':frame((250,0,0)),'k':1},
+                              {'t':1,'act':'GET','who':'agent','on':'screen'},
+                              {'t':1,'d':frame((0,0,250)),'k':1}])
+        red,green,blue=image_pixel(rows[0])
+        self.assertGreater(red,200)
+        self.assertLess(blue,30)
+        self.assertEqual(rows[0]['thumb_source'],'recording')
+        self.assertEqual(rows[0]['thumb_at'],1700000001)
+
+    def test_same_timestamp_actions_remain_distinct_and_reimport_is_stable(self):
+        events=[{'t':1,'d':frame((250,0,0)),'k':1},
+                {'t':1,'act':'GET','who':'agent','on':'screen'},
+                {'t':1,'act':'GET','who':'agent','on':'screen'}]
+        rows=self.run_import(events)
+        self.assertEqual(len(rows),2)
+        self.assertNotEqual(rows[0]['recording_offset'], rows[1]['recording_offset'])
+        import_recording(self.recording,self.history)
+        self.assertEqual(ActivityStore(self.history).load(),rows)
+
+    def test_no_keyframe_false_keyframe_and_corrupt_delta_never_fabricate_picture(self):
+        for frames in [[{'t':1,'d':frame((1,2,3),key=False)}],
+                       [{'t':1,'d':frame((1,2,3),key=False),'k':1}],
+                       [{'t':1,'d':frame((1,2,3)),'k':1},{'t':2,'d':'bad'}],
+                       [{'t':1,'d':frame((1,2,3)),'k':1},{'t':2,'d':frame((1,2,3),key=False,width=3)}]]:
+            with self.subTest(frames=frames):
+                self.history.unlink(missing_ok=True)
+                rows=self.run_import(frames+[{'t':3,'act':'GET'}])
+                self.assertNotIn('thumb',rows[0])
+
+    def test_valid_keyframe_handles_size_change(self):
+        rows=self.run_import([{'t':1,'d':frame((250,0,0)),'k':1},
+                              {'t':2,'d':frame((0,0,250),width=3),'k':1},
+                              {'t':3,'act':'GET'}])
+        self.assertGreater(image_pixel(rows[0])[2],200)
+
+    def test_reimport_adds_missing_thumbnails_and_keeps_existing_original(self):
+        rows=self.run_import([{'t':1,'d':frame((250,0,0)),'k':1},{'t':2,'act':'GET'}])
+        rows[0].pop('thumb')
+        ActivityStore(self.history).save(rows)
+        import_recording(self.recording,self.history)
+        rows=ActivityStore(self.history).load()
+        self.assertIn('thumb',rows[0])
+        original=rows[0]['thumb']
+        rows[0].pop('thumb_source');rows[0].pop('thumb_at')
+        ActivityStore(self.history).save(rows)
+        import_recording(self.recording,self.history)
+        row=ActivityStore(self.history).load()[0]
+        self.assertEqual(row['thumb'],original)
+        self.assertNotIn('thumb_source',row)
+
+    def test_only_latest_forty_gets_receive_previews(self):
+        events=[{'t':0,'d':frame((200,0,0)),'k':1}]
+        events += [{'t':i,'act':'GET'} for i in range(1,51)]
+        rows=self.run_import(events)
+        self.assertEqual(sum('thumb' in r for r in rows),40)
+        self.assertNotIn('thumb',rows[9])
+        self.assertIn('thumb',rows[10])
+
+    def test_oversized_geometry_is_rejected_before_allocation(self):
+        payload=struct.pack('<BHHBBHHH',1,65535,65535,1,1,65535,65535,0)
+        encoded=base64.b64encode(zlib.compress(payload)).decode()
+        with self.assertRaises(ValueError):RecordedScreen().apply(encoded)
+
+
+if __name__=='__main__':unittest.main()

--- a/server/test_game_keyboard.js
+++ b/server/test_game_keyboard.js
@@ -1,0 +1,46 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const test = require('node:test');
+const html = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
+const begin = html.indexOf('// Game keyboard routing.');
+const end = html.indexOf('// End game keyboard routing.');
+assert(begin >= 0 && end > begin);
+const source = html.slice(begin, end);
+
+function fixture() {
+  const handlers={}, docHandlers={}, sent=[];
+  let replay=false, slot=false, observer;
+  const context={MAP:{ArrowRight:'right',Enter:'enter',' ':'space',Escape:'esc'},escSwallow:false,
+    send:e=>sent.push({...e}),slotOpen:()=>slot,
+    addEventListener:(name,fn)=>handlers[name]=fn,
+    document:{hidden:false,getElementById:id=>({classList:{contains:()=>id==='vcr'?replay:slot}}),
+      addEventListener:(name,fn)=>docHandlers[name]=fn},
+    MutationObserver:class {constructor(fn){observer=fn;}observe(){}},
+  };
+  vm.runInNewContext(source,context);
+  const target=(kind='canvas')=>({isContentEditable:kind==='editable',closest:()=>kind==='canvas'||kind==='game-button'?null:{}});
+  function event(key,kind='canvas',extra={}) {return {key,target:target(kind),prevented:false,preventDefault(){this.prevented=true;},...extra};}
+  return {handlers,docHandlers,sent,event,context,openReplay(){replay=true;observer();},openSlot(){slot=true;observer();}};
+}
+
+test('replay controls keep native arrow/space/enter behavior without game messages',()=>{
+  const f=fixture();f.openReplay();
+  for(const key of ['ArrowRight',' ','Enter']) {const e=f.event(key,'slider');f.handlers.keydown(e);f.handlers.keyup(e);assert.equal(e.prevented,false);}
+  assert.deepEqual(f.sent,[]);
+});
+test('history buttons, links, form controls, and shortcuts do not reach the game',()=>{
+  const f=fixture();
+  for(const target of ['button','link','input','select','editable']) {const e=f.event('Enter',target);f.handlers.keydown(e);assert.equal(e.prevented,false);}
+  f.handlers.keydown(f.event('c','canvas',{metaKey:true}));assert.deepEqual(f.sent,[]);
+});
+test('opening a replay or save modal releases a held key once',()=>{
+  for(const open of ['openReplay','openSlot']) {const f=fixture();f.handlers.keydown(f.event('ArrowRight'));f[open]();f.handlers.keyup(f.event('ArrowRight','slider'));assert.deepEqual(f.sent,[{t:'key',k:'right',down:true},{t:'key',k:'right',down:false}]);}
+});
+test('game keys retain repeat suppression and release across focus changes',()=>{
+  const f=fixture();f.handlers.keydown(f.event('ArrowRight'));f.handlers.keydown(f.event('ArrowRight'));f.docHandlers.focusin(f.event('Enter','input'));f.handlers.keyup(f.event('ArrowRight','input'));assert.equal(f.sent.length,2);assert.equal(f.sent[1].down,false);
+});
+test('window blur and hidden page release active game keys',()=>{
+  const f=fixture();f.handlers.keydown(f.event('ArrowRight'));f.handlers.blur();f.handlers.keydown(f.event('Enter'));f.context.document.hidden=true;f.docHandlers.visibilitychange();assert.deepEqual(f.sent.map(e=>e.down),[true,false,true,false]);
+});

--- a/server/test_game_keyboard.py
+++ b/server/test_game_keyboard.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+import shutil
+import subprocess
+import unittest
+class GameKeyboardTests(unittest.TestCase):
+    @unittest.skipUnless(shutil.which('node'), 'Node.js is not installed')
+    def test_ui_keys_never_reach_game(self):
+        run=subprocess.run([shutil.which('node'),'--test',str(Path(__file__).with_suffix('.js'))],capture_output=True,text=True,timeout=30)
+        self.assertEqual(run.returncode,0,run.stdout+run.stderr)

--- a/server/test_history_frames_stream.py
+++ b/server/test_history_frames_stream.py
@@ -1,0 +1,231 @@
+"""Sequential export pictures retain the random-access history contract."""
+import base64
+import io
+import json
+import os
+from pathlib import Path
+import struct
+import tempfile
+import unittest
+from unittest import mock
+import zlib
+
+from PIL import Image
+
+from activity_thumbnails import RecordedScreen
+from history_frames import iter_frames, render_frame
+from history_index import HistoryIndex
+
+
+def frame(when, color, key=False):
+    tiles = [0, 1] if key else [1]
+    raw = struct.pack('<BHHBBHHH', int(key), 2, 1, 1, 1, 2, 1, len(tiles))
+    raw += struct.pack('<' + 'H' * len(tiles), *tiles)
+    raw += bytes(color) * len(tiles)
+    return {'t': when, 'd': base64.b64encode(zlib.compress(raw)).decode()}
+
+
+def action(when, act='GET', **fields):
+    return dict(t=when, act=act, who='agent', history=1, **fields)
+
+
+class HistoryFrameStreamTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def make_index(self, events):
+        path = Path(self.tmp.name) / 'recording.jsonl'
+        data = json.dumps({'version': 1, 'started': 100}).encode() + b'\n'
+        self.offsets, self.ends = [], []
+        for event in events:
+            self.offsets.append(len(data))
+            data += event if isinstance(event, bytes) else json.dumps(event).encode() + b'\n'
+            self.ends.append(len(data))
+        path.write_bytes(data)
+        index = HistoryIndex(dict(path=path, fd=os.open(path, os.O_RDONLY), end=len(data)))
+        self.addCleanup(index.close)
+        index.build()
+        return index
+
+    def assert_matches(self, index, steps=None):
+        compared = []
+        for step, image, when, end in iter_frames(index, steps):
+            expected, expected_when = render_frame(index, step)
+            with Image.open(io.BytesIO(expected)) as reference:
+                self.assertEqual(image.size, reference.size)
+                self.assertEqual(image.tobytes(), reference.tobytes())
+            self.assertEqual(when, expected_when)
+            self.assertIn(end, self.ends)
+            self.assertLessEqual(end, step.get('_end', index.source.end))
+            compared.append((step, image.copy(), when, end))
+        return compared
+
+    def test_default_iterator_preserves_every_private_step_field_and_picture(self):
+        index = self.make_index([
+            frame(10, (1, 2, 3), True),
+            {'t': 10.1, 'key': 'enter', 'down': True, 'who': 'agent'},
+            frame(10.4, (4, 5, 6)), action(11, 'KEY', on='up'),
+            frame(11.8, (7, 8, 9)),
+            {'t': 12.1, 'act': 9, 'label': 'KEY down', 'who': 'agent'},
+            frame(12.2, (10, 11, 12)), action(12.5, 'KEY', phase='after'),
+            action(12.5, 'KEY', ok=False, detail='busy'),
+            frame(12.5, (13, 14, 15)), action(12.5), action(12.6),
+        ])
+        actual = self.assert_matches(index)
+        self.assertEqual(len(actual), index.steps)
+        for number, (step, _, _, _) in enumerate(actual):
+            self.assertEqual(step, index.step(number))
+            self.assertIn('_offset', step)
+            self.assertIn('_cutoff', step)
+        self.assertTrue(any(row[0].get('ok') is False for row in actual))
+
+    def test_equal_timestamps_and_submillisecond_cutoffs_obey_byte_boundaries(self):
+        index = self.make_index([
+            frame(10, (1, 1, 1), True), action(11),
+            frame(11, (2, 2, 2)), action(11),
+            frame(10.5, (3, 3, 3)), action(11, 'KEY', ok=False),
+            frame(11, (4, 4, 4)), action(11, 'KEY', phase='after'),
+            frame(11.0004, (5, 5, 5)), action(11.0004),
+            frame(11.0004, (6, 6, 6)), action(11.0004),
+        ])
+        actual = self.assert_matches(index)
+        self.assertEqual([image.getpixel((1, 0))[0] for _, image, _, _ in actual],
+                         [1, 2, 3, 4, 5, 6])
+        self.assertEqual([end for _, _, _, end in actual], self.ends[::2])
+        self.assertEqual(actual[-1][0]['cutoff'], 1)
+        self.assertEqual(actual[-1][0]['_cutoff'], 11.0004)
+
+    def test_time_and_offset_rewinds_reconstruct_instead_of_reusing_future_pixels(self):
+        index = self.make_index([
+            frame(0, (1, 1, 1), True), frame(1, (2, 2, 2)),
+            frame(2, (3, 3, 3)), frame(2, (4, 4, 4)), action(3),
+        ])
+        bounds = [(2, index.source.end), (1, index.source.end),
+                  (2, self.offsets[3]), (2, self.offsets[2]),
+                  (2, index.source.end)]
+        steps = [dict(cutoff=t, _cutoff=t, _end=end, custom=n)
+                 for n, (t, end) in enumerate(bounds)]
+        actual = self.assert_matches(index, iter(steps))
+        self.assertEqual([image.getpixel((1, 0))[0] for _, image, _, _ in actual],
+                         [4, 2, 3, 2, 4])
+        for step, row in zip(steps, actual):
+            self.assertIs(step, row[0])
+
+    def test_nonmonotonic_source_times_use_the_global_anchor_clock(self):
+        index = self.make_index([
+            frame(10, (1, 1, 1), True), action(11),
+            {'t': 40, 'who': 'web'}, frame(12, (2, 2, 2), True),
+            frame(1, (3, 3, 3)), action(2),
+            frame(41, (4, 4, 4)), action(4),
+        ])
+        actual = self.assert_matches(index)
+        self.assertEqual([when for _, _, when, _ in actual], [10, 40, 41])
+        self.assertEqual([image.getpixel((1, 0))[0] for _, image, _, _ in actual], [1, 3, 4])
+
+    def test_each_delta_is_decoded_once_for_dense_action_history(self):
+        events = [frame(0, (1, 1, 1), True), action(.01)]
+        for n in range(1, 81):
+            events.extend((frame(n, (n, 0, 0)), action(n + .01)))
+        index = self.make_index(events)
+        apply = RecordedScreen.apply
+        calls = []
+
+        def counted(screen, encoded):
+            calls.append(encoded)
+            return apply(screen, encoded)
+
+        with mock.patch.object(RecordedScreen, 'apply', counted), \
+             mock.patch.object(index.source, 'lines', wraps=index.source.lines) as reads:
+            streamed = [(step, image.tobytes()) for step, image, _, _ in iter_frames(index)]
+        self.assertEqual(len(calls), 81)
+        self.assertEqual(reads.call_count, 1)
+        calls.clear()
+        with mock.patch.object(RecordedScreen, 'apply', counted):
+            for step, pixels in streamed:
+                data, _ = render_frame(index, step)
+                with Image.open(io.BytesIO(data)) as image:
+                    self.assertEqual(image.tobytes(), pixels)
+        self.assertEqual(len(calls), 81 * 82 // 2)
+
+    def test_a_nearer_complete_frame_skips_idle_deltas_and_prior_damage(self):
+        events = [frame(0, (1, 1, 1), True), action(.1)]
+        events += [frame(n, (n % 256, 0, 0)) for n in range(1, 201)]
+        events += [b'not-json\n', {'t': 201, 'd': 'broken'},
+                   frame(202, (9, 8, 7), True), action(202.1)]
+        index = self.make_index(events)
+        apply = RecordedScreen.apply
+        calls = []
+
+        def counted(screen, encoded):
+            calls.append(encoded)
+            return apply(screen, encoded)
+
+        with mock.patch.object(RecordedScreen, 'apply', counted):
+            actual = [(step, image.copy(), when, end)
+                      for step, image, when, end in iter_frames(index)]
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(actual[-1][1].getpixel((1, 0)), (9, 8, 7))
+        self.assertEqual(actual[-1][3], self.ends[-2])
+        self.assert_matches(index)
+
+    def test_unchanged_actions_share_the_last_frame_end(self):
+        index = self.make_index([
+            frame(0, (1, 1, 1), True), action(.1), action(.2),
+            {'t': .3, 'key': 'up', 'down': False}, action(.4),
+            frame(.5, (2, 2, 2)), action(.6),
+        ])
+        actual = self.assert_matches(index)
+        self.assertEqual([end for _, _, _, end in actual],
+                         [self.ends[0]] * 3 + [self.ends[5]])
+
+    def test_repeated_cutoffs_do_not_reparse_the_pending_future_frame(self):
+        index = self.make_index([
+            frame(0, (1, 1, 1), True), frame(2, (2, 2, 2)), action(3),
+        ])
+        steps = [dict(cutoff=1) for _ in range(40)]
+        with mock.patch('history_frames.json.loads', wraps=json.loads) as loads:
+            self.assertEqual(len(list(iter_frames(index, steps))), 40)
+        self.assertEqual(loads.call_count, 2)
+
+    def test_damaged_requested_window_has_the_same_error_as_individual_render(self):
+        for damaged, message in [(b'not-json\n', 'damaged recording'),
+                                 ({'t': 1, 'd': 'broken'}, 'damaged frame')]:
+            with self.subTest(damaged=damaged):
+                # Each source needs its own inode for the disposable index.
+                folder = Path(self.tmp.name) / 'recording.jsonl'
+                folder.unlink(missing_ok=True)
+                index = self.make_index([
+                    frame(0, (1, 1, 1), True), action(.1), damaged, action(2),
+                ])
+                rows = iter_frames(index)
+                next(rows)
+                with self.assertRaisesRegex(ValueError, message):
+                    next(rows)
+                with self.assertRaisesRegex(ValueError, message):
+                    render_frame(index, index.step(1))
+                index.close()
+
+    def test_empty_and_cancelled_iterators_do_not_decode(self):
+        index = self.make_index([frame(0, (1, 1, 1), True)])
+        self.assertEqual(list(iter_frames(index)), [])
+        index.cancelled.set()
+        with mock.patch.object(RecordedScreen, 'apply', side_effect=AssertionError('decoded')):
+            self.assertEqual(list(iter_frames(index, [dict(cutoff=0)])), [])
+
+    def test_cancellation_during_a_window_stops_before_yielding_partial_image(self):
+        index = self.make_index([
+            frame(0, (1, 1, 1), True), frame(1, (2, 2, 2)), action(2),
+        ])
+        apply = RecordedScreen.apply
+
+        def cancelled(screen, encoded):
+            apply(screen, encoded)
+            index.cancelled.set()
+
+        with mock.patch.object(RecordedScreen, 'apply', cancelled):
+            self.assertEqual(list(iter_frames(index)), [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/test_history_markers.py
+++ b/server/test_history_markers.py
@@ -40,4 +40,15 @@ class DiskHistoryMarkerTests(unittest.TestCase):
             writer.append.assert_not_called()
 
 
+class HistoryPageCapabilityTests(unittest.IsolatedAsyncioTestCase):
+    async def test_page_exposes_explicit_history_capability(self):
+        for benchmark in (False, True):
+            with mock.patch.object(server.warden, 'ON', benchmark):
+                response = await server.index(None)
+            expected = str(not benchmark).lower()
+            self.assertIn(f'data-history-enabled="{expected}"', response.text)
+            self.assertNotIn('data-history-enabled="auto"', response.text)
+            self.assertEqual(response.headers['Cache-Control'], 'no-store')
+
+
 if __name__=='__main__':unittest.main()

--- a/server/test_history_markers.py
+++ b/server/test_history_markers.py
@@ -1,0 +1,43 @@
+"""Historical GETs must remain on disk after the realtime cache rolls over."""
+import collections
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+with mock.patch('ctypes.CDLL', return_value=mock.MagicMock()):
+    import server
+from recording_store import RecordingStore
+
+
+class DiskHistoryMarkerTests(unittest.TestCase):
+    def test_every_get_survives_realtime_cache_eviction(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            writer=RecordingStore(Path(tmp)/'recording.jsonl')
+            try:
+                with mock.patch.object(server,'recording_store',writer), \
+                     mock.patch.object(server.warden,'ON',False), \
+                     mock.patch.dict(os.environ,QUNXIA_PERSIST_HISTORY='1'), \
+                     mock.patch.object(server,'history',collections.deque(maxlen=300)), \
+                     mock.patch.object(server,'_seq',[0]), \
+                     mock.patch.object(server,'persist_activity'):
+                    for _ in range(350):server.log_action('agent','GET','screen')
+                    self.assertEqual(len(server.history),300)
+                events=[json.loads(line) for line in writer.path.read_text().splitlines()[1:]]
+                self.assertEqual(len(events),350)
+                self.assertTrue(all(row['act']=='GET' and row['history']==1 for row in events))
+            finally:writer.close()
+
+    def test_benchmark_never_adds_interactive_history_markers(self):
+        writer=mock.Mock()
+        with mock.patch.object(server,'recording_store',writer), \
+             mock.patch.object(server.warden,'ON',True), \
+             mock.patch.dict(os.environ,QUNXIA_PERSIST_HISTORY='1'):
+            self.assertFalse(server.disk_history_enabled())
+            server.record_activity(dict(at=1,verb='GET',src='agent',target='screen',detail='',ok=True))
+            writer.append.assert_not_called()
+
+
+if __name__=='__main__':unittest.main()

--- a/server/test_saved_history.py
+++ b/server/test_saved_history.py
@@ -17,7 +17,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from PIL import Image
 
 from history_frames import complete_frame
-from history_index import HistoryIndex, INDEX_LOCK
+from history_index import HistoryIndex, INDEX_LOCK, normalize
 from recording_store import RecordingStore
 from saved_history import SavedHistory
 
@@ -177,6 +177,57 @@ class SavedHistoryTests(unittest.IsolatedAsyncioTestCase):
             self.store.append(event)
         meta = await self.opened()
         self.assertEqual(meta['steps'], 1)
+
+    async def test_failed_key_uses_the_picture_before_the_marker(self):
+        for event in [frame(0, (255, 0, 0)),
+                      {'t': 1, 'act': 'KEY', 'who': 'web', 'on': 'up',
+                       'detail': 'busy', 'ok': False, 'history': 1},
+                      # Millisecond-rounded times may be equal; neither this
+                      # later frame nor another actor's result belongs to the
+                      # rejected input.
+                      frame(1, (0, 255, 0)), frame(1.5, (0, 0, 255))]:
+            self.store.append(event)
+        meta = await self.opened()
+        page = await (await self.client.get(f'/api/replay/{meta["token"]}/steps')).json()
+        self.assertFalse(page['steps'][0]['ok'])
+        self.assertEqual(page['steps'][0]['detail'], 'busy')
+        self.assertEqual(page['steps'][0]['cutoff'], 1)
+        self.assertEqual((await self.picture(meta['token'], 0)).getpixel((0, 0)), (255, 0, 0))
+
+    async def test_unknown_legacy_result_is_not_reported_as_a_failed_action(self):
+        for result in (None, '', 0, 'unknown'):
+            _, mark = normalize({'act': 'KEY', 'who': 'agent', 'ok': result})
+            self.assertIsNone(mark['ok'])
+
+    async def test_version_two_rebuilds_unknown_results_without_touching_old_index_or_source(self):
+        for event in [frame(0, (255, 0, 0)),
+                      {'t': 1, 'act': 'KEY', 'who': 'agent', 'ok': None, 'history': 1},
+                      frame(1.5, (0, 0, 255))]:
+            self.store.append(event)
+        source = self.path.read_bytes()
+
+        def old_normalize(event):
+            result = normalize(event)
+            if result and 'ok' in result[1]:
+                result[1]['ok'] = bool(event['ok'])
+            return result
+
+        with mock.patch('history_index.SCHEMA', 1), mock.patch('history_index.normalize', old_normalize):
+            first = await self.opened()
+        old_index = self.service.states[first['token']]['index']
+        old_path = old_index.path
+        self.assertIs(old_index.step(0)['ok'], False)
+        await self.client.delete('/api/replay/' + first['token'])
+        old_bytes = old_path.read_bytes()
+
+        second = await self.opened()
+        new_index = self.service.states[second['token']]['index']
+        self.assertNotEqual(new_index.path, old_path)
+        self.assertTrue(new_index.path.name.startswith('v2-'))
+        self.assertIsNone(new_index.step(0)['ok'])
+        self.assertEqual((await self.picture(second['token'], 0)).getpixel((0, 0)), (0, 0, 255))
+        self.assertEqual(old_path.read_bytes(), old_bytes)
+        self.assertEqual(self.path.read_bytes(), source)
 
     async def test_false_key_marker_is_not_an_anchor_and_unmarked_whole_frame_is(self):
         self.store.append(frame(0, (10, 10, 10), marked=False))

--- a/server/test_saved_history.py
+++ b/server/test_saved_history.py
@@ -1,0 +1,313 @@
+"""Disk history is complete, paged, pinned, and independent of the live tail."""
+import asyncio
+import base64
+import io
+import json
+import os
+from pathlib import Path
+import struct
+import tempfile
+import time
+import unittest
+from unittest import mock
+import zlib
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from PIL import Image
+
+from history_frames import complete_frame
+from history_index import HistoryIndex, INDEX_LOCK
+from recording_store import RecordingStore
+from saved_history import SavedHistory
+
+
+def frame(when, color, key=True, marked=None):
+    tiles = [0, 1] if key else [1]
+    data = struct.pack('<BHHBBHHH', int(key), 2, 1, 1, 1, 2, 1, len(tiles))
+    data += struct.pack('<' + 'H' * len(tiles), *tiles)
+    data += bytes(color) * len(tiles)
+    event = {'t': when, 'd': base64.b64encode(zlib.compress(data)).decode()}
+    if marked is not None:
+        event['k'] = int(marked)
+    return event
+
+
+class SavedHistoryTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.path = Path(self.temp.name) / 'recording.jsonl'
+        self.store = RecordingStore(self.path, started=100)
+        self.service = SavedHistory(self.store)
+        self.client = await self.client_for(self.service)
+
+    async def client_for(self, service, enabled=True):
+        app = web.Application()
+        service.install(app, enabled=enabled)
+        async def ping(request):
+            return web.Response(text='alive')
+        app.router.add_get('/ping', ping)
+        client = TestClient(TestServer(app))
+        await client.start_server()
+        return client
+
+    async def asyncTearDown(self):
+        await self.client.close()
+        self.store.close()
+        self.temp.cleanup()
+
+    def write(self, count=350):
+        for number in range(count):
+            self.store.append(frame(number * 2, (number % 256, number // 256, 7)))
+            self.store.append({'t': number * 2 + .1, 'act': 'GET', 'who': 'agent', 'on': 'screen'})
+
+    async def opened(self):
+        response = await self.client.get('/api/replay')
+        self.assertIn(response.status, (200, 202))
+        meta = await response.json()
+        for _ in range(500):
+            if not meta.get('indexing'):
+                return meta
+            await asyncio.sleep(.005)
+            response = await self.client.get('/api/replay/' + meta['token'])
+            self.assertIn(response.status, (200, 202), await response.text())
+            meta = await response.json()
+        self.fail('history indexing did not finish')
+
+    async def picture(self, token, number):
+        response = await self.client.get(f'/api/replay/{token}/frame?step={number}')
+        self.assertEqual(response.status, 200, await response.text() if response.status != 200 else '')
+        self.assertEqual(response.headers['X-Replay-Step'], str(number))
+        self.assertEqual(response.headers['X-Replay-Source'], 'recording')
+        image = Image.open(io.BytesIO(await response.read()))
+        image.load()
+        return image
+
+    async def test_entire_history_is_paged_and_old_middle_latest_images_are_correct(self):
+        self.write()
+        original = self.path.read_bytes()
+        meta = await self.opened()
+        self.assertEqual(meta['steps'], 350)
+        self.assertEqual(meta['events'], 700)
+        token = meta['token']
+        response = await self.client.get(f'/api/replay/{token}/steps?start=128&count=999999')
+        page = await response.json()
+        self.assertEqual(page['total'], 350)
+        self.assertEqual(len(page['steps']), 128)
+        self.assertEqual(page['steps'][0]['t'], 256.1)
+        self.assertFalse(any(key.startswith('_') for key in page['steps'][0]))
+        # Include a backward jump after the latest image.
+        for number in (0, 175, 349, 12):
+            picture = await self.picture(token, number)
+            self.assertEqual(picture.getpixel((0, 0)), (number % 256, number // 256, 7))
+        self.assertEqual(self.path.read_bytes(), original)
+        self.assertLess(len(json.dumps(meta)), 2000)
+
+    async def test_service_restart_restores_all_steps_and_index_is_incremental(self):
+        self.write(310)
+        first = await self.opened()
+        index_path = self.service.states[first['token']]['index'].path
+        await self.client.close()
+        self.service = SavedHistory(self.store)
+        self.client = await self.client_for(self.service)
+        with mock.patch('history_index.complete_frame', side_effect=AssertionError('rescanned old payload')):
+            second = await self.opened()
+        self.assertEqual(second['steps'], 310)
+        self.assertEqual(self.service.states[second['token']]['index'].path, index_path)
+        self.assertEqual((await self.picture(second['token'], 0)).getpixel((0, 0)), (0, 0, 7))
+
+    async def test_open_snapshot_survives_append_and_reset(self):
+        self.write(4)
+        old = await self.opened()
+        self.store.append(frame(20, (255, 0, 0)))
+        self.store.append({'t': 20.1, 'act': 'GET', 'who': 'agent'})
+        self.assertEqual((await self.client.get(f'/api/replay/{old["token"]}')).status, 200)
+        self.assertEqual(self.service.states[old['token']]['index'].steps, 4)
+        archive = self.store.reset(200)
+        self.store.append(frame(0, (0, 255, 0)))
+        self.store.append({'t': .1, 'act': 'GET', 'who': 'agent'})
+        self.assertTrue(archive.is_file())
+        self.assertEqual((await self.picture(old['token'], 3)).getpixel((0, 0)), (3, 0, 7))
+        new = await self.opened()
+        self.assertEqual(new['steps'], 1)
+        self.assertEqual((await self.picture(new['token'], 0)).getpixel((0, 0)), (0, 255, 0))
+
+    async def test_get_never_includes_a_frame_after_its_marker_at_the_same_time(self):
+        self.store.append(frame(0, (10, 20, 30)))
+        self.store.append({'t': 1, 'act': 'GET', 'who': 'agent'})
+        self.store.append(frame(1, (90, 80, 70)))
+        meta = await self.opened()
+        self.assertEqual((await self.picture(meta['token'], 0)).getpixel((0, 0)), (10, 20, 30))
+
+    async def test_legacy_and_numbered_keys_settle_but_explicit_after_does_not(self):
+        for event in [frame(0, (1, 1, 1)),
+                      {'t': .1, 'key': 'enter', 'down': True, 'who': 'agent'},
+                      frame(.4, (2, 2, 2)),
+                      {'t': 1, 'act': 'KEY', 'who': 'agent', 'on': 'up'},
+                      {'t': 1.01, 'key': 'up', 'down': True, 'who': 'agent'},
+                      frame(1.8, (3, 3, 3)),
+                      {'t': 2.1, 'act': 9, 'label': 'KEY down', 'who': 'agent'},
+                      frame(2.2, (4, 4, 4)),
+                      {'t': 2.5, 'act': 'KEY', 'who': 'agent', 'phase': 'after'},
+                      frame(2.7, (5, 5, 5))]:
+            self.store.append(event)
+        meta = await self.opened()
+        self.assertEqual(meta['steps'], 3)
+        # The phase=after mark collapses with the previous equal-cutoff step.
+        for number, color in enumerate((2, 3, 4)):
+            self.assertEqual((await self.picture(meta['token'], number)).getpixel((0, 0)), (color,) * 3)
+
+    async def test_rich_markers_keep_web_and_failures_without_changing_legacy_web_filter(self):
+        for event in [frame(0, (1, 2, 3)),
+                      {'t': .1, 'act': 'GET', 'who': 'web'},
+                      {'t': .2, 'act': 'KEY', 'who': 'web', 'history': 1, 'ok': False, 'phase': 'after'},
+                      {'t': .2, 'act': 'GET', 'who': 'agent', 'history': 1}]:
+            self.store.append(event)
+        meta = await self.opened()
+        self.assertEqual(meta['steps'], 2)
+        page = await (await self.client.get(f'/api/replay/{meta["token"]}/steps')).json()
+        self.assertEqual(page['steps'][0]['who'], 'web')
+        self.assertFalse(page['steps'][0]['ok'])
+
+    async def test_raw_keys_at_the_first_action_timestamp_are_not_double_counted(self):
+        for event in [frame(0, (1, 2, 3)),
+                      {'t': 1, 'key': 'enter', 'down': True, 'who': 'agent'},
+                      {'t': 1, 'act': 'KEY', 'who': 'agent', 'on': 'enter'},
+                      frame(1.5, (4, 5, 6))]:
+            self.store.append(event)
+        meta = await self.opened()
+        self.assertEqual(meta['steps'], 1)
+
+    async def test_false_key_marker_is_not_an_anchor_and_unmarked_whole_frame_is(self):
+        self.store.append(frame(0, (10, 10, 10), marked=False))
+        partial = frame(1, (20, 20, 20), key=False, marked=True)
+        self.assertFalse(complete_frame(partial))
+        self.store.append(partial)
+        self.store.append({'t': 1.1, 'act': 'GET', 'who': 'agent'})
+        meta = await self.opened()
+        image = await self.picture(meta['token'], 0)
+        self.assertEqual(image.getpixel((0, 0)), (10, 10, 10))
+        self.assertEqual(image.getpixel((1, 0)), (20, 20, 20))
+
+    async def test_damaged_frame_returns_clear_error_and_preserves_source(self):
+        self.store.append(frame(0, (1, 2, 3)))
+        self.store.append({'t': 1, 'd': 'broken', 'k': 1})
+        self.store.append({'t': 1.1, 'act': 'GET', 'who': 'agent'})
+        original = self.path.read_bytes()
+        meta = await self.opened()
+        response = await self.client.get(f'/api/replay/{meta["token"]}/frame?step=0')
+        self.assertEqual(response.status, 422)
+        self.assertIn('damaged frame', await response.text())
+        self.assertEqual(self.path.read_bytes(), original)
+
+    async def test_malformed_line_does_not_hide_later_intact_pictures_or_change_bytes(self):
+        self.store.append(frame(0, (1, 2, 3)))
+        os.write(self.store.fd, b'not-json\n')
+        self.store.append({'t': 1, 'act': 'GET', 'who': 'agent'})
+        self.store.append(frame(2, (4, 5, 6)))
+        self.store.append({'t': 2.1, 'act': 'GET', 'who': 'agent'})
+        original = self.path.read_bytes()
+        meta = await self.opened()
+        self.assertEqual(meta['steps'], 2)
+        self.assertEqual(meta['damaged_lines'], 1)
+        self.assertEqual((await self.client.get(f'/api/replay/{meta["token"]}/frame?step=0')).status, 422)
+        self.assertEqual((await self.picture(meta['token'], 1)).getpixel((0, 0)), (4, 5, 6))
+        self.assertEqual(self.path.read_bytes(), original)
+
+    async def test_uncommitted_tail_is_not_part_of_the_snapshot(self):
+        self.write(2)
+        original_end = self.store.committed_size
+        os.write(self.store.fd, b'{"t":999,"d":"incomplete')
+        meta = await self.opened()
+        self.assertEqual(meta['steps'], 2)
+        self.assertEqual(self.service.states[meta['token']]['index'].source.end, original_end)
+        self.assertEqual((await self.picture(meta['token'], 1)).getpixel((0, 0)), (1, 0, 7))
+
+    async def test_expiration_eviction_and_close_release_descriptors(self):
+        self.write(2)
+        first = await self.opened()
+        first_index = self.service.states[first['token']]['index']
+        fd = first_index.source.fd
+        second = await self.opened()
+        third = await self.opened()
+        self.assertEqual(len(self.service.states), 2)
+        self.assertEqual((await self.client.get('/api/replay/' + first['token'])).status, 410)
+        self.assertTrue(first_index.closed)
+        self.assertTrue(first_index.source.closed)
+        # The operating system can reuse the evicted fd for the new reader.
+        self.assertEqual(first_index.source.fd, fd)
+        second_fd = self.service.states[second['token']]['index'].source.fd
+        await self.client.delete('/api/replay/' + second['token'])
+        with self.assertRaises(OSError):
+            os.fstat(second_fd)
+        self.assertEqual(len(self.service.states), 1)
+        self.service.states[third['token']]['used'] = time.monotonic() - self.service.TTL - 1
+        self.assertEqual((await self.client.get('/api/replay/' + third['token'])).status, 410)
+        self.assertFalse(self.service.states)
+
+    async def test_cancelling_an_indexing_reader_does_not_block_the_event_loop(self):
+        self.write(2)
+        INDEX_LOCK.acquire()
+        try:
+            response = await self.client.get('/api/replay')
+            self.assertEqual(response.status, 202)
+            meta = await response.json()
+            state = self.service.states[meta['token']]
+            await asyncio.sleep(.02)
+            self.assertEqual(await (await self.client.get('/ping')).text(), 'alive')
+            await self.client.delete('/api/replay/' + meta['token'])
+            self.assertTrue(state['index'].closed)
+            self.assertTrue(state['task'].done())
+        finally:
+            INDEX_LOCK.release()
+
+    async def test_shutdown_waits_for_worker_before_closing_snapshot(self):
+        self.write(2)
+        INDEX_LOCK.acquire()
+        try:
+            response = await self.client.get('/api/replay')
+            meta = await response.json()
+            state = self.service.states[meta['token']]
+            descriptor = state['index'].source.fd
+            await asyncio.sleep(.02)
+            await self.client.close()
+            self.assertTrue(state['task'].done())
+            self.assertTrue(state['index'].closed)
+            with self.assertRaises(OSError):
+                os.fstat(descriptor)
+        finally:
+            INDEX_LOCK.release()
+
+    async def test_invalid_paths_ranges_and_disabled_benchmark_have_no_access(self):
+        self.write(2)
+        for path in ('../recording.jsonl', '/etc/passwd', '20260909-120000-abcdef123456.jsonl'):
+            self.assertEqual((await self.client.get('/api/replay', params={'recording': path})).status, 404)
+        meta = await self.opened()
+        for endpoint in ('steps?start=bad', 'frame?step=-1', 'frame?step=999', 'frame?step=nan'):
+            self.assertEqual((await self.client.get(f'/api/replay/{meta["token"]}/{endpoint}')).status, 400)
+        disabled = await self.client_for(SavedHistory(self.store), enabled=False)
+        try:
+            self.assertEqual((await disabled.get('/api/replay')).status, 404)
+            self.assertEqual((await disabled.get('/api/replay/anything/steps')).status, 404)
+        finally:
+            await disabled.close()
+
+    async def test_longer_index_does_not_contaminate_an_older_pinned_reader(self):
+        self.write(3)
+        old = HistoryIndex(self.store.pin())
+        self.store.append(frame(10, (10, 10, 10)))
+        self.store.append({'t': 10.1, 'act': 'GET', 'who': 'agent'})
+        newer = HistoryIndex(self.store.pin())
+        try:
+            await asyncio.to_thread(newer.build)
+            await asyncio.to_thread(old.build)
+            self.assertEqual(old.steps, 3)
+            self.assertEqual(old.summary['events'], 6)
+            self.assertEqual(newer.steps, 4)
+        finally:
+            old.close()
+            newer.close()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/test_saved_history.py
+++ b/server/test_saved_history.py
@@ -61,8 +61,9 @@ class SavedHistoryTests(unittest.IsolatedAsyncioTestCase):
             self.store.append(frame(number * 2, (number % 256, number // 256, 7)))
             self.store.append({'t': number * 2 + .1, 'act': 'GET', 'who': 'agent', 'on': 'screen'})
 
-    async def opened(self):
-        response = await self.client.get('/api/replay')
+    async def opened(self, recording=None):
+        params = {} if recording is None else {'recording': recording}
+        response = await self.client.get('/api/replay', params=params)
         self.assertIn(response.status, (200, 202))
         meta = await response.json()
         for _ in range(500):
@@ -131,6 +132,83 @@ class SavedHistoryTests(unittest.IsolatedAsyncioTestCase):
         new = await self.opened()
         self.assertEqual(new['steps'], 1)
         self.assertEqual((await self.picture(new['token'], 0)).getpixel((0, 0)), (0, 255, 0))
+
+    async def test_archive_provider_pins_original_history_across_current_reset(self):
+        self.write(3)
+        last_timestamp = self.store.last_timestamp
+        archive = self.store.reset(200)
+        original = archive.read_bytes()
+        self.store.append(frame(0, (255, 0, 0)))
+        self.store.append({'t': .1, 'act': 'GET', 'who': 'agent'})
+
+        def pin_recording(name):
+            if name == 'current':
+                return self.store.pin()
+            self.assertEqual(name, archive.name)
+            descriptor = os.open(archive, os.O_RDONLY)
+            return {'path': archive, 'fd': descriptor,
+                    'end': os.fstat(descriptor).st_size,
+                    'last_timestamp': last_timestamp}
+
+        provider = mock.Mock(side_effect=pin_recording)
+        await self.client.close()
+        self.service = SavedHistory(self.store, pin_provider=provider)
+        self.client = await self.client_for(self.service)
+        saved = await self.opened(archive.name)
+        provider.assert_called_once_with(archive.name)
+        self.assertEqual(saved['started'], 100)
+        self.assertEqual(saved['steps'], 3)
+        self.assertEqual(saved['events'], 6)
+
+        self.store.reset(300)
+        self.store.append(frame(0, (0, 0, 255)))
+        self.store.append({'t': .1, 'act': 'GET', 'who': 'agent'})
+        current = await self.opened()
+        self.assertEqual(current['started'], 300)
+        self.assertEqual(current['steps'], 1)
+        self.assertEqual((await self.picture(current['token'], 0)).getpixel((0, 0)), (0, 0, 255))
+
+        info = await (await self.client.get('/api/replay/' + saved['token'])).json()
+        self.assertEqual(info, saved)
+        page = await (await self.client.get(f'/api/replay/{saved["token"]}/steps')).json()
+        self.assertEqual(page['total'], 3)
+        self.assertEqual([step['t'] for step in page['steps']], [.1, 2.1, 4.1])
+        for number in (2, 0):
+            self.assertEqual((await self.picture(saved['token'], number)).getpixel((0, 0)), (number, 0, 7))
+        self.assertEqual(provider.call_args_list, [mock.call(archive.name), mock.call('current')])
+
+        reopened = await self.opened(archive.name)
+        self.assertEqual(reopened['started'], 100)
+        self.assertEqual(reopened['steps'], 3)
+        self.assertEqual((await self.picture(reopened['token'], 1)).getpixel((0, 0)), (1, 0, 7))
+        self.assertEqual(archive.read_bytes(), original)
+
+    async def test_invalid_archive_names_are_rejected_before_calling_provider(self):
+        provider = mock.Mock(side_effect=AssertionError('invalid name reached provider'))
+        await self.client.close()
+        self.service = SavedHistory(self.store, pin_provider=provider)
+        self.client = await self.client_for(self.service)
+        name = '20260909-120000-abcdef123456.jsonl'
+        for invalid in ('', '../' + name, '/etc/passwd', 'recordings/' + name,
+                        name + '/..', name + '\n', name + '\x00',
+                        name.replace('abcdef', 'ABCDEF'), name.replace('abcdef', 'abcdeg'),
+                        name.replace('123456', '12345'), name.replace('20260909', '２０２６０９０９')):
+            with self.subTest(recording=invalid):
+                response = await self.client.get('/api/replay', params={'recording': invalid})
+                self.assertEqual(response.status, 404)
+        provider.assert_not_called()
+        self.assertFalse(self.service.states)
+
+    async def test_missing_archive_from_provider_returns_not_found(self):
+        provider = mock.Mock(side_effect=FileNotFoundError('archive has been removed'))
+        await self.client.close()
+        self.service = SavedHistory(self.store, pin_provider=provider)
+        self.client = await self.client_for(self.service)
+        name = '20260909-120000-abcdef123456.jsonl'
+        response = await self.client.get('/api/replay', params={'recording': name})
+        self.assertEqual(response.status, 404)
+        provider.assert_called_once_with(name)
+        self.assertFalse(self.service.states)
 
     async def test_get_never_includes_a_frame_after_its_marker_at_the_same_time(self):
         self.store.append(frame(0, (10, 20, 30)))
@@ -336,10 +414,16 @@ class SavedHistoryTests(unittest.IsolatedAsyncioTestCase):
         meta = await self.opened()
         for endpoint in ('steps?start=bad', 'frame?step=-1', 'frame?step=999', 'frame?step=nan'):
             self.assertEqual((await self.client.get(f'/api/replay/{meta["token"]}/{endpoint}')).status, 400)
-        disabled = await self.client_for(SavedHistory(self.store), enabled=False)
+        provider = mock.Mock(side_effect=AssertionError('disabled history reached provider'))
+        disabled = await self.client_for(SavedHistory(self.store, pin_provider=provider), enabled=False)
         try:
             self.assertEqual((await disabled.get('/api/replay')).status, 404)
-            self.assertEqual((await disabled.get('/api/replay/anything/steps')).status, 404)
+            response = await disabled.get('/api/replay', params={'recording': '20260909-120000-abcdef123456.jsonl'})
+            self.assertEqual(response.status, 404)
+            for endpoint in ('anything', 'anything/steps', 'anything/frame'):
+                self.assertEqual((await disabled.get('/api/replay/' + endpoint)).status, 404)
+            self.assertEqual((await disabled.delete('/api/replay/anything')).status, 404)
+            provider.assert_not_called()
         finally:
             await disabled.close()
 

--- a/server/test_saved_history.py
+++ b/server/test_saved_history.py
@@ -117,6 +117,142 @@ class SavedHistoryTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.service.states[second['token']]['index'].path, index_path)
         self.assertEqual((await self.picture(second['token'], 0)).getpixel((0, 0)), (0, 0, 7))
 
+    async def test_recorded_time_preserves_fraction_and_backward_time_without_changing_frames(self):
+        original_times = [250.375123456789, 240.123456789012]
+        for event in [frame(250.25, (10, 20, 30)),
+                      {'t': original_times[0], 'act': 'GET', 'who': 'agent'},
+                      frame(300.75, (40, 50, 60)),
+                      {'t': original_times[1], 'act': 'GET', 'who': 'agent'}]:
+            self.store.append(event)
+        original = self.path.read_bytes()
+        meta = await self.opened()
+        page = await (await self.client.get(f'/api/replay/{meta["token"]}/steps')).json()
+        self.assertEqual([step['recorded_t'] for step in page['steps']], original_times)
+        self.assertEqual([step['t'] for step in page['steps']], [.125, 50.5])
+        self.assertEqual([step['cutoff'] for step in page['steps']], [.125, 50.5])
+        self.assertEqual((await self.picture(meta['token'], 0)).getpixel((0, 0)), (10, 20, 30))
+        self.assertEqual((await self.picture(meta['token'], 1)).getpixel((0, 0)), (40, 50, 60))
+        self.assertEqual(self.path.read_bytes(), original)
+
+    async def test_v2_cache_backfills_only_action_offsets_in_small_reads_once(self):
+        times = [51.1234567890123, 49.2345678901234]
+        self.store.append(frame(50, (1, 2, 3)))
+        for when in times:
+            self.store.append({'t': when, 'act': 'GET', 'who': 'agent', 'history': 1,
+                               'detail': 'long action ' * 150})
+            large_frame = frame(60, (4, 5, 6))
+            large_frame['padding'] = 'x' * (128 << 10)
+            self.store.append(large_frame)
+        original = self.path.read_bytes()
+        first = HistoryIndex(self.store.pin())
+        try:
+            first.build()
+            path = first.path
+            cached_frames = first.db.execute('SELECT * FROM frames ORDER BY off').fetchall()
+            cached_marks = first.db.execute('SELECT off,t,kind FROM marks ORDER BY off').fetchall()
+            cached_state = first.db.execute('SELECT * FROM state').fetchall()
+            rows = first.db.execute('SELECT off,data FROM marks').fetchall()
+            for offset, payload in rows:
+                data = json.loads(payload)
+                del data['recorded_t']
+                first.db.execute('UPDATE marks SET data=? WHERE off=?', (json.dumps(data), offset))
+        finally:
+            first.close()
+
+        second = HistoryIndex(self.store.pin())
+        try:
+            with mock.patch('history_index.complete_frame', side_effect=AssertionError('frame rescanned')), \
+                 mock.patch.object(second.source, 'lines', side_effect=AssertionError('source rescanned')), \
+                 mock.patch('history_index.os.pread', wraps=os.pread) as reads:
+                second.build()
+            self.assertEqual(second.path, path)
+            self.assertTrue(path.name.startswith('v2-'))
+            self.assertEqual([step['recorded_t'] for step in second.page(0, 2)], times)
+            self.assertEqual(second.db.execute('SELECT * FROM frames ORDER BY off').fetchall(), cached_frames)
+            self.assertEqual(second.db.execute('SELECT off,t,kind FROM marks ORDER BY off').fetchall(), cached_marks)
+            self.assertEqual(second.db.execute('SELECT * FROM state').fetchall(), cached_state)
+            action_bounds = [(offset, offset + original[offset:].index(b'\n') + 1)
+                             for offset, _ in rows]
+            self.assertGreater(reads.call_count, 2)
+            for call in reads.call_args_list:
+                descriptor, size, offset = call.args
+                self.assertEqual(descriptor, second.source.fd)
+                self.assertLessEqual(size, 512)
+                self.assertLessEqual(offset + size, second.source.end)
+                self.assertTrue(any(begin <= offset < end for begin, end in action_bounds))
+            self.assertLess(sum(call.args[1] for call in reads.call_args_list), 8192)
+        finally:
+            second.close()
+
+        third = HistoryIndex(self.store.pin())
+        try:
+            with mock.patch.object(third.source, 'lines', side_effect=AssertionError('source rescanned')), \
+                 mock.patch('history_index.os.pread', side_effect=AssertionError('action read twice')):
+                third.build()
+            self.assertEqual(third.path, path)
+            self.assertEqual([step['recorded_t'] for step in third.page(0, 2)], times)
+        finally:
+            third.close()
+        self.assertEqual(self.path.read_bytes(), original)
+
+    async def test_cancelled_v2_backfill_rolls_back_already_updated_batches(self):
+        self.write(260)
+        original = self.path.read_bytes()
+        first = HistoryIndex(self.store.pin())
+        try:
+            first.build()
+            rows = first.db.execute('SELECT off,data FROM marks').fetchall()
+            for offset, payload in rows:
+                data = json.loads(payload)
+                del data['recorded_t']
+                first.db.execute('UPDATE marks SET data=? WHERE off=?', (json.dumps(data), offset))
+        finally:
+            first.close()
+
+        second = HistoryIndex(self.store.pin())
+        read_time = second._recorded_time
+        count = 0
+
+        def cancel_during_second_batch(offset):
+            nonlocal count
+            count += 1
+            if count == 258:
+                second.cancelled.set()
+            return read_time(offset)
+
+        try:
+            with mock.patch.object(second, '_recorded_time', side_effect=cancel_during_second_batch):
+                second.build()
+            self.assertEqual(count, 258)
+            self.assertFalse(second.db.in_transaction)
+            self.assertEqual(second.steps, 0)
+            for (payload,) in second.db.execute('SELECT data FROM marks'):
+                self.assertNotIn('recorded_t', json.loads(payload))
+        finally:
+            second.close()
+        self.assertEqual(self.path.read_bytes(), original)
+
+    async def test_cached_action_read_obeys_line_limit_and_pinned_end(self):
+        self.store.append(frame(0, (1, 2, 3)))
+        action_offset = self.store.committed_size
+        self.store.append({'t': 1.123456789, 'act': 'GET', 'who': 'agent', 'detail': 'x' * 1024})
+        index = HistoryIndex(self.store.pin())
+        pinned_end = index.source.end
+        self.store.append({'t': 2, 'act': 'GET', 'who': 'agent'})
+        original = self.path.read_bytes()
+        try:
+            with mock.patch('history_index.MAX_LINE', 64), \
+                 mock.patch('history_index.os.pread', wraps=os.pread) as reads:
+                with self.assertRaisesRegex(ValueError, 'event is too large'):
+                    index._recorded_time(action_offset)
+            self.assertEqual(sum(call.args[1] for call in reads.call_args_list), 65)
+            with mock.patch('history_index.os.pread', side_effect=AssertionError('read beyond pinned end')):
+                with self.assertRaisesRegex(ValueError, 'incomplete trailing event'):
+                    index._recorded_time(pinned_end)
+        finally:
+            index.close()
+        self.assertEqual(self.path.read_bytes(), original)
+
     async def test_open_snapshot_survives_append_and_reset(self):
         self.write(4)
         old = await self.opened()

--- a/server/test_saved_history_ui.js
+++ b/server/test_saved_history_ui.js
@@ -1,0 +1,430 @@
+// Run with: node --test server/test_saved_history_ui.js
+// A small DOM is enough to exercise asynchronous history ownership without
+// starting a game or changing any saved recording.
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const source = fs.readFileSync(path.join(__dirname, 'saved-history.js'), 'utf8');
+const indexSource = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
+const base = 'http://127.0.0.1:8084/u/test-user/';
+
+function deferred() {
+  let resolve, reject;
+  const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+  return {promise, resolve, reject};
+}
+
+function response(data, status = 200, blob = {name: 'frame'}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+    blob: async () => blob,
+  };
+}
+
+function fixture({enabled = true, handle, decode} = {}) {
+  const mutations = [], requests = [], images = [], created = [], revoked = [];
+  const listeners = new Map();
+  class Element {
+    constructor(tag = 'div') {
+      this.tagName = tag.toUpperCase();
+      this.children = [];
+      this.dataset = {};
+      this.style = {};
+      this.attributes = {};
+      this.hidden = false;
+      this.disabled = false;
+      this.className = '';
+      this._text = '';
+      this.classList = {
+        add: (...names) => { this.className = [...new Set(this.className.split(' ').concat(names))].join(' ').trim(); },
+        remove: (...names) => { this.className = this.className.split(' ').filter(name => !names.includes(name)).join(' '); },
+        contains: name => this.className.split(' ').includes(name),
+      };
+    }
+    set textContent(value) {
+      this._text = String(value);
+      this.children = [];
+      mutations.push({node: this, type: 'text', value: this._text});
+    }
+    get textContent() { return this._text + this.children.map(child => child.textContent).join(''); }
+    append(...children) {
+      for (const child of children) {
+        const node = typeof child === 'string' ? Object.assign(new Element('#text'), {_text: child}) : child;
+        node.parentNode = this;
+        this.children.push(node);
+        mutations.push({node: this, type: 'append', child: node});
+      }
+    }
+    appendChild(child) { this.append(child); return child; }
+    replaceChildren(...children) { this.textContent = ''; this.append(...children); }
+    setAttribute(name, value) { this.attributes[name] = String(value); }
+    getAttribute(name) { return this.attributes[name] ?? null; }
+    addEventListener(name, handler) { this['on' + name] = handler; }
+    click() { if (!this.disabled) return this.onclick?.({target: this}); }
+  }
+  const ids = ['historyrows', 'historyinfo', 'historypane', 'historytab', 'livetab',
+    'logrows', 'historyfirst', 'historyprev', 'historynext', 'historylatest', 'historyrange'];
+  const elements = Object.fromEntries(ids.map(id => [id, Object.assign(new Element(), {id})]));
+  class TestURL extends URL {
+    static createObjectURL(blob) {
+      const url = 'blob:history-test-' + created.length;
+      created.push({url, blob});
+      return url;
+    }
+    static revokeObjectURL(url) { revoked.push(url); }
+  }
+  class TestImage extends Element {
+    constructor() { super('img'); images.push(this); }
+    decode() { return decode ? decode(this, created) : Promise.resolve(); }
+  }
+  const sandbox = {
+    document: {
+      currentScript: {dataset: {historyEnabled: String(enabled)}},
+      getElementById: id => {
+        assert.ok(elements[id], 'unexpected DOM id: ' + id);
+        return elements[id];
+      },
+      createElement: tag => new Element(tag),
+      createTextNode: text => Object.assign(new Element('#text'), {_text: String(text)}),
+    },
+    location: {href: base},
+    URL: TestURL,
+    Image: TestImage,
+    AbortController,
+    DOMException,
+    Event,
+    setTimeout,
+    clearTimeout,
+    queueMicrotask,
+    console,
+    colorOf: () => '#ddd',
+    fmt: time => String(time),
+    keySpans: text => Object.assign(new Element('span'), {_text: text}),
+    updateImageJump: () => {},
+    fetch: (url, options = {}) => {
+      const call = {url: new URL(url), options, method: options.method || 'GET'};
+      requests.push(call);
+      return Promise.resolve().then(() => handle(call));
+    },
+    addEventListener: (name, handler) => {
+      if (!listeners.has(name)) listeners.set(name, []);
+      listeners.get(name).push(handler);
+    },
+    dispatchEvent: event => {
+      for (const handler of listeners.get(event.type) || []) handler(event);
+    },
+  };
+  sandbox.window = sandbox;
+  sandbox.globalThis = sandbox;
+  const context = vm.createContext(sandbox);
+  vm.runInContext(source, context, {filename: 'saved-history.js'});
+  return {
+    elements, requests, mutations, images, created, revoked,
+    emit: (name, detail = {}) => sandbox.dispatchEvent({type: name, ...detail}),
+    clearLog: () => {
+      const definition = indexSource.match(/function clearLog\(\) \{[\s\S]*?\n\}/)?.[0];
+      assert.ok(definition, 'the page must define clearLog');
+      Object.assign(sandbox, {
+        rows: elements.logrows,
+        awaitingHold: [],
+        downAt: new Map(),
+        lastId: 5,
+        logged: 5,
+        logcount: new Element(),
+      });
+      vm.runInContext(definition + '\nclearLog();', context, {filename: 'index.html#clearLog'});
+    },
+    rows: () => elements.historyrows.children.filter(node => node.className.split(' ').includes('saved-row')),
+  };
+}
+
+async function settle() {
+  // Flush promise continuations and one event-loop turn, without waiting for
+  // production polling timers or relying on a particular number of awaits.
+  await new Promise(resolve => setImmediate(resolve));
+}
+
+async function until(condition, label, state) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (condition()) return;
+    await settle();
+  }
+  assert.fail(label + '\nrequests: ' + state.requests.map(call => call.method + ' ' + call.url.pathname + call.url.search).join('\n') +
+    '\nvisible: ' + state.elements.historyrows.textContent);
+}
+
+function isOpen(call) { return call.method === 'GET' && call.url.pathname.endsWith('/api/replay'); }
+function isSteps(call) { return call.url.pathname.endsWith('/steps'); }
+function isFrame(call) { return call.url.pathname.endsWith('/frame'); }
+function tokenOf(call) { return call.url.pathname.split('/api/replay/')[1]?.split('/')[0]; }
+function deleted(state) { return state.requests.filter(call => call.method === 'DELETE').map(tokenOf); }
+function indices(state) { return state.rows().map(row => Number(row.dataset.step)); }
+function step(number, who = 'new-rec') { return {t: number, act: 'KEY', on: 'up', who, ok: true}; }
+
+function standard(call, token = 'new', total = 20, customStep) {
+  if (isOpen(call)) return response({token, started: token, steps: total});
+  if (call.method === 'DELETE') return response({});
+  if (isSteps(call)) {
+    const start = Number(call.url.searchParams.get('start'));
+    const count = Number(call.url.searchParams.get('count'));
+    return response({steps: Array.from({length: Math.min(count, Math.max(0, total - start))},
+      (_, offset) => customStep ? customStep(start + offset) : step(start + offset))});
+  }
+  if (isFrame(call)) return response({}, 200, {name: tokenOf(call)});
+  assert.fail('unexpected request ' + call.url);
+}
+
+test('explicitly disabled history selects realtime and makes no replay request', async () => {
+  const state = fixture({enabled: false, handle: () => assert.fail('disabled history requested the API')});
+  await settle();
+  assert.equal(state.elements.historypane.hidden, true);
+  assert.equal(state.elements.logrows.hidden, false);
+  assert.equal(state.elements.livetab.getAttribute('aria-selected'), 'true');
+  assert.ok(state.elements.historytab.disabled || state.elements.historytab.hidden,
+    'the unavailable history tab must not be interactive');
+  state.elements.historytab.click();
+  state.emit('historyinvalidate');
+  await settle();
+  assert.equal(state.requests.length, 0);
+});
+
+test('an ordinary endpoint 404 remains a visible history error', async () => {
+  const state = fixture({handle: () => response({}, 404)});
+  await until(() => state.elements.historyrows.textContent.includes('历史'), 'history error did not appear', state);
+  assert.equal(state.elements.historypane.hidden, false);
+  assert.equal(state.elements.logrows.hidden, true);
+  assert.equal(state.elements.historytab.getAttribute('aria-selected'), 'true');
+  assert.match(state.elements.historyrows.textContent, /不可用|失败|重试/);
+  assert.equal(state.elements.historylatest.disabled, false);
+});
+
+test('latest, first, next, and previous pages own eight rows and preserve the user-relative API path', async () => {
+  let opened = 0;
+  const state = fixture({handle: call => isOpen(call)
+    ? response({token: 'page-' + (++opened), started: 'same-recording', steps: 20})
+    : standard(call, tokenOf(call), 20)});
+  async function completed(number, expected) {
+    await until(() => deleted(state).length === number && !state.elements.historylatest.disabled,
+      'page did not finish', state);
+    assert.deepEqual(indices(state), expected);
+  }
+  await completed(1, [19, 18, 17, 16, 15, 14, 13, 12]);
+  assert.equal(state.elements.historyrange.textContent, '13–20 / 20 张');
+  state.elements.historyfirst.click();
+  await completed(2, [7, 6, 5, 4, 3, 2, 1, 0]);
+  assert.equal(state.elements.historyprev.disabled, true);
+  state.elements.historynext.click();
+  await completed(3, [15, 14, 13, 12, 11, 10, 9, 8]);
+  state.elements.historyprev.click();
+  await completed(4, [7, 6, 5, 4, 3, 2, 1, 0]);
+  state.elements.historylatest.click();
+  await completed(5, [19, 18, 17, 16, 15, 14, 13, 12]);
+  assert.equal(state.elements.historynext.disabled, true);
+  assert.ok(state.requests.every(call => call.url.pathname.startsWith('/u/test-user/api/replay')));
+  assert.ok(state.requests.filter(isOpen).every(call => call.url.searchParams.get('recording') === 'current'));
+  assert.ok(state.requests.filter(isSteps).every(call => call.url.searchParams.get('count') === '8'));
+  assert.equal(new Set(deleted(state)).size, 5);
+  assert.equal(state.created.length - new Set(state.revoked).size, 8, 'only the current page retains image URLs');
+  state.emit('pagehide', {persisted: false});
+  await settle();
+  assert.ok(state.created.every(({url}) => state.revoked.includes(url)), 'pagehide releases all rendered image URLs');
+});
+
+test('failed actions visibly retain their failure status and reason', async () => {
+  const state = fixture({handle: call => standard(call, 'failed', 1,
+    number => ({...step(number), ok: false, detail: 'busy'}))});
+  await until(() => deleted(state).length === 1, 'failed-action page did not finish', state);
+  assert.match(state.elements.historyrows.textContent, /未执行|失败/);
+  assert.match(state.elements.historyrows.textContent, /busy/);
+});
+
+test('the real clearLog handler replaces the old saved history with the current recording', async () => {
+  let opens = 0;
+  const state = fixture({handle: call => {
+    if (isOpen(call)) {
+      opens++;
+      return response({token: opens === 1 ? 'old' : 'fresh', started: opens === 1 ? 'old' : 'fresh', steps: 8});
+    }
+    return standard(call, tokenOf(call), 8, number => step(number, tokenOf(call) === 'old' ? 'old-rec' : 'new-rec'));
+  }});
+  await until(() => deleted(state).includes('old') && !state.elements.historylatest.disabled,
+    'initial history did not finish', state);
+  assert.ok(state.elements.historyrows.textContent.includes('old-rec'));
+  state.elements.logrows.textContent = 'old live activity';
+  state.clearLog();
+  assert.equal(state.elements.logrows.textContent, '');
+  assert.ok(!state.elements.historyrows.textContent.includes('old-rec'));
+  await until(() => deleted(state).includes('fresh'), 'clearLog did not reload history', state);
+  assert.equal(opens, 2);
+  assert.ok(state.rows().every(row => row.textContent.includes('new-rec')));
+  assert.ok(state.created.filter(item => item.blob.name === 'old').every(item => state.revoked.includes(item.url)));
+});
+
+test('leaving the page releases a late opening token without rendering or reopening', async () => {
+  const pending = deferred();
+  const state = fixture({handle: call => isOpen(call) ? pending.promise : standard(call)});
+  await until(() => state.requests.some(isOpen), 'opening did not start', state);
+  state.emit('pagehide', {persisted: false});
+  state.emit('historyinvalidate');
+  pending.resolve(response({token: 'departed', started: 'old', steps: 8}));
+  await until(() => deleted(state).includes('departed'), 'late token was not released', state);
+  await settle();
+  assert.equal(state.requests.filter(isOpen).length, 1);
+  assert.equal(state.rows().length, 0);
+  assert.equal(state.requests.filter(call => isSteps(call) || isFrame(call)).length, 0);
+});
+
+for (const openingStage of ['fetch', 'json']) {
+  test('invalidation waits for the old opening ' + openingStage + ' and token DELETE before reopening', async () => {
+    const old = deferred(), oldDelete = deferred();
+    let opens = 0;
+    const state = fixture({handle: call => {
+      if (isOpen(call)) {
+        opens++;
+        if (opens === 1) return openingStage === 'fetch' ? old.promise : {...response({}), json: () => old.promise};
+        return standard(call, 'fresh', 8);
+      }
+      if (call.method === 'DELETE' && tokenOf(call) === 'old') return oldDelete.promise;
+      assert.notEqual(tokenOf(call), 'old', 'an invalidated opening must not request old steps or frames');
+      return standard(call, 'fresh', 8);
+    }});
+    await until(() => opens === 1, 'old opening did not start', state);
+    if (openingStage === 'fetch') state.clearLog();
+    else state.emit('historyinvalidate');
+    state.emit('historyinvalidate');
+    await settle();
+    assert.equal(opens, 1, 'a pending unknown token must not overlap another open');
+    const metadata = {token: 'old', started: 'old', steps: 16};
+    old.resolve(openingStage === 'fetch' ? response(metadata) : metadata);
+    await until(() => deleted(state).includes('old'), 'old token was not released', state);
+    await settle();
+    assert.equal(opens, 1, 'the replacement must wait for DELETE completion');
+    oldDelete.resolve(response({}));
+    await until(() => deleted(state).includes('fresh') && state.rows().length === 8,
+      'fresh history was not loaded after invalidation', state);
+    assert.equal(opens, 2, 'repeated invalidations coalesce into one fresh open');
+    assert.deepEqual(deleted(state), ['old', 'fresh']);
+    assert.ok(state.rows().every(row => row.textContent.includes('new-rec')));
+  });
+}
+
+for (const stage of ['steps', 'frame', 'blob', 'decode']) {
+  test('stale ' + stage + ' completion cannot restore old rows after invalidation', async () => {
+    const pending = deferred();
+    let opens = 0, held = false;
+    const state = fixture({
+      handle: call => {
+        if (isOpen(call)) {
+          opens++;
+          return response({token: opens === 1 ? 'old' : 'fresh', started: opens === 1 ? 'old' : 'fresh', steps: opens === 1 ? 16 : 8});
+        }
+        if (tokenOf(call) === 'old') {
+          if (stage === 'steps' && isSteps(call)) {
+            held = true;
+            return {...response({}), json: () => pending.promise};
+          }
+          if (isFrame(call) && !held && (stage === 'frame' || stage === 'blob')) {
+            held = true;
+            return stage === 'frame' ? pending.promise : {...response({}), blob: () => pending.promise};
+          }
+          return standard(call, 'old', 16, number => step(number, 'old-rec'));
+        }
+        return standard(call, 'fresh', 8);
+      },
+      decode: (image, created) => {
+        if (stage === 'decode' && !held && created.find(item => item.url === image.src)?.blob.name === 'old') {
+          held = true;
+          return pending.promise;
+        }
+        return Promise.resolve();
+      },
+    });
+    await until(() => held, 'the deferred ' + stage + ' stage was not reached', state);
+    state.emit('historyinvalidate');
+    const invalidatedAt = state.mutations.length;
+    await settle();
+    assert.ok(!state.elements.historyrows.textContent.includes('old-rec'), 'invalidation immediately clears the old page');
+    if (stage === 'steps') pending.resolve({steps: Array.from({length: 8}, (_, offset) => step(8 + offset, 'old-rec'))});
+    else if (stage === 'frame') pending.resolve(response({}, 200, {name: 'old'}));
+    else if (stage === 'blob') pending.resolve({name: 'old'});
+    else pending.resolve();
+    await until(() => deleted(state).includes('fresh') && !state.elements.historylatest.disabled,
+      'fresh history did not finish', state);
+    assert.deepEqual(indices(state), [7, 6, 5, 4, 3, 2, 1, 0]);
+    assert.ok(state.rows().every(row => row.textContent.includes('new-rec')));
+    assert.equal(state.elements.historyrange.textContent, '1–8 / 8 张');
+    const staleAppends = state.mutations.slice(invalidatedAt).filter(change =>
+      change.type === 'append' && change.node === state.elements.historyrows && change.child.textContent.includes('old-rec'));
+    assert.equal(staleAppends.length, 0, 'a stale step list must never be appended after invalidation');
+    assert.deepEqual(deleted(state), ['old', 'fresh']);
+    assert.ok(state.created.filter(item => item.blob.name === 'old').every(item => state.revoked.includes(item.url)),
+      'old blob URLs must be revoked, including those completing after invalidation');
+    state.emit('pagehide', {persisted: false});
+    await settle();
+    assert.ok(state.created.every(item => state.revoked.includes(item.url)));
+  });
+}
+
+for (const stage of ['frame', 'blob', 'decode']) {
+  test('a late old ' + stage + ' cannot change a replacement page that has already rendered', async () => {
+    const pending = deferred();
+    let opens = 0, oldFrames = 0, held = false, abortable = false;
+    const state = fixture({
+      handle: call => {
+        if (isOpen(call)) {
+          opens++;
+          return response({token: opens === 1 ? 'old' : 'fresh', started: opens === 1 ? 'old' : 'fresh', steps: 8});
+        }
+        if (tokenOf(call) === 'old' && isFrame(call)) {
+          oldFrames++;
+          if (oldFrames === 1) {
+            if (stage === 'frame') { held = true; return pending.promise; }
+            if (stage === 'blob') { held = true; return {...response({}), blob: () => pending.promise}; }
+            return response({}, 200, {name: 'old'});
+          }
+          // A browser can reject one request on abort while its sibling is
+          // already decoding. That releases the old run before the sibling
+          // completes, so this checks ownership after a fresh page is visible.
+          abortable = true;
+          return new Promise((resolve, reject) => {
+            call.options.signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')), {once: true});
+          });
+        }
+        return standard(call, tokenOf(call), 8, number => step(number, tokenOf(call) === 'old' ? 'old-rec' : 'new-rec'));
+      },
+      decode: (image, created) => {
+        if (stage === 'decode' && created.find(item => item.url === image.src)?.blob.name === 'old') {
+          held = true;
+          return pending.promise;
+        }
+        return Promise.resolve();
+      },
+    });
+    await until(() => held && abortable, 'old image requests did not reach the intended race', state);
+    state.emit('historyinvalidate');
+    await until(() => deleted(state).includes('fresh') && !state.elements.historylatest.disabled,
+      'the aborted sibling did not permit a fresh page', state);
+    const rows = [...state.rows()];
+    const text = state.elements.historyrows.textContent;
+    const range = state.elements.historyrange.textContent;
+    if (stage === 'frame') pending.resolve(response({}, 200, {name: 'old'}));
+    else if (stage === 'blob') pending.resolve({name: 'old'});
+    else pending.resolve();
+    await settle();
+    assert.deepEqual(state.rows(), rows, 'late completion must not replace the current rows');
+    assert.equal(state.elements.historyrows.textContent, text);
+    assert.equal(state.elements.historyrange.textContent, range);
+    assert.equal(state.elements.historylatest.disabled, false);
+    assert.deepEqual(deleted(state), ['old', 'fresh']);
+    assert.ok(state.created.filter(item => item.blob.name === 'old').every(item => state.revoked.includes(item.url)));
+    state.emit('pagehide', {persisted: false});
+    assert.ok(state.created.every(item => state.revoked.includes(item.url)));
+  });
+}

--- a/server/test_saved_history_ui.py
+++ b/server/test_saved_history_ui.py
@@ -1,0 +1,19 @@
+"""Include the dependency-free browser-state regression suite in unittest."""
+from pathlib import Path
+import shutil
+import subprocess
+import unittest
+
+
+class SavedHistoryUITests(unittest.TestCase):
+    @unittest.skipUnless(shutil.which('node'), 'Node.js is not installed')
+    def test_async_history_ui_regressions(self):
+        result = subprocess.run(
+            [shutil.which('node'), '--test', str(Path(__file__).with_suffix('.js'))],
+            capture_output=True, text=True, timeout=30,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/test_video_export.py
+++ b/server/test_video_export.py
@@ -212,6 +212,10 @@ class VideoExportTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(first.status, 202)
         conflict = await self.client.post('/api/video', json={'speed': 4, 'requestId': 'fixed-token'})
         self.assertEqual(conflict.status, 409)
+        conflict = await self.client.post('/api/video', json={
+            'speed': 1, 'requestId': 'fixed-token',
+            'recording': '20260909-120000-aaaaaaaaaaaa.jsonl'})
+        self.assertEqual(conflict.status, 409)
         self.assertEqual(len(self.service.jobs), 1)
 
     async def test_request_id_replays_cancelled_and_error_terminal_states(self):
@@ -225,7 +229,9 @@ class VideoExportTests(unittest.IsolatedAsyncioTestCase):
         replay = await self.client.post('/api/video', json={
             'speed': 1, 'requestId': 'cancelled-token'})
         self.assertEqual(replay.status, 200)
-        self.assertEqual((await replay.json())['id'], cancelled['id'])
+        replay = await replay.json()
+        self.assertEqual(replay['id'], cancelled['id'])
+        self.assertEqual(replay['state'], 'cancelled')
         self.assertEqual((await self.client.post('/api/video', json={
             'speed': 4, 'requestId': 'cancelled-token'})).status, 409)
 
@@ -242,6 +248,7 @@ class VideoExportTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(replay['state'], 'error')
         self.assertEqual((await self.client.post('/api/video', json={
             'speed': 4, 'requestId': 'error-token'})).status, 409)
+        self.assertEqual(len(self.service.jobs), 2)
 
     async def test_request_id_ready_artifact_expiry_requires_new_token(self):
         self.write()
@@ -256,10 +263,15 @@ class VideoExportTests(unittest.IsolatedAsyncioTestCase):
             expired = await self.client.post('/api/video', json={
                 'speed': 1, 'requestId': 'ready-token'})
             self.assertEqual(expired.status, 410)
+            self.assertEqual(len(self.service.jobs), 1)
+            self.assertEqual(self.service.request_jobs['ready-token'].id, first['id'])
+            self.assertEqual((await self.client.post('/api/video', json={
+                'speed': 4, 'requestId': 'ready-token'})).status, 409)
             replacement = await self.client.post('/api/video', json={
                 'speed': 1, 'requestId': 'new-ready-token'})
             self.assertEqual(replacement.status, 202)
             self.assertNotEqual((await replacement.json())['id'], first['id'])
+            self.assertEqual(len(self.service.jobs), 2)
 
     async def test_unfinished_settle_and_renderer_changes_invalidate_cache(self):
         self.store.append(frame(0, (1, 2, 3)))

--- a/server/test_video_export.py
+++ b/server/test_video_export.py
@@ -14,14 +14,26 @@ from unittest import mock
 
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from PIL import Image
 
 from history_index import INDEX_LOCK
 from recording_store import RecordingStore
 from test_saved_history import frame
-from video_export import VideoExports
+from video_export import VideoExports, captioned, recorded_clock
 
 
 class VideoExportTests(unittest.IsolatedAsyncioTestCase):
+    def test_caption_preserves_original_time_and_milliseconds_over_a_day(self):
+        step = {'act': 'GET', 't': 1.234, 'recorded_t': 90061.234}
+        self.assertEqual(recorded_clock(step), '25:01:01.234')
+        self.assertEqual(recorded_clock({'t': 0, 'recorded_t': 3599.9996}), '1:00:00.000')
+        draw = mock.Mock()
+        draw.textlength.side_effect = lambda text, **kwargs: len(text) * 8
+        with mock.patch('video_export.ImageDraw.Draw', return_value=draw):
+            captioned(Image.new('RGB', (2, 1)), step, 12345, 99999, 4)
+        displayed = [call.args[1] for call in draw.text.call_args_list]
+        self.assertTrue(any(text.startswith('Original 25:01:01.234') for text in displayed))
+
     async def asyncSetUp(self):
         self.temp = tempfile.TemporaryDirectory()
         self.path = Path(self.temp.name) / 'recording.jsonl'

--- a/server/test_video_export.py
+++ b/server/test_video_export.py
@@ -1,0 +1,437 @@
+"""Fast action MP4s share history semantics, without stopping the emulator."""
+import asyncio
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from history_index import INDEX_LOCK
+from recording_store import RecordingStore
+from test_saved_history import frame
+from video_export import VideoExports
+
+
+class VideoExportTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.path = Path(self.temp.name) / 'recording.jsonl'
+        self.store = RecordingStore(self.path, started=100)
+        self.service = VideoExports(self.store)
+        self.client = await self.client_for(self.service)
+
+    async def client_for(self, service, enabled=True):
+        app = web.Application()
+        service.install(app, enabled=enabled)
+        async def ping(request):
+            return web.Response(text='alive')
+        app.router.add_get('/ping', ping)
+        client = TestClient(TestServer(app))
+        await client.start_server()
+        return client
+
+    async def asyncTearDown(self):
+        await self.client.close()
+        self.store.close()
+        self.temp.cleanup()
+
+    def write(self, count=4):
+        for number in range(count):
+            self.store.append(frame(number * 2, (number, 30, 80)))
+            self.store.append({'t': number * 2 + .1, 'act': 'GET', 'who': 'agent'})
+
+    async def create(self, speed=4, recording='current'):
+        response = await self.client.post('/api/video', json=dict(speed=speed, recording=recording))
+        self.assertIn(response.status, (200, 202), await response.text())
+        return await response.json()
+
+    async def done(self, meta):
+        for _ in range(1000):
+            if meta['state'] in ('ready', 'cancelled', 'error'):
+                return meta
+            await asyncio.sleep(.005)
+            response = await self.client.get('/api/video/' + meta['id'])
+            self.assertEqual(response.status, 200)
+            meta = await response.json()
+        self.fail('export did not finish')
+
+    async def restart(self):
+        await self.client.close()
+        self.service = VideoExports(self.store)
+        self.client = await self.client_for(self.service)
+
+    @staticmethod
+    def fake_encode(index, job, path):
+        Path(path).write_bytes(b'small test video')
+        return index.steps, index.steps * .6 / job.speed
+
+    @unittest.skipUnless(shutil.which('ffmpeg') and shutil.which('ffprobe'), 'ffmpeg and ffprobe required')
+    async def test_small_real_mp4_has_one_frame_per_rich_action_and_fixed_duration(self):
+        events = [frame(0, (10, 20, 30)),
+                  {'t': 1, 'act': 'GET', 'who': 'agent', 'history': 1},
+                  {'t': 1, 'act': 'KEY', 'who': 'web', 'on': 'up', 'ok': False, 'history': 1},
+                  frame(1, (20, 30, 40)),
+                  {'t': 2, 'act': 7, 'label': 'KEY down', 'who': 'agent', 'history': 1},
+                  frame(2.5, (30, 40, 50)),
+                  {'t': 3, 'act': 'KEY', 'phase': 'after', 'who': 'web', 'history': 1},
+                  frame(9000, (40, 50, 60))]
+        for event in events:
+            self.store.append(event)
+        original = self.path.read_bytes()
+        started = time.monotonic()
+        result = await self.done(await self.create())
+        elapsed = time.monotonic() - started
+        self.assertEqual(result['state'], 'ready', result)
+        self.assertEqual(result['completed'], 4)
+        self.assertEqual(result['total'], 4)
+        self.assertAlmostEqual(result['seconds'], .6)
+        download = await self.client.get('/' + result['download'])
+        self.assertEqual(download.status, 200)
+        self.assertEqual(download.content_type, 'video/mp4')
+        self.assertIn('attachment;', download.headers['Content-Disposition'])
+        output = self.service.jobs[result['id']].path
+        self.assertEqual(await download.read(), output.read_bytes())
+        probe = json.loads(subprocess.check_output([
+            shutil.which('ffprobe'), '-v', 'error', '-select_streams', 'v:0',
+            '-show_entries', 'stream=nb_frames,duration,width,height', '-of', 'json', str(output)]))['streams'][0]
+        self.assertEqual(int(probe['nb_frames']), 4)
+        self.assertAlmostEqual(float(probe['duration']), .6, places=3)
+        self.assertEqual(probe['width'] % 2, 0)
+        self.assertEqual(probe['height'] % 2, 0)
+        self.assertEqual(self.path.read_bytes(), original)
+        self.assertLess(elapsed, 5, 'four frames must not wait for 9000 seconds of recording time')
+        print(f'\nsmall MP4 witness: 4 frames, 0.6s video, {elapsed:.3f}s export, {output.stat().st_size} bytes')
+
+    async def test_restart_cache_survives_idle_append_and_isolated_from_new_actions(self):
+        self.write()
+        with mock.patch('video_export.encode', side_effect=self.fake_encode) as render:
+            first = await self.done(await self.create())
+            self.assertEqual(first['state'], 'ready', first)
+            path = self.service.jobs[first['id']].path
+            await self.restart()
+            # A later idle picture cannot change any earlier GET result.
+            self.store.append(frame(5000, (8, 8, 8)))
+            second = await self.done(await self.create())
+            self.assertEqual(second['state'], 'ready', second)
+            self.assertTrue(second['cached'])
+            self.assertEqual(self.service.jobs[second['id']].path, path)
+            self.assertEqual(render.call_count, 1)
+            self.store.append({'t': 5001, 'act': 'GET', 'who': 'agent'})
+            third = await self.done(await self.create())
+            self.assertEqual(third['state'], 'ready', third)
+            self.assertFalse(third['cached'])
+            self.assertEqual(third['total'], 5)
+            self.assertEqual(render.call_count, 2)
+            again = await self.create()
+            self.assertEqual(again['id'], third['id'])
+            self.assertTrue(again['cached'])
+
+    async def test_unfinished_settle_and_renderer_changes_invalidate_cache(self):
+        self.store.append(frame(0, (1, 2, 3)))
+        self.store.append({'t': 1, 'act': 'KEY', 'who': 'agent'})
+        with mock.patch('video_export.encode', side_effect=self.fake_encode) as render:
+            first = await self.done(await self.create())
+            first_path = self.service.jobs[first['id']].path
+            # Same final step, but its settling window is still receiving frames.
+            self.store.append(frame(1.5, (5, 6, 7)))
+            second = await self.done(await self.create())
+            self.assertFalse(second['cached'])
+            self.assertNotEqual(self.service.jobs[second['id']].path, first_path)
+            self.assertEqual(render.call_count, 2)
+            await self.restart()
+            self.service.renderer = 'new-renderer-version'
+            third = await self.done(await self.create())
+            self.assertFalse(third['cached'])
+            self.assertEqual(render.call_count, 3)
+
+    async def test_cancelled_queued_job_closes_pin_and_retry_never_reuses_it(self):
+        self.write()
+        entered, release = threading.Event(), threading.Event()
+
+        def blocked(index, job, path):
+            entered.set()
+            release.wait(3)
+            return self.fake_encode(index, job, path)
+
+        with mock.patch('video_export.encode', side_effect=blocked):
+            first = await self.create(speed=1)
+            for _ in range(200):
+                if entered.is_set():
+                    break
+                await asyncio.sleep(.005)
+            try:
+                queued = await self.create(speed=2)
+                self.assertEqual(queued['state'], 'queued')
+                index = self.service.jobs[queued['id']].index
+                response = await self.client.delete('/api/video/' + queued['id'])
+                self.assertEqual((await response.json())['state'], 'cancelled')
+                self.assertTrue(index.closed)
+                with self.assertRaises(OSError):
+                    os.fstat(index.source.fd)
+                retried = await self.create(speed=2)
+                self.assertNotEqual(retried['id'], queued['id'])
+                self.assertEqual(retried['state'], 'queued')
+            finally:
+                release.set()
+            self.assertEqual((await self.done(first))['state'], 'ready')
+            self.assertEqual((await self.done(retried))['state'], 'ready')
+
+    async def test_indexing_cancel_is_responsive_and_does_not_block_other_routes(self):
+        self.write()
+        INDEX_LOCK.acquire()
+        try:
+            meta = await self.create()
+            for _ in range(20):
+                if self.service.jobs[meta['id']].state == 'indexing':
+                    break
+                await asyncio.sleep(.005)
+            start = time.monotonic()
+            self.assertEqual((await self.client.get('/ping')).status, 200)
+            response = await self.client.get('/api/video/' + meta['id'])
+            self.assertEqual((await response.json())['state'], 'indexing')
+            await self.client.delete('/api/video/' + meta['id'])
+            self.assertEqual((await self.done(meta))['state'], 'cancelled')
+            self.assertLess(time.monotonic() - start, .5)
+        finally:
+            INDEX_LOCK.release()
+
+    async def test_cancel_interrupts_a_blocked_encoder_pipe_and_reaps_process(self):
+        self.write()
+        writing, killed = threading.Event(), threading.Event()
+
+        class Input:
+            closed = False
+
+            def write(self, data):
+                writing.set()
+                if not killed.wait(2):
+                    raise AssertionError('cancel did not interrupt encoder pipe')
+                raise BrokenPipeError()
+
+            def close(self):
+                self.closed = True
+
+        class Process:
+            stdin = Input()
+            returncode = None
+            waited = False
+
+            def kill(self):
+                self.returncode = -9
+                killed.set()
+
+            def poll(self):
+                return self.returncode
+
+            def wait(self, timeout=None):
+                self.waited = True
+                return self.returncode
+
+        process = Process()
+        with mock.patch('video_export.shutil.which', return_value='/fake/ffmpeg'), \
+                mock.patch('video_export.subprocess.Popen', return_value=process):
+            meta = await self.create()
+            for _ in range(200):
+                if writing.is_set():
+                    break
+                await asyncio.sleep(.005)
+            self.assertTrue(writing.is_set())
+            start = time.monotonic()
+            await self.client.delete('/api/video/' + meta['id'])
+            cancelled = await self.done(meta)
+            self.assertEqual(cancelled['state'], 'cancelled', cancelled)
+            self.assertLess(time.monotonic() - start, .5)
+            self.assertTrue(process.waited)
+            self.assertTrue(process.stdin.closed)
+            self.assertIsNone(self.service.jobs[meta['id']].process)
+            self.assertEqual(list(self.service.cache.glob('*')), [])
+
+    async def test_incomplete_or_corrupt_cache_metadata_is_rebuilt(self):
+        self.write()
+        with mock.patch('video_export.encode', side_effect=self.fake_encode) as render:
+            first = await self.done(await self.create())
+            path = self.service.jobs[first['id']].path
+            path.write_bytes(b'truncated')
+            await self.restart()
+            second = await self.done(await self.create())
+            self.assertEqual(second['state'], 'ready', second)
+            self.assertFalse(second['cached'])
+            path.with_suffix('.json').write_text('{broken')
+            await self.restart()
+            third = await self.done(await self.create())
+            self.assertFalse(third['cached'])
+            self.assertEqual(render.call_count, 3)
+
+    async def test_cache_budget_keeps_latest_oversized_video_and_rebuilds_evicted_job(self):
+        self.write()
+        self.service.CACHE_BYTES = 1
+        with mock.patch('video_export.encode', side_effect=self.fake_encode) as render:
+            first = await self.done(await self.create(speed=1))
+            first_path = self.service.jobs[first['id']].path
+            self.assertTrue(first_path.is_file())
+            second = await self.done(await self.create(speed=2))
+            second_path = self.service.jobs[second['id']].path
+            self.assertTrue(second_path.is_file())
+            self.assertGreater(second_path.stat().st_size, self.service.CACHE_BYTES)
+            self.assertFalse(first_path.exists())
+            self.assertFalse(first_path.with_suffix('.json').exists())
+            third = await self.done(await self.create(speed=1))
+            self.assertEqual(third['state'], 'ready', third)
+            self.assertNotEqual(third['id'], first['id'])
+            self.assertFalse(third['cached'])
+            self.assertFalse(second_path.exists())
+            self.assertEqual(render.call_count, 3)
+            self.assertEqual(len(list(self.service.cache.glob('*.mp4'))), 1)
+
+    async def test_cache_age_and_download_protection(self):
+        self.service.cache.mkdir()
+        paths = []
+        for number, letter in enumerate(('a', 'b', 'c')):
+            path = self.service.cache / (letter * 64 + '.mp4')
+            path.write_bytes(b'video')
+            path.with_suffix('.json').write_text('{}')
+            touched = time.time() - self.service.CACHE_TTL - 10 + number
+            os.utime(path, (touched, touched))
+            os.utime(path.with_suffix('.json'), (touched, touched))
+            paths.append(path)
+        self.service.downloads[paths[0]] = 1
+        self.service._trim_cache()
+        self.assertTrue(paths[0].is_file(), 'active download must survive eviction')
+        self.assertFalse(paths[1].exists())
+        self.assertTrue(paths[2].is_file(), 'latest video remains available')
+        self.service.downloads.clear()
+        self.service._trim_cache()
+        self.assertFalse(paths[0].exists())
+        self.assertTrue(paths[2].is_file())
+
+    async def test_startup_removes_only_stale_generated_partials(self):
+        self.service.cache.mkdir()
+        stale = self.service.cache / ('a' * 32 + '.partial.mp4')
+        active = self.service.cache / ('b' * 32 + '.partial.json')
+        unrelated = self.service.cache / 'my-backup.partial.mp4'
+        for path in (stale, active, unrelated):
+            path.write_bytes(b'preserve or reclaim')
+        self.service.jobs['active-test'] = SimpleNamespace(id='b' * 32, state='encoding')
+        try:
+            self.service._trim_cache(startup=True)
+            self.assertFalse(stale.exists())
+            self.assertTrue(active.is_file())
+            self.assertTrue(unrelated.is_file())
+        finally:
+            self.service.jobs.pop('active-test')
+        await self.restart()
+        self.assertFalse(active.exists())
+        self.assertTrue(unrelated.is_file())
+
+    async def test_queue_bound_and_completed_handle_reaping(self):
+        self.write()
+        INDEX_LOCK.acquire()
+        try:
+            jobs = [await self.create(speed=speed) for speed in (1, 2, 4, 8)]
+            self.store.append(frame(20, (1, 2, 3)))
+            rejected = await self.client.post('/api/video', json={'speed': 1})
+            self.assertEqual(rejected.status, 429)
+            await self.client.delete('/api/video/' + jobs[-1]['id'])
+            retry = await self.create(speed=8)
+            self.assertNotEqual(retry['id'], jobs[-1]['id'])
+            self.assertLessEqual(sum(job.state not in ('ready', 'cancelled', 'error')
+                                     for job in self.service.jobs.values()), self.service.MAX_PENDING)
+        finally:
+            for job in self.service.jobs.values():
+                job.cancel()
+            INDEX_LOCK.release()
+        await self.done(jobs[0])
+        self.service.MAX_JOBS = 2
+        self.service._reap()
+        self.assertLess(len(self.service.jobs), 2)
+        self.service.TTL = -1
+        self.service._reap()
+        self.assertEqual(len(self.service.jobs), 0)
+
+    async def test_fixed_pin_survives_reset_and_supports_archived_provider(self):
+        self.write()
+        INDEX_LOCK.acquire()
+        try:
+            before = await self.create()
+            archive = self.store.reset(200)
+            self.store.append(frame(0, (200, 0, 0)))
+            self.store.append({'t': 1, 'act': 'GET', 'who': 'agent'})
+        finally:
+            INDEX_LOCK.release()
+        with mock.patch('video_export.encode', side_effect=self.fake_encode):
+            old = await self.done(before)
+            self.assertEqual(old['total'], 4)
+            new = await self.done(await self.create())
+            self.assertEqual(new['total'], 1)
+            self.assertNotEqual(self.service.jobs[old['id']].path, self.service.jobs[new['id']].path)
+            await self.restart()
+
+            def pin_provider(name):
+                if name == 'current':
+                    return self.store.pin()
+                self.assertEqual(name, archive.name)
+                return dict(path=archive, fd=os.open(archive, os.O_RDONLY),
+                            end=archive.stat().st_size, last_timestamp=6.1)
+
+            self.service.pin_provider = pin_provider
+            restored = await self.done(await self.create(recording=archive.name))
+            self.assertEqual(restored['state'], 'ready', restored)
+            self.assertEqual(restored['total'], 4)
+            self.assertTrue(restored['cached'])
+
+    async def test_errors_do_not_publish_partial_videos_and_retry_is_new_job(self):
+        self.write()
+
+        def failed(index, job, path):
+            Path(path).write_bytes(b'incomplete')
+            raise ValueError('damaged picture')
+
+        with mock.patch('video_export.encode', side_effect=failed):
+            first = await self.done(await self.create())
+            self.assertEqual(first['state'], 'error')
+            self.assertIn('damaged picture', first['error'])
+            self.assertEqual(list(self.service.cache.glob('*')), [])
+            self.assertEqual((await self.client.get('/api/video/' + first['id'] + '/file')).status, 409)
+            second = await self.done(await self.create())
+            self.assertNotEqual(first['id'], second['id'])
+            self.assertTrue(self.service.jobs[second['id']].index.closed)
+
+    async def test_cleanup_waits_for_worker_and_cancels_all_pins(self):
+        self.write()
+        INDEX_LOCK.acquire()
+        try:
+            first = await self.create(speed=1)
+            second = await self.create(speed=2)
+            await self.client.close()
+            self.assertTrue(self.service.task.done())
+            for token in (first['id'], second['id']):
+                job = self.service.jobs[token]
+                self.assertEqual(job.state, 'cancelled')
+                self.assertTrue(job.index.closed)
+        finally:
+            INDEX_LOCK.release()
+
+    async def test_validation_and_disabled_service(self):
+        for body in ({'speed': True}, {'speed': .5}, {'speed': 3}, {'recording': '../secret'},
+                     {'recording': None}, [], None):
+            response = await self.client.post('/api/video', json=body)
+            self.assertEqual(response.status, 400, body)
+        missing = await self.client.post('/api/video', json={'recording': '20260909-121212-aaaaaaaaaaaa.jsonl'})
+        self.assertEqual(missing.status, 404)
+        self.assertEqual((await self.client.get('/api/video/missing')).status, 404)
+        await self.client.close()
+        self.client = await self.client_for(VideoExports(self.store), enabled=False)
+        self.assertEqual((await self.client.post('/api/video', json={})).status, 404)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/test_video_export.py
+++ b/server/test_video_export.py
@@ -214,6 +214,53 @@ class VideoExportTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(conflict.status, 409)
         self.assertEqual(len(self.service.jobs), 1)
 
+    async def test_request_id_replays_cancelled_and_error_terminal_states(self):
+        self.write()
+        cancelled = await self.client.post('/api/video', json={
+            'speed': 1, 'requestId': 'cancelled-token'})
+        self.assertEqual(cancelled.status, 202)
+        cancelled = await cancelled.json()
+        self.service.jobs[cancelled['id']].cancel()
+        cancelled = await self.done(cancelled)
+        replay = await self.client.post('/api/video', json={
+            'speed': 1, 'requestId': 'cancelled-token'})
+        self.assertEqual(replay.status, 200)
+        self.assertEqual((await replay.json())['id'], cancelled['id'])
+        self.assertEqual((await self.client.post('/api/video', json={
+            'speed': 4, 'requestId': 'cancelled-token'})).status, 409)
+
+        failed = await self.client.post('/api/video', json={
+            'speed': 1, 'requestId': 'error-token'})
+        self.assertEqual(failed.status, 202)
+        failed = await failed.json()
+        self.service.jobs[failed['id']].update(state='error', error='test failure')
+        replay = await self.client.post('/api/video', json={
+            'speed': 1, 'requestId': 'error-token'})
+        self.assertEqual(replay.status, 200)
+        replay = await replay.json()
+        self.assertEqual(replay['id'], failed['id'])
+        self.assertEqual(replay['state'], 'error')
+        self.assertEqual((await self.client.post('/api/video', json={
+            'speed': 4, 'requestId': 'error-token'})).status, 409)
+
+    async def test_request_id_ready_artifact_expiry_requires_new_token(self):
+        self.write()
+        with mock.patch('video_export.encode', side_effect=self.fake_encode):
+            response = await self.client.post('/api/video', json={
+                'speed': 1, 'requestId': 'ready-token'})
+            self.assertEqual(response.status, 202)
+            first = await self.done(await response.json())
+            self.assertEqual(first['state'], 'ready')
+            path = self.service.jobs[first['id']].path
+            path.unlink()
+            expired = await self.client.post('/api/video', json={
+                'speed': 1, 'requestId': 'ready-token'})
+            self.assertEqual(expired.status, 410)
+            replacement = await self.client.post('/api/video', json={
+                'speed': 1, 'requestId': 'new-ready-token'})
+            self.assertEqual(replacement.status, 202)
+            self.assertNotEqual((await replacement.json())['id'], first['id'])
+
     async def test_unfinished_settle_and_renderer_changes_invalidate_cache(self):
         self.store.append(frame(0, (1, 2, 3)))
         self.store.append({'t': 1, 'act': 'KEY', 'who': 'agent'})

--- a/server/test_video_export.py
+++ b/server/test_video_export.py
@@ -206,6 +206,14 @@ class VideoExportTests(unittest.IsolatedAsyncioTestCase):
             headers={'X-Video-Request-Id': 'header-token'})
         self.assertEqual(response.status, 400)
 
+    async def test_request_id_cannot_change_export_payload(self):
+        self.write()
+        first = await self.client.post('/api/video', json={'speed': 1, 'requestId': 'fixed-token'})
+        self.assertEqual(first.status, 202)
+        conflict = await self.client.post('/api/video', json={'speed': 4, 'requestId': 'fixed-token'})
+        self.assertEqual(conflict.status, 409)
+        self.assertEqual(len(self.service.jobs), 1)
+
     async def test_unfinished_settle_and_renderer_changes_invalidate_cache(self):
         self.store.append(frame(0, (1, 2, 3)))
         self.store.append({'t': 1, 'act': 'KEY', 'who': 'agent'})

--- a/server/test_video_export.py
+++ b/server/test_video_export.py
@@ -147,6 +147,65 @@ class VideoExportTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(again['id'], third['id'])
             self.assertTrue(again['cached'])
 
+    async def test_request_id_is_idempotent_across_append_and_distinguishes_tokens(self):
+        self.write()
+        with mock.patch('video_export.encode', side_effect=self.fake_encode):
+            first = await self.client.post('/api/video', json={
+                'speed': 4, 'requestId': 'export-1',
+            })
+            self.assertEqual(first.status, 202)
+            first = await first.json()
+            duplicate = await self.client.post('/api/video', json={
+                'speed': 4, 'requestId': 'export-1',
+            })
+            self.assertEqual(duplicate.status, 202)
+            duplicate = await duplicate.json()
+            self.assertEqual(duplicate['id'], first['id'])
+            self.assertEqual(len(self.service.jobs), 1)
+            second = await self.done(first)
+            self.assertEqual(second['state'], 'ready', second)
+            same = await self.client.post('/api/video', json={
+                'speed': 4, 'requestId': 'export-1',
+            })
+            self.assertEqual(same.status, 200)
+            same = await same.json()
+            self.assertEqual(same['id'], first['id'])
+            self.assertEqual(len(self.service.jobs), 1)
+
+            self.store.append(frame(5000, (8, 8, 8)))
+            after_append = await self.client.post('/api/video', json={
+                'speed': 4, 'requestId': 'export-1',
+            })
+            self.assertEqual(after_append.status, 200)
+            self.assertEqual((await after_append.json())['id'], first['id'])
+
+            other = await self.client.post('/api/video', json={
+                'speed': 4, 'requestId': 'export-2',
+            })
+            self.assertEqual(other.status, 202)
+            self.assertNotEqual((await other.json())['id'], first['id'])
+            self.assertEqual(len(self.service.jobs), 2)
+
+    async def test_request_id_header_and_validation(self):
+        self.write()
+        with mock.patch('video_export.encode', side_effect=self.fake_encode):
+            first = await self.client.post('/api/video', json={'speed': 1},
+                                           headers={'X-Video-Request-Id': 'header-token'})
+            self.assertEqual(first.status, 202)
+            first = await first.json()
+            same = await self.client.post('/api/video', json={'speed': 1},
+                                          headers={'X-Video-Request-Id': 'header-token'})
+            self.assertEqual(same.status, 202)
+            self.assertEqual((await same.json())['id'], first['id'])
+        for request_id in ('', 'contains space', '../path', 'x' * 129, None, 7):
+            body = {'requestId': request_id}
+            response = await self.client.post('/api/video', json=body)
+            self.assertEqual(response.status, 400, body)
+        response = await self.client.post(
+            '/api/video', json={'requestId': 'body-token'},
+            headers={'X-Video-Request-Id': 'header-token'})
+        self.assertEqual(response.status, 400)
+
     async def test_unfinished_settle_and_renderer_changes_invalidate_cache(self):
         self.store.append(frame(0, (1, 2, 3)))
         self.store.append({'t': 1, 'act': 'KEY', 'who': 'agent'})

--- a/server/video_export.py
+++ b/server/video_export.py
@@ -33,6 +33,10 @@ BEAT = .6
 SPEEDS = (1, 2, 4, 8)
 TERMINAL = ('ready', 'cancelled', 'error')
 ARCHIVE = re.compile(r'\d{8}-\d{6}-[a-f0-9]{12}\.jsonl')
+# Keep request ids suitable for use as opaque HTTP idempotency tokens.  This
+# follows the HTTP ``token`` character set and bounds memory retained by the
+# in-process request map.
+REQUEST_ID = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]{1,128}\Z")
 BAR = 64
 BACKGROUND = (11, 11, 15)
 
@@ -118,6 +122,7 @@ class Job:
     index: HistoryIndex
     source_key: tuple
     id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    request_id: str | None = None
     state: str = 'queued'
     completed: int = 0
     total: int = 0
@@ -279,6 +284,7 @@ class VideoExports:
     def __init__(self, store, pin_provider=None):
         self.store, self.pin_provider = store, pin_provider
         self.jobs = OrderedDict()
+        self.request_jobs = {}
         self.task = None
         self.wake = asyncio.Event()
         self.closed = False
@@ -343,6 +349,9 @@ class VideoExports:
                 break
             if job.state in TERMINAL:
                 self.jobs.pop(token)
+        for request_id, job in list(self.request_jobs.items()):
+            if self.jobs.get(job.id) is not job:
+                self.request_jobs.pop(request_id, None)
 
     def _lookup(self, request):
         job = self.jobs.get(request.match_info['id'])
@@ -356,14 +365,38 @@ class VideoExports:
         try:
             body = await request.json()
             recording, speed = body.get('recording', 'current'), body.get('speed', 1)
+            header_request_id = request.headers.get('X-Video-Request-Id')
+            request_id = (body['requestId'] if 'requestId' in body else header_request_id)
+            if ('requestId' in body and header_request_id is not None
+                    and request_id != header_request_id):
+                raise ValueError()
+            request_id_supplied = 'requestId' in body or header_request_id is not None
             if (type(speed) is not int or speed not in SPEEDS or not isinstance(recording, str)
                     or (recording != 'current' and not ARCHIVE.fullmatch(recording))):
+                raise ValueError()
+            if request_id_supplied and (not isinstance(request_id, str)
+                                        or REQUEST_ID.fullmatch(request_id) is None):
                 raise ValueError()
         except (ValueError, TypeError, AttributeError):
             raise web.HTTPBadRequest(reason='invalid video export request')
         if recording != 'current' and self.pin_provider is None:
             raise web.HTTPNotFound(reason='recording not found')
         self._reap()
+        if request_id is not None:
+            previous = self.request_jobs.get(request_id)
+            if (previous is not None and previous.recording == recording
+                    and previous.speed == speed and not previous.stop.is_set()
+                    and previous.state not in ('cancelled', 'error')
+                    and (previous.state != 'ready'
+                         or (previous.path is not None and previous.path.is_file()))):
+                meta = previous.public()
+                if previous.state == 'ready':
+                    meta['cached'] = True
+                    with contextlib.suppress(OSError):
+                        os.utime(previous.path, None)
+                return web.json_response(meta, status=200 if previous.state == 'ready' else 202)
+            if previous is not None and self.request_jobs.get(request_id) is previous:
+                self.request_jobs.pop(request_id, None)
         try:
             pin = self.pin_provider(recording) if self.pin_provider else self.store.pin()
             index = HistoryIndex(pin)
@@ -373,7 +406,8 @@ class VideoExports:
         source_key = (stat.st_dev, stat.st_ino, index.source.end,
                       json.dumps(index.source.header, sort_keys=True), speed)
         for job in self.jobs.values():
-            if job.source_key == source_key and not job.stop.is_set() and job.state not in ('cancelled', 'error'):
+            if (request_id is None and job.source_key == source_key and not job.stop.is_set()
+                    and job.state not in ('cancelled', 'error')):
                 if job.state != 'ready' or (job.path and job.path.is_file()):
                     index.close()
                     meta = job.public()
@@ -385,9 +419,11 @@ class VideoExports:
         if sum(job.state not in TERMINAL for job in self.jobs.values()) >= self.MAX_PENDING:
             index.close()
             raise web.HTTPTooManyRequests(reason='video export queue is full')
-        job = Job(recording, speed, index, source_key)
+        job = Job(recording, speed, index, source_key, request_id=request_id)
         index.cancelled = job.stop
         self.jobs[job.id] = job
+        if request_id is not None:
+            self.request_jobs[request_id] = job
         self.wake.set()
         return web.json_response(job.public(), status=202)
 

--- a/server/video_export.py
+++ b/server/video_export.py
@@ -386,19 +386,25 @@ class VideoExports:
             previous = self.request_jobs.get(request_id)
             if previous is not None and (previous.recording != recording or previous.speed != speed):
                 raise web.HTTPConflict(reason='request id is already bound to another export')
-            if (previous is not None and previous.recording == recording
-                    and previous.speed == speed and not previous.stop.is_set()
-                    and previous.state not in ('cancelled', 'error')
-                    and (previous.state != 'ready'
-                         or (previous.path is not None and previous.path.is_file()))):
-                meta = previous.public()
+            if previous is not None and previous.recording == recording and previous.speed == speed:
+                # A request token is an idempotency key for the lifetime of the
+                # in-process job record.  Terminal cancellation/failure must
+                # therefore be replayable instead of silently starting a second
+                # export on a retry.
+                if previous.state in ('cancelled', 'error'):
+                    return web.json_response(previous.public(), status=200)
                 if previous.state == 'ready':
+                    # The job record outlives disposable cache files.  Do not
+                    # turn a missing ready artifact into a different export
+                    # under the same token; require a fresh token instead.
+                    if previous.path is None or not previous.path.is_file():
+                        raise web.HTTPGone(reason='video artifact expired; start a new export with a new request id')
+                    meta = previous.public()
                     meta['cached'] = True
                     with contextlib.suppress(OSError):
                         os.utime(previous.path, None)
-                return web.json_response(meta, status=200 if previous.state == 'ready' else 202)
-            if previous is not None and self.request_jobs.get(request_id) is previous:
-                self.request_jobs.pop(request_id, None)
+                    return web.json_response(meta, status=200)
+                return web.json_response(previous.public(), status=202)
         try:
             pin = self.pin_provider(recording) if self.pin_provider else self.store.pin()
             index = HistoryIndex(pin)

--- a/server/video_export.py
+++ b/server/video_export.py
@@ -384,6 +384,8 @@ class VideoExports:
         self._reap()
         if request_id is not None:
             previous = self.request_jobs.get(request_id)
+            if previous is not None and (previous.recording != recording or previous.speed != speed):
+                raise web.HTTPConflict(reason='request id is already bound to another export')
             if (previous is not None and previous.recording == recording
                     and previous.speed == speed and not previous.stop.is_set()
                     and previous.state not in ('cancelled', 'error')

--- a/server/video_export.py
+++ b/server/video_export.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 import functools
 import hashlib
 import json
+import math
 import os
 from pathlib import Path
 import re
@@ -72,6 +73,13 @@ def caption_font():
     return ImageFont.load_default()
 
 
+def recorded_clock(step):
+    """Original journal time, independent of the compressed video position."""
+    when = step.get('recorded_t', step.get('_when', step['t']))
+    seconds, milliseconds = divmod(math.floor(max(0, when) * 1000 + .5), 1000)
+    return f'{seconds // 3600}:{seconds // 60 % 60:02}:{seconds % 60:02}.{milliseconds:03}'
+
+
 def captioned(picture, step, number, total, speed, size=None):
     """Keep the whole picture on resolution changes, with a bounded caption."""
     if size is None:
@@ -97,9 +105,9 @@ def captioned(picture, step, number, total, speed, size=None):
     result = ' [failed]' if step.get('ok') is False else ''
     label = f"{step.get('who') or 'web'}  {step['act']} {step.get('on', '')}{result}"
     line(label, height - BAR + 5, (143, 203, 247) if not result else (247, 143, 143))
-    when = max(0, int(step['t']))
-    clock = f'{when // 3600}:{when // 60 % 60:02}:{when % 60:02}'
-    line(f'{number + 1} / {total}   {speed}x   {clock}', height - BAR + 33, (158, 158, 174))
+    # Put source time first so narrow recordings cannot crop it behind counters.
+    line(f'Original {recorded_clock(step)}   {number + 1} / {total}   {speed}x',
+         height - BAR + 33, (158, 158, 174))
     return canvas
 
 

--- a/server/video_export.py
+++ b/server/video_export.py
@@ -1,0 +1,495 @@
+"""Cancellable, disk-backed action videos, using the screenshot history contract.
+
+Each saved action becomes one frame. Encoding runs off the event loop and never
+waits for recording time to pass, so watching or playing the game can continue.
+"""
+import asyncio
+from collections import OrderedDict
+import contextlib
+from dataclasses import dataclass, field
+import functools
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+import uuid
+
+from aiohttp import web
+from PIL import Image, ImageDraw, ImageFont
+
+import activity_thumbnails
+import history_frames
+import history_index
+from history_index import HistoryIndex
+
+BEAT = .6
+SPEEDS = (1, 2, 4, 8)
+TERMINAL = ('ready', 'cancelled', 'error')
+ARCHIVE = re.compile(r'\d{8}-\d{6}-[a-f0-9]{12}\.jsonl')
+BAR = 64
+BACKGROUND = (11, 11, 15)
+
+
+class Aborted(Exception):
+    """The export no longer has a consumer."""
+
+
+class CachedFileResponse(web.FileResponse):
+    """Do not evict a cached file while aiohttp is sending it."""
+
+    def __init__(self, service, path, **kwargs):
+        super().__init__(path, **kwargs)
+        self.service, self.cache_path = service, path
+
+    async def prepare(self, request):
+        try:
+            return await super().prepare(request)
+        finally:
+            with self.service.cache_lock:
+                count = self.service.downloads.get(self.cache_path, 1)
+                if count <= 1:
+                    self.service.downloads.pop(self.cache_path, None)
+                else:
+                    self.service.downloads[self.cache_path] = count - 1
+
+
+@functools.lru_cache(maxsize=1)
+def caption_font():
+    for name in ('/System/Library/Fonts/Hiragino Sans GB.ttc',
+                 '/System/Library/Fonts/PingFang.ttc',
+                 '/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc',
+                 '/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf'):
+        try:
+            return ImageFont.truetype(name, 16)
+        except OSError:
+            pass
+    return ImageFont.load_default()
+
+
+def captioned(picture, step, number, total, speed, size=None):
+    """Keep the whole picture on resolution changes, with a bounded caption."""
+    if size is None:
+        size = (max(320, picture.width * 2), picture.height * 2 + BAR)
+    width, height = size
+    canvas = Image.new('RGB', size, BACKGROUND)
+    available = (width, height - BAR)
+    scale = min(available[0] / picture.width, available[1] / picture.height)
+    shown = picture.resize((max(1, round(picture.width * scale)),
+                            max(1, round(picture.height * scale))), Image.Resampling.NEAREST)
+    canvas.paste(shown, ((width - shown.width) // 2, (available[1] - shown.height) // 2))
+    draw, font = ImageDraw.Draw(canvas), caption_font()
+    draw.rectangle((0, height - BAR, width, height), fill=(18, 18, 24))
+
+    def line(text, y, color):
+        text = str(text).replace('\n', ' ')[:200]
+        # Crop labels before drawing; arbitrarily long actor names or details
+        # cannot overlap the progress line or create an unbounded glyph cache.
+        while text and draw.textlength(text, font=font) > width - 24:
+            text = text[:-1]
+        draw.text((12, y), text, font=font, fill=color)
+
+    result = ' [failed]' if step.get('ok') is False else ''
+    label = f"{step.get('who') or 'web'}  {step['act']} {step.get('on', '')}{result}"
+    line(label, height - BAR + 5, (143, 203, 247) if not result else (247, 143, 143))
+    when = max(0, int(step['t']))
+    clock = f'{when // 3600}:{when // 60 % 60:02}:{when % 60:02}'
+    line(f'{number + 1} / {total}   {speed}x   {clock}', height - BAR + 33, (158, 158, 174))
+    return canvas
+
+
+@dataclass
+class Job:
+    recording: str
+    speed: int
+    index: HistoryIndex
+    source_key: tuple
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    state: str = 'queued'
+    completed: int = 0
+    total: int = 0
+    seconds: float = 0
+    cached: bool = False
+    error: str = ''
+    path: Path | None = None
+    created: float = field(default_factory=time.monotonic)
+    finished: float | None = None
+    stop: threading.Event = field(default_factory=threading.Event)
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    process: subprocess.Popen | None = None
+
+    def update(self, **values):
+        with self.lock:
+            if self.state in TERMINAL:
+                return
+            if values.get('state') == 'ready' and self.stop.is_set():
+                values.update(state='cancelled', error='')
+            for key, value in values.items():
+                setattr(self, key, value)
+            if self.state in TERMINAL:
+                self.finished = time.monotonic()
+
+    def cancel(self):
+        with self.lock:
+            if self.state in TERMINAL:
+                return
+            self.stop.set()
+            self.index.cancelled.set()
+            if self.state == 'queued':
+                self.state, self.finished = 'cancelled', time.monotonic()
+                self.index.close()
+            # Interrupt a blocked pipe write as well as the between-frame loop.
+            if self.process is not None:
+                try:
+                    self.process.kill()
+                except ProcessLookupError:
+                    pass
+
+    def public(self):
+        with self.lock:
+            completed, total = self.completed, self.total
+            if self.state == 'indexing':
+                completed, total = self.index.scanned, self.index.total
+            return dict(id=self.id, state=self.state, recording=self.recording,
+                        speed=self.speed, completed=completed, total=total,
+                        seconds=self.seconds, cached=self.cached, error=self.error,
+                        download=f'api/video/{self.id}/file' if self.state == 'ready' else None)
+
+
+def renderer_signature():
+    """Any change in frame selection, decoding or captions invalidates old MP4s."""
+    digest = hashlib.sha256()
+    for module in (__file__, history_frames.__file__, history_index.__file__, activity_thumbnails.__file__):
+        digest.update(Path(module).read_bytes())
+    return digest.hexdigest()
+
+
+def cache_identity(index, speed, renderer):
+    stat = os.fstat(index.source.fd)
+    marks = hashlib.sha256()
+    for (data,) in index.db.execute('SELECT data FROM steps ORDER BY seq'):
+        if index.cancelled.is_set():
+            raise Aborted()
+        marks.update(data.encode())
+        marks.update(b'\n')
+    last = index.step(index.steps - 1)
+    try:
+        _, _, _, frame_end = next(history_frames.iter_frames(index, [last]))
+    except StopIteration:
+        raise Aborted() if index.cancelled.is_set() else ValueError('no recorded picture for this action')
+    identity = dict(device=stat.st_dev, inode=stat.st_ino, header=index.source.header,
+                    steps=index.steps, marks=marks.hexdigest(), frame_end=frame_end,
+                    speed=speed, renderer=renderer)
+    # Appending idle frames beyond an already settled last action cannot affect
+    # its MP4. Inside that final interval, additional frames still may matter.
+    if index.source.duration < last.get('_cutoff', last['cutoff'] + index.base):
+        identity['unfinished_tail'] = index.source.end
+    key = hashlib.sha256(json.dumps(identity, sort_keys=True).encode()).hexdigest()
+    return key, identity
+
+
+def encode(index, job, path):
+    executable = shutil.which('ffmpeg')
+    if executable is None:
+        raise RuntimeError('ffmpeg is required for video export')
+    count, size, process = 0, None, None
+    # stderr is a disk file, so a noisy encoder cannot deadlock a full pipe or
+    # leave an unbounded error string in memory.
+    with tempfile.TemporaryFile() as errors:
+        try:
+            for step, picture, _, _ in history_frames.iter_frames(index):
+                if job.stop.is_set():
+                    raise Aborted()
+                canvas = captioned(picture, step, count, index.steps, job.speed, size)
+                if process is None:
+                    size = canvas.size
+                    with job.lock:
+                        if job.stop.is_set():
+                            raise Aborted()
+                        process = subprocess.Popen([
+                            executable, '-hide_banner', '-loglevel', 'error', '-y',
+                            '-f', 'rawvideo', '-pix_fmt', 'rgb24',
+                            '-s', f'{size[0]}x{size[1]}', '-r', f'{job.speed * 5}/3',
+                            '-i', 'pipe:0', '-an', '-c:v', 'libx264', '-threads', '2',
+                            '-preset', 'veryfast', '-crf', '23', '-pix_fmt', 'yuv420p',
+                            '-movflags', '+faststart', str(path)],
+                            stdin=subprocess.PIPE, stdout=subprocess.DEVNULL, stderr=errors)
+                        job.process = process
+                process.stdin.write(canvas.tobytes())
+                count += 1
+                job.update(completed=count)
+            if job.stop.is_set():
+                raise Aborted()
+            if process is None or count != index.steps:
+                raise ValueError('not every saved action has a recorded picture')
+            job.update(state='finalizing')
+            process.stdin.close()
+            while True:
+                if job.stop.is_set():
+                    raise Aborted()
+                try:
+                    process.wait(timeout=.1)
+                    break
+                except subprocess.TimeoutExpired:
+                    pass
+            if process.returncode:
+                errors.seek(0)
+                raise RuntimeError('ffmpeg failed: ' + errors.read(1024).decode('utf-8', 'replace').strip())
+            return count, count * BEAT / job.speed
+        except (BrokenPipeError, OSError) as error:
+            if job.stop.is_set():
+                raise Aborted() from error
+            errors.seek(0)
+            reason = errors.read(1024).decode('utf-8', 'replace').strip()
+            raise RuntimeError('video encoder failed: ' + (reason or str(error))) from error
+        finally:
+            if process is not None:
+                if process.poll() is None:
+                    process.kill()
+                process.wait()
+                if process.stdin and not process.stdin.closed:
+                    try:
+                        process.stdin.close()
+                    except (BrokenPipeError, OSError):
+                        pass
+            with job.lock:
+                job.process = None
+
+
+class VideoExports:
+    MAX_PENDING = 4
+    MAX_JOBS = 64
+    TTL = 86400
+    CACHE_BYTES = 2 << 30
+    CACHE_TTL = 30 * 86400
+
+    def __init__(self, store, pin_provider=None):
+        self.store, self.pin_provider = store, pin_provider
+        self.jobs = OrderedDict()
+        self.task = None
+        self.wake = asyncio.Event()
+        self.closed = False
+        self.renderer = renderer_signature()
+        self.cache = Path(store.path).parent / '.video-cache'
+        self.cache_lock = threading.Lock()
+        self.downloads = {}
+
+    def _trim_cache(self, keep=None, startup=False):
+        """Bound disposable files, retaining the latest result even if oversized.
+
+        A recording directory has one writer/service. Only our generated names
+        are eligible; source recordings and active partials are never removed.
+        """
+        with self.cache_lock:
+            if not self.cache.is_dir():
+                return
+            active = {job.id for job in list(self.jobs.values()) if job.state not in TERMINAL}
+            pairs = {}
+            for path in self.cache.iterdir():
+                if path.is_symlink() or not path.is_file():
+                    continue
+                partial = re.fullmatch(r'([a-f0-9]{32})\.partial\.(mp4|json)', path.name)
+                if startup and partial and partial[1] not in active:
+                    with contextlib.suppress(OSError):
+                        path.unlink()
+                if re.fullmatch(r'[a-f0-9]{64}\.(mp4|json)', path.name):
+                    pairs.setdefault(path.stem, []).append(path)
+            entries = []
+            for key, paths in pairs.items():
+                try:
+                    size = sum(path.stat().st_size for path in paths)
+                    touched = max(path.stat().st_mtime for path in paths)
+                except OSError:
+                    continue
+                entries.append((touched, size, self.cache / (key + '.mp4'), paths))
+            entries.sort(reverse=True)
+            if keep is None and entries:
+                keep = next((video for _, _, video, _ in entries if video.is_file()), None)
+            protected = set(self.downloads)
+            if keep is not None:
+                protected.add(keep)
+            total = sum(size for _, size, _, _ in entries)
+            for touched, size, video, paths in reversed(entries):
+                if video in protected:
+                    continue
+                if total <= self.CACHE_BYTES and time.time() - touched <= self.CACHE_TTL:
+                    continue
+                for path in paths:
+                    with contextlib.suppress(OSError):
+                        path.unlink()
+                if not any(path.exists() for path in paths):
+                    total -= size
+
+    def _reap(self):
+        now = time.monotonic()
+        for token, job in list(self.jobs.items()):
+            if job.state in TERMINAL and now - (job.finished or job.created) > self.TTL:
+                self.jobs.pop(token)
+        for token, job in list(self.jobs.items()):
+            if len(self.jobs) < self.MAX_JOBS:
+                break
+            if job.state in TERMINAL:
+                self.jobs.pop(token)
+
+    def _lookup(self, request):
+        job = self.jobs.get(request.match_info['id'])
+        if job is None:
+            raise web.HTTPNotFound(reason='video job expired; start a new export')
+        return job
+
+    async def create(self, request):
+        if self.closed:
+            raise web.HTTPServiceUnavailable(reason='video service is closing')
+        try:
+            body = await request.json()
+            recording, speed = body.get('recording', 'current'), body.get('speed', 1)
+            if (type(speed) is not int or speed not in SPEEDS or not isinstance(recording, str)
+                    or (recording != 'current' and not ARCHIVE.fullmatch(recording))):
+                raise ValueError()
+        except (ValueError, TypeError, AttributeError):
+            raise web.HTTPBadRequest(reason='invalid video export request')
+        if recording != 'current' and self.pin_provider is None:
+            raise web.HTTPNotFound(reason='recording not found')
+        self._reap()
+        try:
+            pin = self.pin_provider(recording) if self.pin_provider else self.store.pin()
+            index = HistoryIndex(pin)
+        except (ValueError, TypeError, KeyError, OSError) as error:
+            raise web.HTTPUnprocessableEntity(reason='recording cannot be opened: ' + str(error))
+        stat = os.fstat(index.source.fd)
+        source_key = (stat.st_dev, stat.st_ino, index.source.end,
+                      json.dumps(index.source.header, sort_keys=True), speed)
+        for job in self.jobs.values():
+            if job.source_key == source_key and not job.stop.is_set() and job.state not in ('cancelled', 'error'):
+                if job.state != 'ready' or (job.path and job.path.is_file()):
+                    index.close()
+                    meta = job.public()
+                    if job.state == 'ready':
+                        meta['cached'] = True
+                        with contextlib.suppress(OSError):
+                            os.utime(job.path, None)
+                    return web.json_response(meta, status=200 if job.state == 'ready' else 202)
+        if sum(job.state not in TERMINAL for job in self.jobs.values()) >= self.MAX_PENDING:
+            index.close()
+            raise web.HTTPTooManyRequests(reason='video export queue is full')
+        job = Job(recording, speed, index, source_key)
+        index.cancelled = job.stop
+        self.jobs[job.id] = job
+        self.wake.set()
+        return web.json_response(job.public(), status=202)
+
+    async def info(self, request):
+        return web.json_response(self._lookup(request).public())
+
+    async def cancel(self, request):
+        job = self._lookup(request)
+        job.cancel()
+        return web.json_response(job.public())
+
+    async def download(self, request):
+        job = self._lookup(request)
+        with self.cache_lock:
+            if job.state != 'ready' or job.path is None or not job.path.is_file():
+                raise web.HTTPConflict(reason='video is not ready')
+            response = CachedFileResponse(self, job.path, headers={
+                'Content-Type': 'video/mp4',
+                'Content-Disposition': f'attachment; filename="qunxia-{job.speed}x-{job.id[:8]}.mp4"',
+            })
+            self.downloads[job.path] = self.downloads.get(job.path, 0) + 1
+            with contextlib.suppress(OSError):
+                os.utime(job.path, None)
+            return response
+
+    async def _worker(self):
+        while not self.closed:
+            job = next((job for job in self.jobs.values() if job.state == 'queued'), None)
+            if job is None:
+                self.wake.clear()
+                await self.wake.wait()
+                continue
+            job.update(state='indexing')
+            await asyncio.to_thread(self.render, job)
+
+    def render(self, job):
+        index, partial, temp_meta = job.index, None, None
+        try:
+            if job.stop.is_set():
+                raise Aborted()
+            index.build()
+            if job.stop.is_set():
+                raise Aborted()
+            if not index.steps:
+                raise ValueError('this recording has no saved actions to export')
+            key, identity = cache_identity(index, job.speed, self.renderer)
+            self.cache.mkdir(exist_ok=True)
+            target, metadata = self.cache / (key + '.mp4'), self.cache / (key + '.json')
+            if job.stop.is_set():
+                raise Aborted()
+            try:
+                saved = json.loads(metadata.read_text())
+                if (saved.get('identity') == identity and target.stat().st_size == saved.get('bytes')
+                        and saved.get('frames') == index.steps and saved.get('seconds') == index.steps * BEAT / job.speed):
+                    os.utime(target, None)
+                    self._trim_cache(keep=target)
+                    job.update(state='ready', completed=index.steps, total=index.steps,
+                               seconds=saved['seconds'], path=target, cached=True)
+                    return
+            except (OSError, ValueError, AttributeError):
+                pass
+            job.update(state='encoding', completed=0, total=index.steps,
+                       seconds=index.steps * BEAT / job.speed)
+            partial = self.cache / (job.id + '.partial.mp4')
+            count, seconds = encode(index, job, partial)
+            if job.stop.is_set():
+                raise Aborted()
+            os.replace(partial, target)
+            saved = dict(identity=identity, frames=count, seconds=seconds, bytes=target.stat().st_size)
+            temp_meta = self.cache / (job.id + '.partial.json')
+            temp_meta.write_text(json.dumps(saved, ensure_ascii=False) + '\n')
+            os.replace(temp_meta, metadata)
+            self._trim_cache(keep=target)
+            job.update(state='ready', completed=count, total=count, seconds=seconds, path=target)
+        except Aborted:
+            job.update(state='cancelled', error='')
+        except Exception as error:
+            job.update(state='cancelled' if job.stop.is_set() else 'error',
+                       error='' if job.stop.is_set() else str(error)[:300])
+        finally:
+            index.close()
+            for path in (partial, temp_meta):
+                if path is not None:
+                    with contextlib.suppress(OSError):
+                        path.unlink(missing_ok=True)
+
+    async def startup(self, app):
+        await asyncio.to_thread(self._trim_cache, startup=True)
+        self.task = asyncio.create_task(self._worker())
+
+    async def cleanup(self, app):
+        self.closed = True
+        for job in self.jobs.values():
+            job.cancel()
+        self.wake.set()
+        if self.task:
+            try:
+                await asyncio.shield(self.task)
+            except asyncio.CancelledError:
+                await self.task
+                raise
+
+    def install(self, app, enabled=True):
+        if not enabled:
+            return
+        app.add_routes([
+            web.post('/api/video', self.create),
+            web.get('/api/video/{id}', self.info),
+            web.delete('/api/video/{id}', self.cancel),
+            web.get('/api/video/{id}/file', self.download),
+        ])
+        app.on_startup.append(self.startup)
+        app.on_cleanup.append(self.cleanup)

--- a/server/video_export.py
+++ b/server/video_export.py
@@ -379,8 +379,6 @@ class VideoExports:
                 raise ValueError()
         except (ValueError, TypeError, AttributeError):
             raise web.HTTPBadRequest(reason='invalid video export request')
-        if recording != 'current' and self.pin_provider is None:
-            raise web.HTTPNotFound(reason='recording not found')
         self._reap()
         if request_id is not None:
             previous = self.request_jobs.get(request_id)
@@ -405,6 +403,8 @@ class VideoExports:
                         os.utime(previous.path, None)
                     return web.json_response(meta, status=200)
                 return web.json_response(previous.public(), status=202)
+        if recording != 'current' and self.pin_provider is None:
+            raise web.HTTPNotFound(reason='recording not found')
         try:
             pin = self.pin_provider(recording) if self.pin_provider else self.store.pin()
             index = HistoryIndex(pin)


### PR DESCRIPTION
Restore complete screenshot history from the recording on disk, independently of the bounded realtime cache. History opens with eight screenshots per page; an incremental SQLite index pins committed recording prefixes and reconstructs bounded action frames. Current/archive selection uses #37. Each action retains original recorded_t separately from normalized history time, including backwards and fractional source timestamps.

Legacy activity import now matches offset-less cached rows within the recording millisecond-rounding tolerance, consuming candidates once in recorded order. Recording offsets remain the primary identity. This avoids duplicate cache entries and eviction of newly reconstructed rows during migration, while preserving original JSONL bytes and idempotent repeated imports.

POST /api/video encodes the same action frames with ffmpeg without waiting through idle timestamps. A validated JSON requestId or X-Video-Request-Id binds retries to the original job even after the source grows. The same token returns the original active/ready/cancelled/error result; conflicting recording or speed returns 409. A missing ready artifact returns 410, requiring a new token. Tokens are scoped to the retained in-process job record and do not survive restart/reaping; persistent MP4 caching is unchanged.

Progress, cancellation, pinned snapshots, sequential decoding, cache quota/age cleanup and benchmark-disabled routes are retained. The #38 frontend persists submission tokens and handles interrupted response bodies. History assets are registered separately from replay assets, keeping the branches mergeable.

Validation: 21 backend video tests, including real tiny MP4s, same-token retries after append, terminal replay, conflict/expiry validation and cache behavior; timestamp/migration regressions including fractional legacy time and 300-row capacity; full integration server suite 283 tests with 9 skipped. A real-browser POST-body-loss fixture recovered the same task ID and cancelled it normally. Source recordings and production test inputs were not modified.