### PR TITLE
bench: add additive medium and long horizon scoring

### DIFF
--- a/bench/LONG_HORIZON_SCORING.md
+++ b/bench/LONG_HORIZON_SCORING.md
@@ -25,8 +25,8 @@ a failure.
 | Horizon | Wall-clock budget | What it asks | Examples of evidence |
 | --- | ---: | --- | --- |
 | Short | 20 minutes | Can the agent operate and make early progress? | Existing paper metrics: acted, picked something up, reached the world map, experience, level, companion, and book fields |
-| Medium | 30 minutes to 2 hours | Can it establish a plan and carry dependencies across several locations? | Inn, Nan Xian, compass, a second meaningful location, first battle, companion, skill or quest flags |
-| Long | 24 to 48 hours | Can it sustain a coherent route through the game's story? | Repeated battles, durable growth, multiple quest chains, books held with evidence, all fourteen books, ending state |
+| Medium | 30 minutes to 2 hours | Can it establish a plan and carry dependencies across several locations? | Inn, Nan Xian, compass, a second meaningful location, first battle, companion, skill or story nodes |
+| Long | 24 to 48 hours | Can it sustain a coherent route through the game's story? | Repeated battles, durable growth, multiple story chains, books held with evidence, all fourteen books, ending state |
 
 The medium horizon has two natural checkpoints. **M1** is the opening route:
 leave the home, reach the inn, find Nan Xian and obtain the compass. **M2** is
@@ -48,17 +48,23 @@ elapsed `at` time and may contain the following fields:
 ```json
 {
   "at": 7200,
+  "measured_tiers": ["medium", "long"],
   "milestones": ["inn", "nanxian", "compass", "battle_won"],
   "locations": ["home", "inn", "nanxian", "kunlun"],
-  "quest_flags": ["opening", "kunlun_intro"],
+  "story_nodes": ["opening", "tianlong"],
   "books": [],
   "level": 4,
   "team_size": 3,
+  "key_items": ["compass", "jade_seal"],
   "inventory_distinct": 14,
   "recoveries": 1,
   "state_loss_events": 0
 }
 ```
+
+`measured_tiers` is required for medium and long scoring. If omitted, a
+`milestones` list is treated as short-tier data only. This prevents an old
+short run from being interpreted as a measured long-run failure.
 
 `milestones` uses these stable ids:
 
@@ -69,7 +75,8 @@ The existing short ids may also be present for cross-referencing, but the
 short score remains owned by the existing scorer: `acted`, `picked_item`,
 `world_map`, `experience`, `level_2`, `companion`, and `book`.
 
-Every claim needs state evidence. A location should be emitted only after an
+`story_nodes` is restricted to the registered book and opening nodes. Unknown
+free-form strings are ignored. A location should be emitted only after an
 entry, coordinate checkpoint, or reliable dialogue/event record. A book should
 be emitted from the game's item or story state and not from a model's text.
 The scorer treats checkpoint times as ordered and rejects a backwards clock.
@@ -81,17 +88,18 @@ separate in the JSON so a reader can see why a run scored as it did:
 
 | Component | Points | Measurement |
 | --- | ---: | --- |
-| Milestone progression | 30 | Ordered gates from operation through ending; the next unmet gate is reported |
-| Exploration | 20 | Unique evidence-backed locations against a configurable target (default 8) |
-| Growth | 20 | The best observed level, team size, and distinct inventory, averaged only over measured fields |
-| Story coverage | 15 | Unique evidence-backed quest flags against a configurable target (default 12) |
-| Book collection | 10 | Verified book ids out of 14 |
+| Medium/long gate progression | 25 | Dependency-aware gates; the frozen short ladder is reported separately |
+| Exploration | 15 | Unique evidence-backed locations against a configurable target (default 8) |
+| Growth | 15 | The best observed level, team size, and key-item set; arbitrary inventory size is diagnostic only |
+| Story coverage | 15 | Unique registered story nodes against a configurable target (default 12) |
+| Book collection | 25 | Verified book ids out of 14 |
 | Reliability | 5 | Recovery events divided by recovery plus state-loss events, when both are measured |
 
-The report also returns `maximum_measured`. Its displayed score is normalized
-over measured components, while the missing components remain explicit. This
-prevents a run from being punished for an instrument that did not yet exist.
-The `short_metrics_unchanged` marker makes the separation machine-checkable.
+The displayed `score` uses a fixed 100-point denominator. The report also
+returns `maximum_measured` and `coverage`; a run with only a partial instrument
+cannot receive a falsely high normalized score. Missing components remain
+explicit and should not be compared across runs with different coverage. The
+`short_metrics_unchanged` marker makes the separation machine-checkable.
 
 This weighting is a secondary analysis convention, not a new claim about the
 paper's short benchmark. For scientific comparisons, publish the component

