### PR TITLE
server: restore recording archives and resumable downloads

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -183,3 +183,27 @@ execution lock. A time-limit ending still validates core health before it can
 be scored as valid. Input/environment failures remain invalid. The broker
 stores diagnostics under `<result-dir>/<session-id>.diagnostics` and archives
 the last heartbeat, fault and exit status before reclaiming worker scratch.
+
+
+## Recording files and reset archives
+
+Interactive servers expose `GET /api/recordings` with a `files` list containing
+the current recording and reset archives, including their IDs, filenames and
+byte sizes. `GET /api/recordings/{id}` downloads the original JSONL as an
+attachment. Single byte ranges, open-ended ranges, suffix ranges and `If-Range`
+are supported so a large download can resume. Each response pins its file
+descriptor and byte length before streaming; a concurrent reset or append does
+not change the bytes in that response.
+
+To replay an archive, start the existing paged reader with
+`/api/recording?view=paged&recording={id}`. Continue with the returned token and
+cursor as usual; subsequent requests keep the same snapshot. `current` remains
+the default. Archive IDs must match `YYYYMMDD-HHMMSS-<12 lowercase hex>.jsonl`
+inside the recording's `recordings/` directory. Symbolic links and other file
+types are refused. Archives are opened read-only, and their replay duration is
+recovered from a bounded file tail without opening another recording writer.
+
+In benchmark mode, the file-list and download routes are absent and archive
+selection is rejected. The existing current-recording endpoint and benchmark
+accounting remain unchanged. These file selectors do not change the source of
+the right-hand screenshot history.

--- a/server/recording.py
+++ b/server/recording.py
@@ -4,6 +4,8 @@ import os
 import time
 from pathlib import Path
 
+from recording_files import RecordingFiles, archive_name, download
+
 MAX_LINE = 4 << 20
 
 
@@ -78,16 +80,48 @@ class Snapshot:
 
 
 class RecordingAPI:
-    def __init__(self, store):
+    def __init__(self, store, archives=True):
         self.store = store
+        self.archives = archives
+        self.files = RecordingFiles(store)
         self.readers = {}
 
-    def snapshot(self):
-        return Snapshot(**self.store.pin())
+    def pin(self, name='current'):
+        if name != 'current' and not self.archives:
+            raise FileNotFoundError('recording archives are disabled')
+        return self.files.pin(name)
+
+    def snapshot(self, name='current'):
+        return Snapshot(**self.pin(name))
+
+    async def list_files(self, request):
+        from aiohttp import web
+        if not self.archives:
+            raise web.HTTPNotFound()
+        return web.json_response({'files': self.files.listing()}, headers={'Cache-Control': 'no-store'})
+
+    async def download_file(self, request):
+        from aiohttp import web
+        if not self.archives:
+            raise web.HTTPNotFound()
+        try:
+            pin = self.pin(request.match_info['name'])
+        except FileNotFoundError:
+            raise web.HTTPNotFound()
+        return await download(pin, request)
+
+    def install(self, app):
+        from aiohttp import web
+        if self.archives:
+            app.add_routes([web.get('/api/recordings', self.list_files),
+                            web.get('/api/recordings/{name}', self.download_file)])
 
     async def handle(self, request):
         from aiohttp import web
         import uuid
+        name = request.query.get('recording', 'current')
+        if name != 'current' and (not self.archives or not archive_name(name)):
+            raise web.HTTPNotFound()
         if request.query.get('view') == 'paged':
             now = time.monotonic()
             for token, (reader, touched) in list(self.readers.items()):
@@ -99,7 +133,10 @@ class RecordingAPI:
                 if len(self.readers) >= 4:
                     return web.json_response({'error': 'too many replay readers'}, status=429)
                 token = uuid.uuid4().hex
-                self.readers[token] = (self.snapshot(), now)
+                try:
+                    self.readers[token] = (self.snapshot(name), now)
+                except FileNotFoundError:
+                    raise web.HTTPNotFound()
             elif token not in self.readers:
                 return web.json_response({'error': 'replay expired; reopen it'}, status=410)
             reader, _ = self.readers[token]
