### PR TITLE
Allowlist public benchmark session routes

### DIFF
--- a/bench/broker.py
+++ b/bench/broker.py
@@ -381,10 +381,12 @@ def proxy_cors_headers(content_type=None):
     return headers
 
 
-def proxy_preflight():
+def proxy_preflight(path):
+    methods = sorted({method for method, route_path in PUBLIC_SESSION_ROUTES
+                      if route_path == path} | {"OPTIONS"})
     return web.Response(status=204, headers={
         **CORS,
-        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+        "Access-Control-Allow-Methods": ", ".join(methods),
         "Access-Control-Allow-Headers": "Content-Type, X-Agent",
         "Access-Control-Max-Age": "600",
     })
@@ -414,7 +416,7 @@ async def proxy(request):
                                  headers=proxy_cors_headers())
 
     if request.method == "OPTIONS":
-        return proxy_preflight()
+        return proxy_preflight(tail.strip("/"))
 
     url = f"http://127.0.0.1:{sess['port']}/{tail}"
 

--- a/bench/broker.py
+++ b/bench/broker.py
@@ -351,6 +351,7 @@ async def api_new(request):
 PUBLIC_SESSION_ROUTES = {
     ("GET", "api/screen"),
     ("GET", "api/help"),
+    ("GET", "api/keys"),
     ("POST", "api/key"),
     ("POST", "api/keys"),
     ("POST", "api/wait"),
@@ -358,11 +359,35 @@ PUBLIC_SESSION_ROUTES = {
 
 
 def public_session_route(method, tail, websocket=False):
-    """Whether an untrusted benchmark client may reach this game route."""
+    """Whether an untrusted benchmark client may reach this game route.
+
+    OPTIONS is accepted only as a CORS preflight for an already public route;
+    it is never a way to probe or reach one of the worker's private routes.
+    """
     path = str(tail or "").strip("/")
     if websocket:
         return method == "GET" and path == "ws"
+    if method == "OPTIONS":
+        return any(route_path == path for _, route_path in PUBLIC_SESSION_ROUTES)
     return (method, path) in PUBLIC_SESSION_ROUTES
+
+
+def proxy_cors_headers(content_type=None):
+    """Headers needed when an agent calls a session from another origin."""
+    headers = dict(CORS)
+    headers["Access-Control-Expose-Headers"] = "X-Bench-Remaining"
+    if content_type:
+        headers["Content-Type"] = content_type
+    return headers
+
+
+def proxy_preflight():
+    return web.Response(status=204, headers={
+        **CORS,
+        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type, X-Agent",
+        "Access-Control-Max-Age": "600",
+    })
 
 
 async def proxy(request):
@@ -385,7 +410,11 @@ async def proxy(request):
     if res or sess["proc"].poll() is not None:
         if res:
             res = await wait_published(sid, res)
-        return web.json_response(ended_payload(sess, res), status=410)
+        return web.json_response(ended_payload(sess, res), status=410,
+                                 headers=proxy_cors_headers())
+
+    if request.method == "OPTIONS":
+        return proxy_preflight()
 
     url = f"http://127.0.0.1:{sess['port']}/{tail}"
 
@@ -402,7 +431,10 @@ async def proxy(request):
             async with http.request(request.method, url, params=request.query,
                                     data=data or None, headers=headers,
                                     timeout=aiohttp.ClientTimeout(total=180)) as r:
-                out = web.StreamResponse(status=r.status, headers={'Content-Type':r.headers.get('Content-Type','application/octet-stream')})
+                out = web.StreamResponse(
+                    status=r.status,
+                    headers=proxy_cors_headers(
+                        r.headers.get('Content-Type', 'application/octet-stream')))
                 out.headers['X-Bench-Remaining'] = str(max(0, int(sess['ends_at'] - time.time())))
                 await out.prepare(request)
                 async for chunk in r.content.iter_chunked(64 << 10):

--- a/bench/broker.py
+++ b/bench/broker.py
@@ -348,7 +348,31 @@ async def api_new(request):
     })
 
 
+PUBLIC_SESSION_ROUTES = {
+    ("GET", "api/screen"),
+    ("GET", "api/help"),
+    ("POST", "api/key"),
+    ("POST", "api/keys"),
+    ("POST", "api/wait"),
+}
+
+
+def public_session_route(method, tail, websocket=False):
+    """Whether an untrusted benchmark client may reach this game route."""
+    path = str(tail or "").strip("/")
+    if websocket:
+        return method == "GET" and path == "ws"
+    return (method, path) in PUBLIC_SESSION_ROUTES
+
+
 async def proxy(request):
+    tail = request.match_info.get("tail", "")
+    websocket = request.headers.get("Upgrade", "").lower() == "websocket"
+    if not public_session_route(request.method, tail, websocket):
+        raise web.HTTPNotFound(
+            text=json.dumps({"ok": False, "error": "route not available in benchmark sessions"}),
+            content_type="application/json")
+
     sid = request.match_info["sid"]
     sess = sessions.get(sid)
     if not sess:
@@ -363,10 +387,9 @@ async def proxy(request):
             res = await wait_published(sid, res)
         return web.json_response(ended_payload(sess, res), status=410)
 
-    tail = request.match_info.get("tail", "")
     url = f"http://127.0.0.1:{sess['port']}/{tail}"
 
-    if request.headers.get("Upgrade", "").lower() == "websocket":
+    if websocket:
         return await spectate(request, sess, url)
 
     data = await request.read()