--- a/bench/LONG_HORIZON_SCORING.md
+++ b/bench/LONG_HORIZON_SCORING.md
@@ -1,0 +1,109 @@
+# Long-horizon scoring
+
+This is an additive secondary report for runs that last longer than the
+paper's short benchmark. It does not change the existing short-run fields,
+the published 20-minute results, their confidence intervals, or the current
+leaderboard ordering.
+
+## Why a second report exists
+
+The current benchmark answers an intentionally narrow question: can an agent
+make useful progress during a short, fixed wall-clock window? That result is
+already reported in the paper and must remain comparable. A ten-hour run
+answers a different question. It may not hold a book yet, but it can still
+show whether the agent discovered the overworld, found the inn, reached Nan
+Xian, obtained the compass, recruited a companion, won a battle, learned a
+skill, and preserved state across a long sequence. Collapsing that trajectory
+to the unchanged short score would discard useful evidence.
+
+The long-horizon report therefore publishes a trajectory and a secondary
+score. It never replaces a short score and never turns an unmeasured field into
+a failure.
+
+## Three horizons
+
+| Horizon | Wall-clock budget | What it asks | Examples of evidence |
+| --- | ---: | --- | --- |
+| Short | 20 minutes | Can the agent operate and make early progress? | Existing paper metrics: acted, picked something up, reached the world map, experience, level, companion, and book fields |
+| Medium | 30 minutes to 2 hours | Can it establish a plan and carry dependencies across several locations? | Inn, Nan Xian, compass, a second meaningful location, first battle, companion, skill or quest flags |
+| Long | 24 to 48 hours | Can it sustain a coherent route through the game's story? | Repeated battles, durable growth, multiple quest chains, books held with evidence, all fourteen books, ending state |
+
+The medium horizon has two natural checkpoints. **M1** is the opening route:
+leave the home, reach the inn, find Nan Xian and obtain the compass. **M2** is
+the first multi-location plan: reach another meaningful location, complete a
+battle or training step, and keep the resulting state after a save/load
+checkpoint. A run can pass M1 without passing M2.
+
+The long horizon is deliberately not “fourteen books or zero”. Book count is
+one component of the long report. A long run with no book can still receive
+measured journey evidence for exploration, growth, story flags and battles;
+the book component remains zero only when the harness measured that no book was
+held. If books were never instrumented, that component is unmeasured.
+
+## Checkpoint contract
+
+The scorer accepts an ordered JSON array of checkpoints. A checkpoint has an
+elapsed `at` time and may contain the following fields:
+
+```json
+{
+  "at": 7200,
+  "milestones": ["inn", "nanxian", "compass", "battle_won"],
+  "locations": ["home", "inn", "nanxian", "kunlun"],
+  "quest_flags": ["opening", "kunlun_intro"],
+  "books": [],
+  "level": 4,
+  "team_size": 3,
+  "inventory_distinct": 14,
+  "recoveries": 1,
+  "state_loss_events": 0
+}
+```
+
+`milestones` uses these stable ids:
+
+- Medium: `inn`, `nanxian`, `compass`, `second_location`.
+- Long: `battle_won`, `skill_gain`, `book`, `all_books`, `ending`.
+
+The existing short ids may also be present for cross-referencing, but the
+short score remains owned by the existing scorer: `acted`, `picked_item`,
+`world_map`, `experience`, `level_2`, `companion`, and `book`.
+
+Every claim needs state evidence. A location should be emitted only after an
+entry, coordinate checkpoint, or reliable dialogue/event record. A book should
+be emitted from the game's item or story state and not from a model's text.
+The scorer treats checkpoint times as ordered and rejects a backwards clock.
+
+## Secondary score
+
+The optional long report has 100 maximum points. Its components are kept
+separate in the JSON so a reader can see why a run scored as it did:
+
+| Component | Points | Measurement |
+| --- | ---: | --- |
+| Milestone progression | 30 | Ordered gates from operation through ending; the next unmet gate is reported |
+| Exploration | 20 | Unique evidence-backed locations against a configurable target (default 8) |
+| Growth | 20 | The best observed level, team size, and distinct inventory, averaged only over measured fields |
+| Story coverage | 15 | Unique evidence-backed quest flags against a configurable target (default 12) |
+| Book collection | 10 | Verified book ids out of 14 |
+| Reliability | 5 | Recovery events divided by recovery plus state-loss events, when both are measured |
+
+The report also returns `maximum_measured`. Its displayed score is normalized
+over measured components, while the missing components remain explicit. This
+prevents a run from being punished for an instrument that did not yet exist.
+The `short_metrics_unchanged` marker makes the separation machine-checkable.
+
+This weighting is a secondary analysis convention, not a new claim about the
+paper's short benchmark. For scientific comparisons, publish the component
+vector, checkpoint timeline, budget, and evidence source beside the aggregate;
+do not rank two runs solely by the aggregate when their measured coverage
+differs.
+
+## What is intentionally unchanged
+
+The existing short fields (`meaningful`, `oscillation`, `reads`, `ttfa`,
+`actions`, the current milestone fields, and the paper tables) remain byte and
+schema compatible. No old run is re-scored. No long-run field is fed back into
+the 20-minute confidence intervals. A future long-run leaderboard can show the
+secondary report beside the short score, but it must label the horizons and
+budgets separately.