@@ -115,7 +152,10 @@ class RecordingAPI:
             except ValueError as exc:
                 return web.json_response({'error': str(exc)}, status=400)
 
-        pin = self.store.pin()
+        try:
+            pin = self.pin(name)
+        except FileNotFoundError:
+            raise web.HTTPNotFound()
         raw = request.query.get('format') == 'jsonl'
         response = web.StreamResponse(headers={'Content-Type': 'application/x-ndjson' if raw else 'application/json'})
         reader = None
@@ -127,7 +167,8 @@ class RecordingAPI:
                 for start in range(0, pin['end'], 64 << 10):
                     await response.write(os.pread(pin['fd'], min(64 << 10, pin['end']-start), start))
             else:
-                head = json.dumps({'started': reader.header['started'], 'duration': reader.elapsed})[:-1]
+                head = json.dumps({'started': reader.header['started'],
+                                   'duration': reader.elapsed if name == 'current' else reader.duration})[:-1]
                 await response.write((head + ',"events":[').encode())
                 first = True
                 payload_bytes = 0

--- a/server/recording.py
+++ b/server/recording.py
@@ -83,8 +83,12 @@ class RecordingAPI:
     def __init__(self, store, archives=True):
         self.store = store
         self.archives = archives
-        self.files = RecordingFiles(store)
         self.readers = {}
+
+    @property
+    def files(self):
+        # Follow a replaced writer as the original current-recording API did.
+        return RecordingFiles(self.store)
 
     def pin(self, name='current'):
         if name != 'current' and not self.archives:

--- a/server/recording_files.py
+++ b/server/recording_files.py
@@ -1,0 +1,168 @@
+"""Read-only access to the current journal and its named reset archives."""
+import json
+import math
+import os
+import re
+import stat
+from email.utils import formatdate, parsedate_to_datetime
+
+
+ARCHIVE_NAME = re.compile(r'\d{8}-\d{6}-[a-f0-9]{12}\.jsonl', re.ASCII)
+TAIL_BYTES = (4 << 20) + (64 << 10)
+
+
+def archive_name(name):
+    return isinstance(name, str) and ARCHIVE_NAME.fullmatch(name) is not None
+
+
+def tail_timestamp(fd, end):
+    """Recover replay duration from one bounded tail without opening a writer."""
+    start = max(0, end - TAIL_BYTES)
+    data = os.pread(fd, end - start, start)
+    if start:
+        _, _, data = data.partition(b'\n')  # discard a possible partial first line
+    last = 0.0
+    for line in data.splitlines():
+        try:
+            event = json.loads(line)
+            when = float(event.get('t', 0))
+            if math.isfinite(when) and when >= 0:
+                last = max(last, when)
+        except (ValueError, TypeError, AttributeError):
+            continue
+    return last
+
+
+def byte_range(value, size):
+    """One inclusive HTTP range, returned as a bounded Python interval."""
+    match = re.fullmatch(r'bytes=(\d*)-(\d*)', value.strip(), re.ASCII)
+    if match is None or not any(match.groups()) or not size:
+        raise ValueError('invalid range')
+    first, last = match.groups()
+    if not first:
+        length = int(last)
+        if length <= 0:
+            raise ValueError('invalid suffix range')
+        return max(0, size - length), size
+    start = int(first)
+    end = min(size, int(last) + 1) if last else size
+    if start >= size or end <= start:
+        raise ValueError('unsatisfiable range')
+    return start, end
+
+
+def matches_if_range(value, etag, modified):
+    if value.startswith(('"', 'W/')):
+        return value == etag  # a weak validator is never a match
+    try:
+        date = parsedate_to_datetime(value)
+        return date.tzinfo is not None and int(modified) <= date.timestamp()
+    except (ValueError, TypeError, OverflowError):
+        return False
+
+
+async def download(pin, request):
+    """Stream a pinned prefix; a reset cannot switch a download to a new inode."""
+    from aiohttp import web
+    from aiohttp.helpers import content_disposition_header
+
+    fd, size = pin['fd'], pin['end']
+    try:
+        status = os.fstat(fd)
+        etag = f'"{status.st_dev:x}-{status.st_ino:x}-{size:x}-{status.st_mtime_ns:x}"'
+        headers = {
+            'Content-Type': 'application/x-ndjson; charset=utf-8',
+            'Content-Disposition': content_disposition_header('attachment', filename=pin['path'].name),
+            'Accept-Ranges': 'bytes', 'Cache-Control': 'no-store', 'ETag': etag,
+            'Last-Modified': formatdate(status.st_mtime, usegmt=True),
+        }
+        start, end, response_status = 0, size, 200
+        selected = request.headers.get('Range')
+        condition = request.headers.get('If-Range')
+        if selected and (not condition or matches_if_range(condition, etag, status.st_mtime)):
+            try:
+                start, end = byte_range(selected, size)
+            except ValueError:
+                raise web.HTTPRequestRangeNotSatisfiable(headers={'Content-Range': f'bytes */{size}'})
+            response_status = 206
+            headers['Content-Range'] = f'bytes {start}-{end-1}/{size}'
+        headers['Content-Length'] = str(end - start)
+        response = web.StreamResponse(status=response_status, headers=headers)
+        await response.prepare(request)
+        if request.method != 'HEAD':
+            while start < end:
+                data = os.pread(fd, min(64 << 10, end - start), start)
+                if not data:
+                    raise OSError('pinned recording was truncated')
+                await response.write(data)
+                start += len(data)
+        await response.write_eof()
+        return response
+    finally:
+        os.close(fd)
+
+
+class RecordingFiles:
+    def __init__(self, store):
+        self.store = store
+
+    def _directory(self):
+        # The configured journal directory is trusted; the selectable archive
+        # directory and its entries must never redirect readers through links.
+        parent = os.open(self.store.path.parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            return os.open('recordings', os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                           dir_fd=parent)
+        finally:
+            os.close(parent)
+
+    def pin(self, name='current'):
+        if name == 'current':
+            return self.store.pin()
+        if not archive_name(name):
+            raise FileNotFoundError('invalid recording name')
+        folder = fd = None
+        try:
+            folder = self._directory()
+            # NONBLOCK prevents a substituted FIFO from blocking before fstat;
+            # NOFOLLOW and dir_fd also cover swaps between validation and open.
+            fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=folder)
+            status = os.fstat(fd)
+            if not stat.S_ISREG(status.st_mode):
+                raise FileNotFoundError('recording is not a regular file')
+            result = {'path': self.store.path.parent / 'recordings' / name,
+                      'fd': fd, 'end': status.st_size,
+                      'last_timestamp': tail_timestamp(fd, status.st_size)}
+            fd = None
+            return result
+        except OSError as error:
+            raise FileNotFoundError('recording is unavailable') from error
+        finally:
+            if fd is not None:
+                os.close(fd)
+            if folder is not None:
+                os.close(folder)
+
+    def listing(self):
+        pin = self.store.pin()
+        try:
+            files = [{'id': 'current', 'name': self.store.path.name, 'bytes': pin['end']}]
+        finally:
+            os.close(pin['fd'])
+        try:
+            folder = self._directory()
+        except OSError:
+            return files
+        try:
+            for name in sorted(os.listdir(folder), reverse=True):
+                if not archive_name(name):
+                    continue
+                try:
+                    status = os.stat(name, dir_fd=folder, follow_symlinks=False)
+                except OSError:
+                    continue
+                if stat.S_ISREG(status.st_mode):
+                    files.append({'id': name, 'name': name, 'bytes': status.st_size})
+        finally:
+            os.close(folder)
+        return files

--- a/server/server.py
+++ b/server/server.py
@@ -2308,7 +2308,7 @@ def main():
     path = pathlib.Path(os.environ.get("QUNXIA_RECORDING_FILE", str(pathlib.Path(directory) / f"{PORT}.jsonl")))
     validate_recording_directory(path.parent)
     recording_store = RecordingStore(path)