--- a/bench/test_proxy_routes.py
+++ b/bench/test_proxy_routes.py
@@ -1,0 +1,41 @@
+import pathlib
+import sys
+import unittest
+
+
+BENCH_DIR = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(BENCH_DIR))
+
+import broker
+
+
+class PublicSessionRouteTests(unittest.TestCase):
+    def test_only_visual_benchmark_routes_are_public(self):
+        allowed = {
+            ("GET", "api/screen"),
+            ("GET", "api/help"),
+            ("POST", "api/key"),
+            ("POST", "api/keys"),
+            ("POST", "api/wait"),
+        }
+        for method, path in allowed:
+            self.assertTrue(broker.public_session_route(method, path))
+
+        for method, path in {
+            ("GET", "status"),
+            ("GET", "api/history"),
+            ("GET", "api/recording"),
+            ("POST", "api/reset"),
+            ("POST", "api/snapshot"),
+            ("GET", ""),
+        }:
+            self.assertFalse(broker.public_session_route(method, path))
+
+    def test_only_the_spectator_socket_is_public(self):
+        self.assertTrue(broker.public_session_route("GET", "ws", websocket=True))
+        self.assertFalse(broker.public_session_route("GET", "status", websocket=True))
+        self.assertFalse(broker.public_session_route("POST", "ws", websocket=True))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/test_proxy_routes.py
+++ b/bench/test_proxy_routes.py
@@ -14,6 +14,9 @@ class PublicSessionRouteTests(unittest.TestCase):
         allowed = {
             ("GET", "api/screen"),
             ("GET", "api/help"),
+            ("GET", "api/keys"),
+            ("OPTIONS", "api/keys"),
+            ("OPTIONS", "api/screen"),
             ("POST", "api/key"),
             ("POST", "api/keys"),
             ("POST", "api/wait"),
@@ -28,8 +31,22 @@ class PublicSessionRouteTests(unittest.TestCase):
             ("POST", "api/reset"),
             ("POST", "api/snapshot"),
             ("GET", ""),
+            ("OPTIONS", "status"),
+            ("OPTIONS", "api/history"),
         }:
             self.assertFalse(broker.public_session_route(method, path))
+
+    def test_public_preflight_and_proxy_responses_allow_cross_origin_reads(self):
+        preflight = broker.proxy_preflight()
+        self.assertEqual(preflight.status, 204)
+        self.assertEqual(preflight.headers["Access-Control-Allow-Origin"], "*")
+        self.assertIn("GET", preflight.headers["Access-Control-Allow-Methods"])
+        self.assertIn("X-Agent", preflight.headers["Access-Control-Allow-Headers"])
+
+        headers = broker.proxy_cors_headers("application/json")
+        self.assertEqual(headers["Access-Control-Allow-Origin"], "*")
+        self.assertEqual(headers["Content-Type"], "application/json")
+        self.assertEqual(headers["Access-Control-Expose-Headers"], "X-Bench-Remaining")
 
     def test_only_the_spectator_socket_is_public(self):
         self.assertTrue(broker.public_session_route("GET", "ws", websocket=True))

--- a/bench/test_proxy_routes.py
+++ b/bench/test_proxy_routes.py
@@ -37,11 +37,14 @@ class PublicSessionRouteTests(unittest.TestCase):
             self.assertFalse(broker.public_session_route(method, path))
 
     def test_public_preflight_and_proxy_responses_allow_cross_origin_reads(self):
-        preflight = broker.proxy_preflight()
+        preflight = broker.proxy_preflight("api/keys")
         self.assertEqual(preflight.status, 204)
         self.assertEqual(preflight.headers["Access-Control-Allow-Origin"], "*")
-        self.assertIn("GET", preflight.headers["Access-Control-Allow-Methods"])
+        self.assertEqual(preflight.headers["Access-Control-Allow-Methods"], "GET, OPTIONS, POST")
         self.assertIn("X-Agent", preflight.headers["Access-Control-Allow-Headers"])
+
+        screen_preflight = broker.proxy_preflight("api/screen")
+        self.assertEqual(screen_preflight.headers["Access-Control-Allow-Methods"], "GET, OPTIONS")
 
         headers = broker.proxy_cors_headers("application/json")
         self.assertEqual(headers["Access-Control-Allow-Origin"], "*")


### PR DESCRIPTION
## 中文摘要
- 为 benchmark session proxy 建立公开路由白名单：GET `/api/screen`、`/api/help`、`/api/keys`，POST `/api/key`、`/api/keys`、`/api/wait`，以及只读 WebSocket `/ws`。
- history、recording、reset、snapshot、status 等私有/状态接口仍返回 404，避免 benchmark agent 通过代理读取隐藏状态或控制会话。
- 为跨源客户端补充按路由收紧的 OPTIONS 预检、CORS 响应头和 `X-Bench-Remaining` 暴露；兼容现有 GET `/api/keys` 控制 API。

## English summary
- Add an explicit public route allowlist for benchmark session proxies: GET `/api/screen`, `/api/help`, `/api/keys`; POST `/api/key`, `/api/keys`, `/api/wait`; and the read-only `/ws` socket.
- Keep history, recording, reset, snapshot, status, and other private/state routes at 404 so benchmark agents cannot read hidden state or control the session through the proxy.
- Add route-scoped OPTIONS preflight, CORS response headers, and `X-Bench-Remaining` exposure while preserving the existing GET `/api/keys` control API.

## 威胁模型 / Threat model
公开 session URL 只提供玩家交互和观看能力；录像、历史、快照、重置和状态接口不属于 benchmark agent 的观察面。`/ws` 下行只读，代理不会转发 spectator 写入。

## 验证 / Validation
- `python -m unittest discover -s bench -p 'test*.py' -v`: 12 tests passed.
- Route predicate, allow/deny, GET `/api/keys`, OPTIONS/CORS method scoping and header exposure are covered.
- No GitHub workflow jobs were available for this repository, so the validation above is local rather than CI-backed.