--- a/bench/README.md
+++ b/bench/README.md
@@ -91,6 +91,17 @@ framebuffer, and the framebuffer cannot answer it: the menu is an overlay whose
 width follows its contents, so no fixed mask covers it, and a five tile
 corridor reported ten places.
 
+## Long-horizon report
+
+The short run and its published fields remain the benchmark's frozen baseline.
+For runs lasting from tens of minutes through one or two days, an additive
+checkpoint report can score the journey without changing those fields. It has
+separate medium and long horizons for the inn, Nan Xian, the compass, battles,
+growth, quest coverage, the fourteen books and the ending. The checkpoint
+contract, component weights, missing-data rules and examples are documented in
+[`LONG_HORIZON_SCORING.md`](LONG_HORIZON_SCORING.md); the pure scorer is
+`long_horizon.py` and does not read or rewrite the short-run metrics.
+
 ## Recording
 
 A recording is the tile deltas the browser stream already produces, kept with

--- a/bench/long_horizon.py
+++ b/bench/long_horizon.py
@@ -1,0 +1,242 @@
+"""Additive long-horizon scoring for multi-hour game runs.
+
+The published short-run metrics are deliberately not used here.  A harness
+may submit a sequence of state checkpoints after a long run and receive a
+secondary report describing the journey: ordered milestones, exploration,
+growth, story coverage, book collection, and recovery.  Missing fields are
+reported as unmeasured rather than treated as zero.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+
+
+SCHEMA_VERSION = 1
+BOOK_IDS = frozenset(range(144, 158))
+DEFAULT_TARGETS = {
+    "locations": 8,
+    "quests": 12,
+}
+
+# These are long-run gates.  The first seven mirror the existing benchmark's
+# vocabulary for comparability; the last two are only long-horizon additions.
+MILESTONES = (
+    "acted",
+    "picked_item",
+    "world_map",
+    "experience",
+    "level_2",
+    "companion",
+    "book",
+    "all_books",
+    "ending",
+)
+
+# Long-horizon additions are deliberately separate from the short-run ladder.
+# A checkpoint may use these stable English ids while its UI renders Chinese
+# labels.  The short tier is a pointer to the frozen paper score, never a
+# recomputation of it.
+TIER_MILESTONES = {
+    "short": ("acted", "picked_item", "world_map", "experience", "level_2",
+               "companion", "book"),
+    "medium": ("inn", "nanxian", "compass", "second_location"),
+    "long": ("battle_won", "skill_gain", "book", "all_books", "ending"),
+}
+
+
+def _number(value, *, integer=False):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    if integer and not isinstance(value, int):
+        return None
+    if value < 0:
+        return None
+    return value
+
+
+def _checkpoint_list(checkpoints: Iterable[Mapping]) -> list[dict]:
+    out = []
+    previous = -1.0
+    for raw in checkpoints:
+        if not isinstance(raw, Mapping):
+            raise ValueError("each checkpoint must be an object")
+        at = _number(raw.get("at"))
+        if at is None or at < previous:
+            raise ValueError("checkpoint times must be non-negative and ordered")
+        previous = float(at)
+        out.append(dict(raw))
+    if not out:
+        raise ValueError("at least one checkpoint is required")
+    return out
+
+
+def _union(checkpoints: Sequence[Mapping], key: str) -> tuple[set, bool]:
+    values, measured = set(), False
+    for checkpoint in checkpoints:
+        if key not in checkpoint or checkpoint[key] is None:
+            continue
+        measured = True
+        value = checkpoint[key]
+        if isinstance(value, str):
+            values.add(value)
+        elif isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+            values.update(v for v in value if isinstance(v, (str, int)) and not isinstance(v, bool))
+    return values, measured
+
+
+def _max_value(checkpoints: Sequence[Mapping], key: str) -> tuple[float | None, bool]:
+    values = [_number(c.get(key)) for c in checkpoints if key in c]
+    values = [v for v in values if v is not None]
+    return (max(values), True) if values else (None, False)
+
+
+def _milestones(checkpoints: Sequence[Mapping]) -> tuple[set[str], bool]:
+    reached, measured = set(), False
+    valid = set(MILESTONES)
+    valid.update(gate for gates in TIER_MILESTONES.values() for gate in gates)
+    for checkpoint in checkpoints:
+        if "milestones" not in checkpoint:
+            continue
+        measured = True
+        values = checkpoint["milestones"]
+        if isinstance(values, str):
+            values = [values]
+        if isinstance(values, Sequence):
+            reached.update(v for v in values if v in valid)
+    return reached, measured
+
+
+def _component(points, value, measured, evidence):
+    return {
+        "points": round(points * value, 3) if measured else None,
+        "maximum": points,
+        "value": round(value, 6) if measured else None,
+        "score": round(value * 100, 3) if measured else None,
+        "measured": measured,
+        "evidence": evidence,
+    }
+
+
+def _tier_report(reached, measured):
+    """Report additive medium/long gates without touching short metrics."""
+    reports = {}
+    for tier, gates in TIER_MILESTONES.items():
+        if tier == "short":
+            reports[tier] = {
+                "status": "frozen_external_metric",
+                "score": None,
+                "reached": [gate for gate in gates if gate in reached],
+                "gates": list(gates),
+                "measured": measured,
+            }
+            continue
+        known = [gate for gate in gates if gate in measured]
+        reached_known = [gate for gate in known if gate in reached]
+        reports[tier] = {
+            "status": "measured" if known else "unmeasured",
+            "score": round(100 * len(reached_known) / len(known), 3) if known else None,
+            "reached": reached_known,
+            "gates": list(gates),
+            "measured_gates": known,
+        }
+    return reports
+
+
+def score_long_horizon(checkpoints: Iterable[Mapping], *, budget_seconds=None,
+                       targets=None) -> dict:
+    """Return an additive secondary score for a checkpoint trajectory.
+
+    Checkpoints are harness-produced records.  Useful keys are ``at``,
+    ``milestones`` (a list from :data:`MILESTONES`), ``location``,
+    ``quest_flags``, ``books`` (item ids), ``level``, ``team_size``,
+    ``inventory_distinct``, ``recoveries`` and ``state_loss_events``.
+    ``budget_seconds`` is metadata and never changes the frozen short score.
+    """
+    rows = _checkpoint_list(checkpoints)
+    targets = {**DEFAULT_TARGETS, **(targets or {})}
+    if any(_number(targets.get(k), integer=True) in (None, 0) for k in DEFAULT_TARGETS):
+        raise ValueError("long-horizon targets must be positive integers")
+
+    milestones, milestone_measured = _milestones(rows)
+    # A milestone list is a complete read of the milestone instrument at that
+    # checkpoint: omitted ids are known false, not silently unmeasured. Runs
+    # that never provide the key keep every milestone unmeasured.
+    all_measured_milestones = set()
+    if any("milestones" in checkpoint for checkpoint in rows):
+        all_measured_milestones = set(MILESTONES)
+        all_measured_milestones.update(gate for gates in TIER_MILESTONES.values()
+                                       for gate in gates)
+    locations, location_measured = _union(rows, "locations")
+    if not locations:
+        locations, location_measured = _union(rows, "location")
+    quests, quest_measured = _union(rows, "quest_flags")
+    books, books_measured = _union(rows, "books")
+    books = {book for book in books if book in BOOK_IDS}
+
+    level, level_measured = _max_value(rows, "level")
+    team, team_measured = _max_value(rows, "team_size")
+    inventory, inventory_measured = _max_value(rows, "inventory_distinct")
+    recoveries, recoveries_measured = _max_value(rows, "recoveries")
+    losses, losses_measured = _max_value(rows, "state_loss_events")
+
+    # The ordered-gate component gives credit for a journey that has not yet
+    # reached a book.  It is separate from the frozen short-run score.
+    prefix = 0
+    for milestone in MILESTONES:
+        if milestone not in milestones:
+            break
+        prefix += 1
+    growth_values = (
+        min(1.0, (level or 0) / 10) if level_measured else 0,
+        min(1.0, (team or 0) / 6) if team_measured else 0,
+        min(1.0, (inventory or 0) / 20) if inventory_measured else 0,
+    )
+    growth_measured = any((level_measured, team_measured, inventory_measured))
+    components = {
+        "milestone_progress": _component(
+            30, prefix / len(MILESTONES), milestone_measured,
+            {"reached": [m for m in MILESTONES if m in milestones],
+             "next": MILESTONES[prefix] if prefix < len(MILESTONES) else None}),
+        "exploration": _component(
+            20, min(1.0, len(locations) / targets["locations"]),
+            location_measured, {"unique_locations": len(locations), "target": targets["locations"]}),
+        "growth": _component(
+            20, sum(growth_values) / sum((level_measured, team_measured, inventory_measured))
+            if growth_measured else 0,
+            growth_measured,
+            {"level": level, "team_size": team, "inventory_distinct": inventory}),
+        "story": _component(
+            15, min(1.0, len(quests) / targets["quests"]), quest_measured,
+            {"unique_quest_flags": len(quests), "target": targets["quests"]}),
+        "book_collection": _component(
+            10, len(books) / len(BOOK_IDS), books_measured,
+            {"books": sorted(books), "count": len(books), "total": len(BOOK_IDS)}),
+    }
+
+    reliability_measured = recoveries_measured and losses_measured
+    if reliability_measured:
+        total = (recoveries or 0) + (losses or 0)
+        reliability = (recoveries or 0) / total if total else 1.0
+    else:
+        reliability = 0.0
+    components["reliability"] = _component(
+        5, reliability, reliability_measured,
+        {"recoveries": recoveries, "state_loss_events": losses})
+
+    measured = [c for c in components.values() if c["measured"]]
+    maximum = sum(c["maximum"] for c in measured)
+    points = sum(c["points"] for c in measured)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "score": round(points / maximum * 100, 3) if maximum else None,
+        "points": round(points, 3),
+        "maximum_measured": maximum,
+        "maximum_total": 100,
+        "budget_seconds": _number(budget_seconds),
+        "checkpoints": len(rows),
+        "elapsed_seconds": rows[-1]["at"],
+        "components": components,
+        "tiers": _tier_report(milestones, all_measured_milestones),
+        "short_metrics_unchanged": True,
+    }

--- a/bench/long_horizon.py
+++ b/bench/long_horizon.py
@@ -16,21 +16,26 @@ SCHEMA_VERSION = 1
 BOOK_IDS = frozenset(range(144, 158))
 DEFAULT_TARGETS = {
     "locations": 8,
-    "quests": 12,
+    "story_nodes": 12,
 }
 
-# These are long-run gates.  The first seven mirror the existing benchmark's
-# vocabulary for comparability; the last two are only long-horizon additions.
-MILESTONES = (
-    "acted",
-    "picked_item",
-    "world_map",
-    "experience",
-    "level_2",
-    "companion",
-    "book",
-    "all_books",
-    "ending",
+# Stable evidence-backed route nodes.  A deployment may extend this registry,
+# but a free-form string is never counted as a story node.
+STORY_NODE_IDS = frozenset({
+    "opening", "compass", "flying_fox", "snowy_fox", "liancheng",
+    "tianlong", "shediao", "baima", "luding", "xiaoyao", "shujian",
+    "shendiao", "xiake", "yitian", "bixue", "yuanyang",
+})
+
+HORIZON_BANDS = (
+    ("short", 0, 20 * 60),
+    ("medium", 30 * 60, 2 * 60 * 60),
+    ("long", 24 * 60 * 60, 48 * 60 * 60),
+)
+
+SHORT_MILESTONES = (
+    "acted", "picked_item", "world_map", "experience", "level_2",
+    "companion", "book",
 )
 
 # Long-horizon additions are deliberately separate from the short-run ladder.
@@ -38,11 +43,29 @@ MILESTONES = (
 # labels.  The short tier is a pointer to the frozen paper score, never a
 # recomputation of it.
 TIER_MILESTONES = {
-    "short": ("acted", "picked_item", "world_map", "experience", "level_2",
-               "companion", "book"),
+    "short": SHORT_MILESTONES,
     "medium": ("inn", "nanxian", "compass", "second_location"),
     "long": ("battle_won", "skill_gain", "book", "all_books", "ending"),
 }
+
+# These prerequisites express only hard, instrumentable dependencies from the
+# walkthrough.  Optional route choices remain independent gates.
+PREREQUISITES = {
+    "nanxian": ("inn",),
+    "compass": ("nanxian",),
+    "all_books": ("book",),
+    "ending": ("all_books",),
+}
+
+
+def _horizon(budget_seconds):
+    budget = _number(budget_seconds)
+    if budget is None:
+        return None
+    for name, low, high in HORIZON_BANDS:
+        if low <= budget <= high:
+            return name
+    return "extended"
 
 
 def _number(value, *, integer=False):
@@ -91,20 +114,24 @@ def _max_value(checkpoints: Sequence[Mapping], key: str) -> tuple[float | None, 
     return (max(values), True) if values else (None, False)
 
 
-def _milestones(checkpoints: Sequence[Mapping]) -> tuple[set[str], bool]:
+def _milestones(checkpoints: Sequence[Mapping]) -> tuple[set[str], bool, set[str]]:
     reached, measured = set(), False
-    valid = set(MILESTONES)
-    valid.update(gate for gates in TIER_MILESTONES.values() for gate in gates)
+    valid = set(gate for gates in TIER_MILESTONES.values() for gate in gates)
+    measured_tiers = set()
     for checkpoint in checkpoints:
         if "milestones" not in checkpoint:
             continue
         measured = True
+        tiers = checkpoint.get("measured_tiers", ["short"])
+        if isinstance(tiers, str):
+            tiers = [tiers]
+        measured_tiers.update(tier for tier in tiers if tier in TIER_MILESTONES)
         values = checkpoint["milestones"]
         if isinstance(values, str):
             values = [values]
         if isinstance(values, Sequence):
             reached.update(v for v in values if v in valid)
-    return reached, measured
+    return reached, measured, measured_tiers
 
 
 def _component(points, value, measured, evidence):
@@ -118,7 +145,7 @@ def _component(points, value, measured, evidence):
     }
 
 
-def _tier_report(reached, measured):
+def _tier_report(reached, measured, measured_tiers):
     """Report additive medium/long gates without touching short metrics."""
     reports = {}
     for tier, gates in TIER_MILESTONES.items():
@@ -131,7 +158,12 @@ def _tier_report(reached, measured):
                 "measured": measured,
             }
             continue
-        known = [gate for gate in gates if gate in measured]
+        if tier not in measured_tiers:
+            reports[tier] = {"status": "unmeasured", "score": None,
+                             "reached": [], "gates": list(gates),
+                             "measured_gates": []}
+            continue
+        known = list(gates)
         reached_known = [gate for gate in known if gate in reached]
         reports[tier] = {
             "status": "measured" if known else "unmeasured",
@@ -148,9 +180,9 @@ def score_long_horizon(checkpoints: Iterable[Mapping], *, budget_seconds=None,
     """Return an additive secondary score for a checkpoint trajectory.
 
     Checkpoints are harness-produced records.  Useful keys are ``at``,