-    recording_api = RecordingAPI(recording_store)
+    recording_api = RecordingAPI(recording_store, archives=not warden.ON)
     rec.update(started=recording_store.started, events=[], bytes=recording_store.committed_size)
     health = Health(LIB.core_ticks, paused.is_set, os.environ.get("QUNXIA_HEALTH_DIR", str(pathlib.Path(SAVES) / ".health")))
     health.start()
@@ -2348,6 +2348,7 @@ def main():
         web.post("/api/save", api_save),
         web.post("/api/load", api_load),
     ])
+    recording_api.install(app)
     # Startup handlers are awaited, so the workers are detached tasks rather
     # than returned, or startup would block on loops that never end.
     app.on_startup.append(startup)

--- a/server/test_recording_archives.py
+++ b/server/test_recording_archives.py
@@ -1,0 +1,345 @@
+"""HTTP regressions for immutable current and archived recording reads."""
+import asyncio
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+from urllib.parse import quote
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from recording import RecordingAPI
+from recording_store import RecordingStore
+
+
+class RecordingArchiveTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.path = self.root / 'current.jsonl'
+        self.store = RecordingStore(self.path, started=10)
+        self.addCleanup(self.store.close)
+        self.old_events = [
+            {'t': 1, 'key': 'up', 'down': True},
+            {'t': 7.25, 'key': 'up', 'down': False, 'note': '旧录像'},
+        ]
+        for event in self.old_events:
+            self.assertTrue(self.store.append(event))
+        self.archive = self.store.reset(20)
+        self.current_events = [{'t': 2, 'key': 'left', 'down': True}]
+        for event in self.current_events:
+            self.assertTrue(self.store.append(event))
+        self.api, self.client = await self.make_client(archives=True)
+
+    async def make_client(self, archives):
+        api = RecordingAPI(self.store, archives=archives)
+        self.addCleanup(api.close)
+        app = web.Application()
+        app.router.add_get('/api/recording', api.handle)
+        api.install(app)
+        client = TestClient(TestServer(app))
+        await client.start_server()
+        self.addAsyncCleanup(client.close)
+        return api, client
+
+    async def get_json(self, query, client=None, status=200):
+        async with (client or self.client).get('/api/recording', params=query) as response:
+            self.assertEqual(response.status, status, await response.text())
+            return await response.json()
+
+    def download_path(self, name):
+        return '/api/recordings/' + quote(name, safe='')
+
+    async def inventory(self):
+        async with self.client.get('/api/recordings') as response:
+            self.assertEqual(response.status, 200, await response.text())
+            return (await response.json())['files']
+
+    async def test_inventory_includes_current_and_archive_sizes(self):
+        entries = {entry['id']: entry for entry in await self.inventory()}
+        self.assertEqual(set(entries), {'current', self.archive.name})
+        self.assertEqual(entries['current']['bytes'], self.path.stat().st_size)
+        self.assertEqual(entries[self.archive.name]['bytes'], self.archive.stat().st_size)
+        self.assertEqual(entries[self.archive.name]['name'], self.archive.name)
+        self.assertTrue(entries['current']['name'])
+
+    async def test_full_current_and_archive_downloads_are_exact_attachments(self):
+        for name, path in [('current', self.path), (self.archive.name, self.archive)]:
+            with self.subTest(recording=name):
+                expected = path.read_bytes()
+                async with self.client.get(self.download_path(name)) as response:
+                    self.assertEqual(response.status, 200, await response.text())
+                    self.assertEqual(await response.read(), expected)
+                    self.assertEqual(response.headers['Content-Length'], str(len(expected)))
+                    self.assertEqual(response.headers['Accept-Ranges'], 'bytes')
+                    self.assertIn('attachment;', response.headers['Content-Disposition'])
+                    self.assertIn('.jsonl', response.headers['Content-Disposition'])
+                    self.assertEqual(response.content_type, 'application/x-ndjson')
+
+    async def test_bounded_open_ended_suffix_and_clamped_ranges_are_exact(self):
+        for name, path in [('current', self.path), (self.archive.name, self.archive)]:
+            expected = path.read_bytes()
+            ranges = [
+                ('bytes=3-31', 3, 31),
+                ('bytes=5-', 5, len(expected) - 1),
+                ('bytes=-19', len(expected) - 19, len(expected) - 1),
+                ('bytes=0-999999', 0, len(expected) - 1),
+                ('bytes=-999999', 0, len(expected) - 1),
+            ]
+            for header, start, end in ranges:
+                with self.subTest(recording=name, range=header):
+                    async with self.client.get(self.download_path(name), headers={'Range': header}) as response:
+                        self.assertEqual(response.status, 206, await response.text())
+                        self.assertEqual(await response.read(), expected[start:end + 1])
+                        self.assertEqual(response.headers['Content-Length'], str(end - start + 1))
+                        self.assertEqual(response.headers['Content-Range'], f'bytes {start}-{end}/{len(expected)}')
+
+    async def test_malformed_multiple_and_unsatisfiable_ranges_return_416(self):
+        for name, path in [('current', self.path), (self.archive.name, self.archive)]:
+            size = path.stat().st_size
+            for header in [
+                'bytes=wrong', 'bytes=', 'bytes=8-3', 'bytes=-0',
+                'bytes=0-1,3-4', 'items=0-4', f'bytes={size}-',
+            ]:
+                with self.subTest(recording=name, range=header):
+                    async with self.client.get(self.download_path(name), headers={'Range': header}) as response:
+                        self.assertEqual(response.status, 416, await response.text())
+                        self.assertEqual(response.headers['Content-Range'], f'bytes */{size}')
+
+    async def test_if_range_requires_the_matching_validator(self):
+        expected = self.archive.read_bytes()
+        url = self.download_path(self.archive.name)
+        async with self.client.get(url) as response:
+            self.assertEqual(response.status, 200)
+            validators = [response.headers['ETag'], response.headers['Last-Modified']]
+            await response.read()
+        for validator in validators:
+            with self.subTest(validator=validator):
+                async with self.client.get(url, headers={'Range': 'bytes=1-9', 'If-Range': validator}) as response:
+                    self.assertEqual(response.status, 206, await response.text())
+                    self.assertEqual(await response.read(), expected[1:10])
+        for validator in ['"unrelated-recording"', 'Wed, 21 Oct 2015 07:28:00 GMT']:
+            with self.subTest(stale_validator=validator):
+                async with self.client.get(url, headers={'Range': 'bytes=1-9', 'If-Range': validator}) as response:
+                    self.assertEqual(response.status, 200, await response.text())
+                    self.assertEqual(await response.read(), expected)
+                    self.assertNotIn('Content-Range', response.headers)
+
+    async def test_current_download_keeps_its_prefix_during_append_and_reset(self):
+        self.assertTrue(self.store.append({'t': 3, 'd': 'x' * (192 << 10)}))
+        expected = self.path.read_bytes()
+        first_write = asyncio.Event()
+        release_write = asyncio.Event()
+        original_write = web.StreamResponse.write
+        write_count = 0
+
+        async def gated_write(response, data):
+            nonlocal write_count
+            write_count += 1
+            if write_count == 1:
+                first_write.set()
+                await release_write.wait()
+            return await original_write(response, data)
+
+        async def download():
+            async with self.client.get(self.download_path('current')) as response:
+                return response.status, dict(response.headers), await response.read()
+
+        with mock.patch.object(web.StreamResponse, 'write', new=gated_write):
+            transfer = asyncio.create_task(download())
+            try:
+                await asyncio.wait_for(first_write.wait(), 5)
+                self.assertTrue(self.store.append({'t': 4, 'note': 'late old-session append'}))
+                archived = self.store.reset(30)
+                self.assertTrue(self.store.append({'t': 1, 'note': 'new session'}))
+                release_write.set()
+                status, headers, actual = await asyncio.wait_for(transfer, 5)
+            finally:
+                release_write.set()
+                if not transfer.done():
+                    transfer.cancel()
+                    await asyncio.gather(transfer, return_exceptions=True)
+        self.assertEqual(status, 200)
+        self.assertGreater(write_count, 1)
+        self.assertEqual(actual, expected)
+        self.assertEqual(headers['Content-Length'], str(len(expected)))
+        self.assertIn(b'late old-session append', archived.read_bytes())
+        self.assertIn(b'new session', self.path.read_bytes())
+
+    async def test_current_range_still_reads_the_old_inode_after_headers_are_sent(self):
+        expected = self.path.read_bytes()
+        original_prepare = web.StreamResponse.prepare
+        replaced = False
+
+        async def reset_after_headers(response, request):
+            nonlocal replaced
+            result = await original_prepare(response, request)
+            if response.status == 206 and not replaced:
+                replaced = True
+                self.store.reset(30)
+                self.store.append({'t': 1, 'note': 'replacement current recording'})
+            return result
+
+        with mock.patch.object(web.StreamResponse, 'prepare', new=reset_after_headers):
+            async with self.client.get(self.download_path('current'), headers={'Range': 'bytes=7-55'}) as response:
+                self.assertEqual(response.status, 206)
+                self.assertEqual(await response.read(), expected[7:56])
+                self.assertEqual(response.headers['Content-Range'], f'bytes 7-55/{len(expected)}')
+        self.assertTrue(replaced)
+        self.assertIn(b'replacement current recording', self.path.read_bytes())
+
+    async def test_current_listing_and_download_exclude_an_uncommitted_suffix(self):
+        expected = self.path.read_bytes()
+        os.write(self.store.fd, b'{"t":999,"incomplete":')
+        current = next(row for row in await self.inventory() if row['id'] == 'current')
+        self.assertEqual(current['bytes'], len(expected))
+        async with self.client.get(self.download_path('current')) as response:
+            self.assertEqual(response.status, 200)
+            self.assertEqual(await response.read(), expected)
+            self.assertEqual(response.headers['Content-Length'], str(len(expected)))
+
+    async def test_archive_reader_and_duration_survive_name_replacement(self):
+        first = await self.get_json({'view': 'paged', 'recording': self.archive.name})
+        self.assertEqual(first['events'], self.old_events)
+        self.assertEqual(first['duration'], 7.25)
+        replacement = self.root / 'replacement.jsonl'
+        replacement_events = [{'t': 90, 'note': 'replacement'}]
+        replacement.write_bytes(
+            (json.dumps({'version': 1, 'started': 80}) + '\n' +
+             json.dumps(replacement_events[0]) + '\n').encode())
+        os.replace(replacement, self.archive)
+        self.store.reset(30)
+        old = await self.get_json({'view': 'paged', 'token': first['token']})
+        self.assertEqual(old, first)
+        fresh = await self.get_json({'view': 'paged', 'recording': self.archive.name})
+        self.assertEqual(fresh['events'], replacement_events)
+        self.assertEqual(fresh['started'], 80)
+        self.assertEqual(fresh['duration'], 90)
+
+    async def test_archive_tail_duration_and_reads_do_not_open_a_writer(self):
+        # Enough data to put the origin outside the bounded timestamp tail.
+        for index in range(5):
+            self.assertTrue(self.store.append({'t': index * 37.5, 'd': 'a' * (1 << 20)}))
+        self.assertTrue(self.store.append({'t': 187.5, 'key': 'esc', 'down': True}))
+        archive = self.store.reset(30)
+        expected = archive.read_bytes()
+        names_before = set(archive.parent.iterdir())
+        with mock.patch.object(RecordingStore, '__init__', side_effect=AssertionError('archive opened as a writer')):
+            reader = self.api.snapshot(archive.name)
+            try:
+                self.assertEqual(reader.duration, 187.5)
+                self.assertEqual(reader.header['started'], 20)
+                self.assertEqual(reader.end, len(expected))
+            finally:
+                reader.close()
+            async with self.client.get(self.download_path(archive.name)) as response:
+                self.assertEqual(response.status, 200, await response.text())
+                self.assertEqual(await response.read(), expected)
+        self.assertEqual(archive.read_bytes(), expected)
+        self.assertEqual(set(archive.parent.iterdir()), names_before)
+
+    async def test_archive_pages_can_traverse_refetch_touch_and_close(self):
+        events = [{'t': index + 10, 'd': str(index) * (550 << 10)} for index in range(5)]
+        for event in events:
+            self.assertTrue(self.store.append(event))
+        archive = self.store.reset(30)
+        expected = self.current_events + events
+        first = await self.get_json({'view': 'paged', 'recording': archive.name})
+        self.assertFalse(first['done'])
+        token = first['token']
+        collected = list(first['events'])
+        cursor = first['next']
+        starts = []
+        while not first['done']:
+            starts.append(cursor)
+            page = await self.get_json({'view': 'paged', 'token': token, 'start': str(cursor)})
+            repeated = await self.get_json({'view': 'paged', 'token': token, 'start': str(cursor)})
+            self.assertEqual(repeated, page)
+            self.assertEqual(page['token'], token)
+            self.assertGreater(page['next'], cursor)
+            self.assertEqual(page['end'], first['end'])
+            collected.extend(page['events'])
+            cursor = page['next']
+            if page['done']:
+                self.assertEqual(cursor, page['end'])
+                break
+        self.assertGreaterEqual(len(starts), 2)
+        self.assertEqual(collected, expected)
+        self.assertEqual(await self.get_json({'view': 'paged', 'token': token, 'touch': '1'}), {'ok': True})
+        closed = await self.get_json({'view': 'paged', 'token': token, 'close': '1'})
+        self.assertEqual(closed, {'ok': True})
+        self.assertNotIn(token, self.api.readers)
+        await self.get_json({'view': 'paged', 'token': token}, status=410)
+
+    async def test_invalid_names_and_traversal_are_rejected(self):
+        names = [
+            '../current.jsonl', '../recordings/' + self.archive.name,
+            '/etc/passwd', 'current.jsonl', self.archive.name.upper(),
+            '20260909-123456-123456789ab.jsonl',
+            '20260909-123456-123456789abc.jsonl.bak',
+            '20260909-123456-123456789abc.jsonl',
+        ]
+        for name in names:
+            with self.subTest(recording=name):
+                async with self.client.get('/api/recording', params={'view': 'paged', 'recording': name}) as response:
+                    self.assertEqual(response.status, 404, await response.text())
+                async with self.client.get(self.download_path(name)) as response:
+                    self.assertEqual(response.status, 404, await response.text())
+        self.assertFalse(self.api.readers)
+
+    async def test_inventory_omits_foreign_files_directories_and_file_symlinks(self):
+        folder = self.archive.parent
+        (folder / 'README.txt').write_text('not a recording')
+        (folder / '20260909-123456-aaaaaaaaaaaa.jsonl').mkdir()
+        linked_name = '20260909-123456-bbbbbbbbbbbb.jsonl'
+        (folder / linked_name).symlink_to(self.path)
+        entries = {entry['id'] for entry in await self.inventory()}
+        self.assertEqual(entries, {'current', self.archive.name})
+        async with self.client.get(self.download_path(linked_name)) as response:
+            self.assertEqual(response.status, 404, await response.text())
+        async with self.client.get('/api/recording', params={'view': 'paged', 'recording': linked_name}) as response:
+            self.assertEqual(response.status, 404, await response.text())
+
+    async def test_symlink_archive_directory_is_not_followed(self):
+        folder = self.archive.parent
+        target = self.root / 'outside-recordings'
+        original = self.archive.read_bytes()
+        folder.rename(target)
+        folder.symlink_to(target, target_is_directory=True)
+        self.assertEqual({entry['id'] for entry in await self.inventory()}, {'current'})
+        async with self.client.get(self.download_path(self.archive.name)) as response:
+            self.assertEqual(response.status, 404, await response.text())
+        async with self.client.get('/api/recording', params={'view': 'paged', 'recording': self.archive.name}) as response:
+            self.assertEqual(response.status, 404, await response.text())
+        async with self.client.get(self.download_path('current')) as response:
+            self.assertEqual(response.status, 200, await response.text())
+            self.assertEqual(await response.read(), self.path.read_bytes())
+        self.assertEqual((target / self.archive.name).read_bytes(), original)
+
+    async def test_benchmark_mode_has_no_archive_routes_or_selection(self):
+        api, client = await self.make_client(archives=False)
+        for url in ['/api/recordings', self.download_path('current'), self.download_path(self.archive.name)]:
+            async with client.get(url) as response:
+                self.assertEqual(response.status, 404, await response.text())
+        for query in [
+            {'view': 'paged', 'recording': self.archive.name},
+            {'format': 'jsonl', 'recording': self.archive.name},
+            {'recording': self.archive.name},
+        ]:
+            async with client.get('/api/recording', params=query) as response:
+                self.assertEqual(response.status, 404, await response.text())
+        self.assertFalse(api.readers)
+        for query in [{'format': 'jsonl'}, {'format': 'jsonl', 'recording': 'current'}]:
+            async with client.get('/api/recording', params=query) as response:
+                self.assertEqual(response.status, 200, await response.text())
+                self.assertEqual(await response.read(), self.path.read_bytes())
+        page = await self.get_json({'view': 'paged'}, client=client)
+        self.assertEqual(page['events'], self.current_events)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/test_recording_archives.py
+++ b/server/test_recording_archives.py
@@ -242,6 +242,23 @@ class RecordingArchiveTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(archive.read_bytes(), expected)
         self.assertEqual(set(archive.parent.iterdir()), names_before)
 