-    ``milestones`` (a list from :data:`MILESTONES`), ``location``,
-    ``quest_flags``, ``books`` (item ids), ``level``, ``team_size``,
-    ``inventory_distinct``, ``recoveries`` and ``state_loss_events``.
+    ``milestones`` (tier-specific gate ids), ``measured_tiers``, ``location``,
+    ``story_nodes``, ``books`` (item ids), ``level``, ``team_size``,
+    ``key_items``, ``recoveries`` and ``state_loss_events``.
     ``budget_seconds`` is metadata and never changes the frozen short score.
     """
     rows = _checkpoint_list(checkpoints)
@@ -158,59 +190,63 @@ def score_long_horizon(checkpoints: Iterable[Mapping], *, budget_seconds=None,
     if any(_number(targets.get(k), integer=True) in (None, 0) for k in DEFAULT_TARGETS):
         raise ValueError("long-horizon targets must be positive integers")
 
-    milestones, milestone_measured = _milestones(rows)
+    milestones, milestone_measured, measured_tiers = _milestones(rows)
     # A milestone list is a complete read of the milestone instrument at that
     # checkpoint: omitted ids are known false, not silently unmeasured. Runs
     # that never provide the key keep every milestone unmeasured.
     all_measured_milestones = set()
     if any("milestones" in checkpoint for checkpoint in rows):
-        all_measured_milestones = set(MILESTONES)
-        all_measured_milestones.update(gate for gates in TIER_MILESTONES.values()
-                                       for gate in gates)
+        all_measured_milestones = set(gate for tier in measured_tiers
+                                      for gate in TIER_MILESTONES[tier])
     locations, location_measured = _union(rows, "locations")
     if not locations:
         locations, location_measured = _union(rows, "location")
-    quests, quest_measured = _union(rows, "quest_flags")
+    story_nodes, story_measured = _union(rows, "story_nodes")
+    story_nodes = {node for node in story_nodes if node in STORY_NODE_IDS}
     books, books_measured = _union(rows, "books")
     books = {book for book in books if book in BOOK_IDS}
 
     level, level_measured = _max_value(rows, "level")
     team, team_measured = _max_value(rows, "team_size")
+    key_items, key_items_measured = _union(rows, "key_items")
+    # Keep the old field readable for diagnostics, but do not award growth for
+    # arbitrary inventory size. Key items are the guide's actual prerequisites.
     inventory, inventory_measured = _max_value(rows, "inventory_distinct")
     recoveries, recoveries_measured = _max_value(rows, "recoveries")
     losses, losses_measured = _max_value(rows, "state_loss_events")
 
-    # The ordered-gate component gives credit for a journey that has not yet
-    # reached a book.  It is separate from the frozen short-run score.
-    prefix = 0
-    for milestone in MILESTONES:
-        if milestone not in milestones:
-            break
-        prefix += 1
-    growth_values = (
-        min(1.0, (level or 0) / 10) if level_measured else 0,
-        min(1.0, (team or 0) / 6) if team_measured else 0,
-        min(1.0, (inventory or 0) / 20) if inventory_measured else 0,
-    )
-    growth_measured = any((level_measured, team_measured, inventory_measured))
+    # Medium and long gates are scored as a dependency-aware set.  The frozen
+    # short ladder is reported separately and is never recomputed here.
+    long_gates = tuple(gate for tier in ("medium", "long")
+                       if tier in measured_tiers for gate in TIER_MILESTONES[tier])
+    valid_gates = list(dict.fromkeys(long_gates))
+    valid_reached = {gate for gate in milestones if gate in valid_gates}
+    for gate in list(valid_reached):
+        if any(pre not in valid_reached for pre in PREREQUISITES.get(gate, ())):
+            valid_reached.remove(gate)
+    gate_fraction = len(valid_reached) / len(valid_gates) if valid_gates else 0
     components = {
         "milestone_progress": _component(
-            30, prefix / len(MILESTONES), milestone_measured,
-            {"reached": [m for m in MILESTONES if m in milestones],
-             "next": MILESTONES[prefix] if prefix < len(MILESTONES) else None}),
+            25, gate_fraction, bool(valid_gates),
+            {"reached": sorted(valid_reached), "measured_gates": valid_gates,
+             "prerequisites": PREREQUISITES}),
         "exploration": _component(
-            20, min(1.0, len(locations) / targets["locations"]),
+            15, min(1.0, len(locations) / targets["locations"]),
             location_measured, {"unique_locations": len(locations), "target": targets["locations"]}),
         "growth": _component(
-            20, sum(growth_values) / sum((level_measured, team_measured, inventory_measured))
-            if growth_measured else 0,
-            growth_measured,
-            {"level": level, "team_size": team, "inventory_distinct": inventory}),
+            15, sum((min(1.0, (level or 0) / 10) if level_measured else 0,
+                     min(1.0, (team or 0) / 6) if team_measured else 0,
+                     min(1.0, len(key_items) / 8) if key_items_measured else 0))
+            / sum((level_measured, team_measured, key_items_measured))
+            if any((level_measured, team_measured, key_items_measured)) else 0,
+            any((level_measured, team_measured, key_items_measured)),
+            {"level": level, "team_size": team, "key_items": sorted(key_items),
+             "inventory_distinct_diagnostic": inventory}),
         "story": _component(
-            15, min(1.0, len(quests) / targets["quests"]), quest_measured,
-            {"unique_quest_flags": len(quests), "target": targets["quests"]}),
+            15, min(1.0, len(story_nodes) / targets["story_nodes"]), story_measured,
+            {"unique_story_nodes": len(story_nodes), "target": targets["story_nodes"]}),
         "book_collection": _component(
-            10, len(books) / len(BOOK_IDS), books_measured,
+            25, len(books) / len(BOOK_IDS), books_measured,
             {"books": sorted(books), "count": len(books), "total": len(BOOK_IDS)}),
     }
 
@@ -229,14 +265,16 @@ def score_long_horizon(checkpoints: Iterable[Mapping], *, budget_seconds=None,
     points = sum(c["points"] for c in measured)
     return {
         "schema_version": SCHEMA_VERSION,
-        "score": round(points / maximum * 100, 3) if maximum else None,
+        "score": round(points, 3) if maximum else None,
         "points": round(points, 3),
         "maximum_measured": maximum,
         "maximum_total": 100,
+        "coverage": round(maximum / 100, 6),
         "budget_seconds": _number(budget_seconds),
+        "horizon": _horizon(budget_seconds),
         "checkpoints": len(rows),
         "elapsed_seconds": rows[-1]["at"],
         "components": components,
-        "tiers": _tier_report(milestones, all_measured_milestones),
+        "tiers": _tier_report(milestones, all_measured_milestones, measured_tiers),
         "short_metrics_unchanged": True,
     }

--- a/bench/test_long_horizon.py
+++ b/bench/test_long_horizon.py
@@ -6,42 +6,46 @@ from long_horizon import score_long_horizon
 class LongHorizonScoreTests(unittest.TestCase):
     def test_short_metrics_are_frozen_and_medium_gates_show_the_journey(self):
         report = score_long_horizon([
-            {"at": 0, "milestones": ["acted"]},
-            {"at": 1800, "milestones": ["acted", "inn"]},
+            {"at": 0, "milestones": ["acted"], "measured_tiers": ["short"]},
+            {"at": 1800, "milestones": ["inn"], "measured_tiers": ["medium"]},
             {"at": 2400, "milestones": ["acted", "inn", "nanxian", "compass"],
+             "measured_tiers": ["short", "medium"],
              "locations": ["home", "inn", "nanxian"],
-             "level": 1, "team_size": 1, "inventory_distinct": 5},
+             "level": 1, "team_size": 1, "key_items": ["compass"]},
         ])
         self.assertTrue(report["short_metrics_unchanged"])
         self.assertEqual(report["tiers"]["short"]["status"], "frozen_external_metric")
         self.assertEqual(report["tiers"]["medium"]["score"], 75.0)
-        self.assertEqual(report["tiers"]["long"]["status"], "measured")
-        self.assertEqual(report["tiers"]["long"]["score"], 0.0)
+        self.assertEqual(report["tiers"]["long"]["status"], "unmeasured")
 
     def test_long_run_without_books_still_has_a_measured_trajectory(self):
         report = score_long_horizon([
-            {"at": 0, "milestones": ["acted", "inn", "nanxian", "compass"],
-             "locations": ["home", "inn", "nanxian"], "quest_flags": ["opening"],
-             "level": 1, "team_size": 1, "inventory_distinct": 5, "books": []},
-            {"at": 7200, "milestones": ["acted", "inn", "nanxian", "compass",
+            {"at": 0, "milestones": ["inn", "nanxian", "compass"],
+             "measured_tiers": ["medium", "long"],
+             "locations": ["home", "inn", "nanxian"], "story_nodes": ["opening"],
+             "level": 1, "team_size": 1, "key_items": ["compass"], "books": []},
+            {"at": 7200, "milestones": ["inn", "nanxian", "compass",
                                            "second_location", "battle_won", "skill_gain"],
+             "measured_tiers": ["medium", "long"],
              "locations": ["home", "inn", "nanxian", "kunlun", "wudang"],
-             "quest_flags": ["opening", "kunlun_intro", "wudang_intro"],
-             "level": 4, "team_size": 3, "inventory_distinct": 14, "books": []},
+             "story_nodes": ["opening", "tianlong", "yitian"],
+             "level": 4, "team_size": 3, "key_items": ["compass", "jade_seal"], "books": []},
         ])
         self.assertGreater(report["score"], 0)
         self.assertEqual(report["components"]["book_collection"]["measured"], True)
         self.assertEqual(report["components"]["book_collection"]["value"], 0.0)
         self.assertEqual(report["tiers"]["long"]["score"], 40.0)
+        self.assertEqual(report["score"], 35.542)
 
     def test_missing_optional_dimensions_are_unmeasured_not_zero(self):
         report = score_long_horizon([
-            {"at": 0, "milestones": ["acted"]},
+            {"at": 0, "milestones": ["acted"], "measured_tiers": ["short"]},
         ])
         self.assertIsNone(report["components"]["exploration"]["score"])
         self.assertIsNone(report["components"]["reliability"]["score"])
-        self.assertEqual(report["score"], 11.11)
-        self.assertEqual(report["maximum_measured"], 30)
+        self.assertIsNone(report["score"])
+        self.assertEqual(report["maximum_measured"], 0)
+        self.assertEqual(report["coverage"], 0.0)
 
     def test_checkpoint_time_must_be_ordered(self):
         with self.assertRaises(ValueError):

--- a/bench/test_long_horizon.py
+++ b/bench/test_long_horizon.py
@@ -1,0 +1,52 @@
+import unittest
+
+from long_horizon import score_long_horizon
+
+
+class LongHorizonScoreTests(unittest.TestCase):
+    def test_short_metrics_are_frozen_and_medium_gates_show_the_journey(self):
+        report = score_long_horizon([
+            {"at": 0, "milestones": ["acted"]},
+            {"at": 1800, "milestones": ["acted", "inn"]},
+            {"at": 2400, "milestones": ["acted", "inn", "nanxian", "compass"],
+             "locations": ["home", "inn", "nanxian"],
+             "level": 1, "team_size": 1, "inventory_distinct": 5},
+        ])
+        self.assertTrue(report["short_metrics_unchanged"])
+        self.assertEqual(report["tiers"]["short"]["status"], "frozen_external_metric")
+        self.assertEqual(report["tiers"]["medium"]["score"], 75.0)
+        self.assertEqual(report["tiers"]["long"]["status"], "measured")
+        self.assertEqual(report["tiers"]["long"]["score"], 0.0)
+
+    def test_long_run_without_books_still_has_a_measured_trajectory(self):
+        report = score_long_horizon([
+            {"at": 0, "milestones": ["acted", "inn", "nanxian", "compass"],
+             "locations": ["home", "inn", "nanxian"], "quest_flags": ["opening"],
+             "level": 1, "team_size": 1, "inventory_distinct": 5, "books": []},
+            {"at": 7200, "milestones": ["acted", "inn", "nanxian", "compass",
+                                           "second_location", "battle_won", "skill_gain"],
+             "locations": ["home", "inn", "nanxian", "kunlun", "wudang"],
+             "quest_flags": ["opening", "kunlun_intro", "wudang_intro"],
+             "level": 4, "team_size": 3, "inventory_distinct": 14, "books": []},
+        ])
+        self.assertGreater(report["score"], 0)
+        self.assertEqual(report["components"]["book_collection"]["measured"], True)
+        self.assertEqual(report["components"]["book_collection"]["value"], 0.0)
+        self.assertEqual(report["tiers"]["long"]["score"], 40.0)
+
+    def test_missing_optional_dimensions_are_unmeasured_not_zero(self):
+        report = score_long_horizon([
+            {"at": 0, "milestones": ["acted"]},
+        ])
+        self.assertIsNone(report["components"]["exploration"]["score"])
+        self.assertIsNone(report["components"]["reliability"]["score"])
+        self.assertEqual(report["score"], 11.11)
+        self.assertEqual(report["maximum_measured"], 30)
+
+    def test_checkpoint_time_must_be_ordered(self):
+        with self.assertRaises(ValueError):
+            score_long_horizon([{"at": 2}, {"at": 1}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add an additive long-horizon trajectory report while preserving the frozen short-run benchmark.

The report covers short, medium, and long horizons with guide-backed gates, evidence rules, fixed-denominator scores, and coverage.

## Validation

- python3 -m unittest discover -s bench -p test_*.py
- python3 -m py_compile bench/long_horizon.py

The existing short metrics and paper results are unchanged.