+    async def test_replacing_writer_updates_new_reads_without_repointing_old_tokens(self):
+        old = await self.get_json({'view': 'paged'})
+        self.store.close()
+        replacement = RecordingStore(self.root / 'other' / 'replacement.jsonl', started=99)
+        self.addCleanup(replacement.close)
+        replacement.append({'t': 3, 'key': 'down', 'down': True})
+        self.api.store = replacement
+        fresh = await self.get_json({'view': 'paged'})
+        retained = await self.get_json({'view': 'paged', 'token': old['token']})
+        self.assertEqual(fresh['started'], 99)
+        self.assertEqual(retained['started'], 20)
+        response = await self.client.get('/api/recordings')
+        files = (await response.json())['files']
+        self.assertEqual([file['name'] for file in files], ['replacement.jsonl'])
+        response = await self.client.get('/api/recordings/current')
+        self.assertEqual(await response.read(), replacement.path.read_bytes())
+
     async def test_archive_pages_can_traverse_refetch_touch_and_close(self):
         events = [{'t': index + 10, 'd': str(index) * (550 << 10)} for index in range(5)]
         for event in events:


### PR DESCRIPTION
Superseded by #37: both archive commits and their regression tests are now included in that existing recording PR. The combined branch passed 36 recording/archive/seek tests and matches the verified local implementation. PR #38 now references #37 for the menu and archive playback backend. This PR is being closed to avoid duplicate review.

Restore read-only access to recordings that the existing storage lifecycle archives on reset. GET /api/recordings lists the current journal and valid archived files; /api/recordings/<name> downloads a JSONL attachment with Range and If-Range support. The existing paged recording endpoint can select an archive on its first request, then keeps that pinned source for all later token requests.

Current downloads pin the committed prefix, so append or reset cannot swap their contents midway. Archives are opened read-only through a fixed directory descriptor with no-follow checks; traversal, symlink directories/files and non-regular files are rejected. Replay duration is recovered from a bounded tail without opening an archive writer or scanning the full file. Benchmark mode exposes neither the new routes nor archive selection, while the existing current raw endpoint remains unchanged.

This applies independently to main. PR #38 restores the matching recordings menu and uses this API for archive playback; the right-hand screenshot history continues to show the current recording.

Validation: 30 recording tests passed, including 16 archive HTTP regressions for byte-exact downloads, Range/If-Range, reset during streaming, uncommitted suffixes, fixed old readers, filename replacement, duration, path rejection and benchmark isolation. No real user data or game assets are included.

Replacing the active writer updates new reads and listings while existing tokens keep their original pinned source; this is covered by an additional regression and by integration with #37.