### PR TITLE
server: record private trajectory observations for offline analysis

### DIFF
--- a/Scripts/analyze_trajectory.py
+++ b/Scripts/analyze_trajectory.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Analyze action timing and optional position samples in a saved recording."""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "server"))
+from trajectory import analyze  # noqa: E402
+
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("recording", type=Path)
+parser.add_argument("--window", type=int, default=25)
+args = parser.parse_args()
+if args.window < 1:
+    parser.error("--window must be positive")
+print(json.dumps(analyze(args.recording, window_size=args.window),
+                 ensure_ascii=False, indent=2))
+

--- a/Scripts/analyze_trajectory.py
+++ b/Scripts/analyze_trajectory.py
@@ -17,4 +17,3 @@ if args.window < 1:
     parser.error("--window must be positive")
 print(json.dumps(analyze(args.recording, window_size=args.window),
                  ensure_ascii=False, indent=2))
-

--- a/server/README.md
+++ b/server/README.md
@@ -321,27 +321,6 @@ long pauses, reversals, screen-change ratio, and position distance/frontier
 regressions when coordinates are available. Comparing the windows shows
 whether later movement is becoming steadier; the `position-unmeasured` status
 marks runs where only action-level smoothness can be assessed.
-
-
-## Recording files and reset archives
-
-Interactive servers expose `GET /api/recordings` with a `files` list containing
-the current recording and reset archives, including their IDs, filenames and
-byte sizes. `GET /api/recordings/{id}` downloads the original JSONL as an
-attachment. Single byte ranges, open-ended ranges, suffix ranges and `If-Range`
-are supported so a large download can resume. Each response pins its file
-descriptor and byte length before streaming; a concurrent reset or append does
-not change the bytes in that response.
-
-To replay an archive, start the existing paged reader with
-`/api/recording?view=paged&recording={id}`. Continue with the returned token and
-cursor as usual; subsequent requests keep the same snapshot. `current` remains
-the default. Archive IDs must match `YYYYMMDD-HHMMSS-<12 lowercase hex>.jsonl`
-inside the recording's `recordings/` directory. Symbolic links and other file
-types are refused. Archives are opened read-only, and their replay duration is
-recovered from a bounded file tail without opening another recording writer.
-
-In benchmark mode, the file-list and download routes are absent and archive
-selection is rejected. The existing current-recording endpoint and benchmark
-accounting remain unchanged. These file selectors do not change the source of
-the right-hand screenshot history.
+Trajectory events are recorder-only data: benchmark callers can continue to
+read the ordinary action/frame journal, while the coordinate-bearing events
+are filtered from their recording endpoint responses.

--- a/server/README.md
+++ b/server/README.md
@@ -299,3 +299,47 @@ The optional `server/import_activity.py` command can seed that **realtime
 cache** while the server is stopped. This import is optional and not needed to browse complete disk history.
 It preserves the recording and labels reconstructed previews with their source
 and frame time; existing original thumbnails take priority.
+
+### Trajectory analysis
+
+Every completed input action now has a post-action `trajectory` event in the
+JSONL recording. It carries the action number, original recording time, scene,
+frontier, and whether the settled picture changed. When position offsets have
+been calibrated for that worker it also carries the game's `x` and `y`; a
+missing coordinate is explicit and is never interpreted as zero distance.
+
+The raw recording can be analyzed without starting the game:
+
+```sh
+python3 Scripts/analyze_trajectory.py /path/to/recording.jsonl --window 25
+```
+
+The JSON result includes per-action rows, early/later windows, action gaps,
+long pauses, reversals, screen-change ratio, and position distance/frontier
+regressions when coordinates are available. Comparing the windows shows
+whether later movement is becoming steadier; the `position-unmeasured` status
+marks runs where only action-level smoothness can be assessed.
+
+
+## Recording files and reset archives
+
+Interactive servers expose `GET /api/recordings` with a `files` list containing
+the current recording and reset archives, including their IDs, filenames and
+byte sizes. `GET /api/recordings/{id}` downloads the original JSONL as an
+attachment. Single byte ranges, open-ended ranges, suffix ranges and `If-Range`
+are supported so a large download can resume. Each response pins its file
+descriptor and byte length before streaming; a concurrent reset or append does
+not change the bytes in that response.
+
+To replay an archive, start the existing paged reader with
+`/api/recording?view=paged&recording={id}`. Continue with the returned token and
+cursor as usual; subsequent requests keep the same snapshot. `current` remains
+the default. Archive IDs must match `YYYYMMDD-HHMMSS-<12 lowercase hex>.jsonl`
+inside the recording's `recordings/` directory. Symbolic links and other file
+types are refused. Archives are opened read-only, and their replay duration is
+recovered from a bounded file tail without opening another recording writer.
+
+In benchmark mode, the file-list and download routes are absent and archive
+selection is rejected. The existing current-recording endpoint and benchmark
+accounting remain unchanged. These file selectors do not change the source of
+the right-hand screenshot history.

--- a/server/README.md
+++ b/server/README.md
@@ -306,7 +306,9 @@ Every completed input action now has a post-action `trajectory` event in the
 JSONL recording. It carries the action number, original recording time, scene,
 frontier, and whether the settled picture changed. When position offsets have
 been calibrated for that worker it also carries the game's `x` and `y`; a
-missing coordinate is explicit and is never interpreted as zero distance.
+missing coordinate is explicit and is never interpreted as zero distance. The
+event also stores the source action timestamp, so analysis remains correct
+when a worker restarts and its local action counter starts over.
 
 The raw recording can be analyzed without starting the game:
 

--- a/server/README.md
+++ b/server/README.md
@@ -318,8 +318,10 @@ python3 Scripts/analyze_trajectory.py /path/to/recording.jsonl --window 25
 
 The JSON result includes per-action rows, early/later windows, action gaps,
 long pauses, reversals, screen-change ratio, and position distance/frontier
-regressions when coordinates are available. Comparing the windows shows
-whether later movement is becoming steadier; the `position-unmeasured` status
+regressions when coordinates are available. These are descriptive indicators, not a route-quality score. Distances
+only join consecutive samples in the same recorded scene; missing samples
+and scene changes break the path. Calibration remains off by default, so
+this change does not by itself provide reliable live coordinates. The the `position-unmeasured` status
 marks runs where only action-level smoothness can be assessed.
 Trajectory events are recorder-only data: benchmark callers can continue to
 read the ordinary action/frame journal, while the coordinate-bearing events

--- a/server/index.html
+++ b/server/index.html
@@ -267,7 +267,7 @@
   #historyrows { flex: none; overflow: visible; padding: 3px 0; }
   #historynav { position: relative; z-index: 2; display: flex; align-items: center; justify-content: space-between; gap: 6px; padding: 8px 12px; border-top: 1px solid #26262c; background: #101014; }
   #historynav button { padding: 4px 7px; font-size: 10px; }
-  #historypage { width: 3.5em; padding: 3px 4px; font: inherit; font-size: 10px; text-align: center; }
+  #historypage { width: 5em; padding: 3px 4px; font: inherit; font-size: 11px; text-align: center; }
   #historypages { color: #818190; font-size: 10px; white-space: nowrap; }
   #historyrange { color: #818190; font-size: 10px; }
   .saved-row { padding: 8px 12px 10px; border-bottom: 1px solid #202028; }

--- a/server/index.html
+++ b/server/index.html
@@ -263,7 +263,7 @@
   #timeline { flex: 1; min-height: 0; overflow-y: auto; }
   #logrows { flex: none; overflow: visible; }
   #historyinfo { margin-left: 5px; font-size: 10px; color: #818190; }
-  #historypane { display: contents; }
+  #historypane { display: block; }
   #historyrows { flex: none; overflow: visible; padding: 3px 0; }
   #historynav { position: sticky; bottom: 0; z-index: 2; display: flex; align-items: center; justify-content: space-between; gap: 6px; padding: 8px 12px; border-top: 1px solid #26262c; background: #101014; }
   #historynav button { padding: 4px 7px; font-size: 10px; }

--- a/server/index.html
+++ b/server/index.html
@@ -266,13 +266,14 @@
   #historyinfo { margin-left: 5px; font-size: 10px; color: #818190; }
   #historypane { display: block; }
   #historyrows { flex: none; overflow: visible; padding: 3px 0; }
-  #historynav { position: relative; z-index: 2; display: flex; flex-wrap: wrap; align-items: center; justify-content: flex-start; gap: 6px; padding: 8px 12px; border-top: 1px solid #26262c; background: #101014; }
+  #historynav { position: relative; z-index: 2; display: flex; flex-wrap: wrap; align-items: center; gap: 6px; padding: 8px 12px; border-top: 1px solid #26262c; background: #101014; }
+  #historycontrols { display: flex; align-items: center; gap: 6px; min-width: 0; }
   #historynav button { padding: 4px 7px; font-size: 10px; }
   #historypage { width: 5em; padding: 3px 4px; font: inherit; font-size: 11px; text-align: center; }
   #historysize { width: 4.2em; padding: 3px 2px; font: inherit; font-size: 11px; }
-  #historypages { color: #818190; font-size: 10px; white-space: nowrap; }
-  #historyrange { color: #818190; font-size: 10px; white-space: nowrap; flex: 1 0 auto; }
-  #historynav label { white-space: nowrap; margin-left: auto; color: #818190; font-size: 10px; }
+  #historypages { color: #818190; font-size: 10px; white-space: nowrap; min-width: 2.8em; text-align: center; }
+  #historyrange { color: #818190; font-size: 10px; white-space: nowrap; flex: 1 0 100%; }
+  #historynav label { white-space: nowrap; color: #818190; font-size: 10px; margin-left: 2px; }
   .saved-row { padding: 8px 12px 10px; border-bottom: 1px solid #202028; }
   .saved-meta { display: flex; justify-content: space-between; gap: 5px; font-size: 10px; color: #707080; margin-bottom: 4px; }
   .saved-who { color: #8ecdf7; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 160px; }
@@ -286,7 +287,7 @@
   .history-empty { padding: 15px 12px; color: #9292a0; font-size: 11px; }
 
 </style>
-<script defer src="saved-history.js?v=timeline6" data-history-enabled="auto"></script>
+<script defer src="saved-history.js?v=timeline7" data-history-enabled="auto"></script>
 
 <div id="app">
 <div id="main">
@@ -390,7 +391,7 @@
   </div>
   <div id="bars"></div>
   <div id="activityheader" aria-label="活动时间线"><span>活动时间线</span><span id="historyinfo"></span></div>
-  <div id="historynav"><button id="historyfirst" title="最早的截图" disabled>«</button><button id="historyprev" title="上一页" disabled>‹</button><input id="historypage" type="text" inputmode="numeric" autocomplete="off" aria-label="历史页码" disabled><span>/ <span id="historypages">—</span></span><button id="historynext" title="下一页" disabled>›</button><button id="historylatest" title="最新 / 刷新" disabled>»</button><span id="historyrange"></span><label>每页 <select id="historysize" aria-label="每页条数" disabled><option value="8">8</option><option value="16">16</option><option value="32">32</option><option value="64">64</option></select></label></div>
+  <div id="historynav"><div id="historycontrols"><button id="historyfirst" title="最早的截图" disabled>«</button><button id="historyprev" title="上一页" disabled>‹</button><input id="historypage" type="text" inputmode="numeric" autocomplete="off" aria-label="历史页码" disabled><span>/ <span id="historypages">—</span></span><button id="historynext" title="下一页" disabled>›</button><button id="historylatest" title="最新 / 刷新" disabled>»</button><label>每页 <select id="historysize" aria-label="每页条数" disabled><option value="8">8</option><option value="16">16</option><option value="32">32</option><option value="64">64</option></select></label></div><span id="historyrange"></span></div>
   <div id="timeline" aria-label="活动时间线">
     <div id="historypane">
       <div id="historyrows"><div class="history-empty">正在读取截图…</div></div>

--- a/server/index.html
+++ b/server/index.html
@@ -262,6 +262,7 @@
   #image-jump { margin: 0 12px 8px; align-self: flex-start; font: inherit; font-size: 11px; padding: 4px 8px; }
   #timeline { flex: 1; min-height: 0; overflow-y: auto; }
   #logrows { flex: none; overflow: visible; }
+  #activityheader { display: flex; justify-content: space-between; padding: 9px 12px; border-bottom: 1px solid #26262c; color: #a6d5ff; font-size: 11px; flex: none; }
   #historyinfo { margin-left: 5px; font-size: 10px; color: #818190; }
   #historypane { display: block; }
   #historyrows { flex: none; overflow: visible; padding: 3px 0; }
@@ -386,6 +387,7 @@
     <span>web <b id="m-web">0</b></span>
   </div>
   <div id="bars"></div>
+  <div id="activityheader" aria-label="活动时间线"><span>活动时间线</span><span id="historyinfo"></span></div>
   <div id="historynav"><button id="historyfirst" title="最早的截图" disabled>«</button><button id="historyprev" title="上一页" disabled>‹</button><input id="historypage" type="text" inputmode="numeric" autocomplete="off" aria-label="历史页码" disabled><span>/ <span id="historypages">—</span></span><button id="historynext" title="下一页" disabled>›</button><button id="historylatest" title="最新 / 刷新" disabled>»</button><span id="historyrange"></span></div>
   <div id="timeline" aria-label="活动时间线">
     <div id="historypane">
@@ -1016,6 +1018,14 @@ function clearLog() {
 function addLog(e) {
   if (e.id <= lastId) return;             // reconnects resend recent backlog
   lastId = e.id;
+  // Saved-history.js owns the visible feed when disk history is available.
+  // Keep the websocket only as a refresh signal; appending the same entries
+  // here would recreate the second, unpaginated list underneath it.
+  if (globalThis.__savedHistoryEnabled) {
+    logcount.textContent = ++logged;
+    dispatchEvent(new Event("activityrecorded"));
+    return;
+  }
   empty?.remove();
   const d = new Date(e.at * 1000);
   const ts = [d.getHours(), d.getMinutes(), d.getSeconds()]
@@ -1061,14 +1071,17 @@ function addLog(e) {
       ? "Nearest recorded frame before this action" + (e.thumb_at ? " · " + new Date(e.thumb_at * 1000).toLocaleString() : "")
       : "what the API returned";
     img.onclick = () => window.open(e.thumb, "_blank");
-    img.onload = () => { timeline.scrollTop = timeline.scrollHeight; };
+    img.onload = () => {
+      if (!globalThis.__savedHistoryEnabled) timeline.scrollTop = timeline.scrollHeight;
+    };
     box.append(img);
     rows.appendChild(box);
   }
   while (rows.children.length > 400) rows.firstChild.remove();
-  timeline.scrollTop = timeline.scrollHeight;
+  if (!globalThis.__savedHistoryEnabled) timeline.scrollTop = timeline.scrollHeight;
   logcount.textContent = ++logged;
   updateImageJump();
+  dispatchEvent(new Event("activityrecorded"));
 }
 
 const send = o => {

--- a/server/index.html
+++ b/server/index.html
@@ -265,7 +265,7 @@
   #historyinfo { margin-left: 5px; font-size: 10px; color: #818190; }
   #historypane { display: block; }
   #historyrows { flex: none; overflow: visible; padding: 3px 0; }
-  #historynav { position: sticky; bottom: 0; z-index: 2; display: flex; align-items: center; justify-content: space-between; gap: 6px; padding: 8px 12px; border-top: 1px solid #26262c; background: #101014; }
+  #historynav { position: relative; z-index: 2; display: flex; align-items: center; justify-content: space-between; gap: 6px; padding: 8px 12px; border-top: 1px solid #26262c; background: #101014; }
   #historynav button { padding: 4px 7px; font-size: 10px; }
   #historypage { width: 3.5em; padding: 3px 4px; font: inherit; font-size: 10px; text-align: center; }
   #historypages { color: #818190; font-size: 10px; white-space: nowrap; }
@@ -386,10 +386,10 @@
     <span>web <b id="m-web">0</b></span>
   </div>
   <div id="bars"></div>
+  <div id="historynav"><button id="historyfirst" title="最早的截图" disabled>«</button><button id="historyprev" title="上一页" disabled>‹</button><input id="historypage" type="number" min="1" inputmode="numeric" aria-label="历史页码" disabled><span>/ <span id="historypages">—</span></span><button id="historynext" title="下一页" disabled>›</button><button id="historylatest" title="最新 / 刷新" disabled>»</button><span id="historyrange"></span></div>
   <div id="timeline" aria-label="活动时间线">
     <div id="historypane">
       <div id="historyrows"><div class="history-empty">正在读取截图…</div></div>
-      <div id="historynav"><button id="historyfirst" title="最早的截图" disabled>«</button><button id="historyprev" title="上一页" disabled>‹</button><input id="historypage" type="number" min="1" inputmode="numeric" aria-label="历史页码" disabled><span>/ <span id="historypages">—</span></span><button id="historynext" title="下一页" disabled>›</button><button id="historylatest" title="最新 / 刷新" disabled>»</button><span id="historyrange"></span></div>
     </div>
     <button id="image-jump" hidden>Show latest image</button>
     <div id="logrows"><div id="empty">nothing yet. keys you press here, and calls

--- a/server/index.html
+++ b/server/index.html
@@ -261,9 +261,10 @@
   #meter { color: #8b8b99; }
   #image-jump { margin: 0 12px 8px; align-self: flex-start; font: inherit; font-size: 11px; padding: 4px 8px; }
   #timeline { flex: 1; min-height: 0; overflow-y: auto; }
+  #logrows { flex: none; overflow: visible; }
   #historyinfo { margin-left: 5px; font-size: 10px; color: #818190; }
   #historypane { display: contents; }
-  #historyrows { padding: 3px 0; }
+  #historyrows { flex: none; overflow: visible; padding: 3px 0; }
   #historynav { position: sticky; bottom: 0; z-index: 2; display: flex; align-items: center; justify-content: space-between; gap: 6px; padding: 8px 12px; border-top: 1px solid #26262c; background: #101014; }
   #historynav button { padding: 4px 7px; font-size: 10px; }
   #historypage { width: 3.5em; padding: 3px 4px; font: inherit; font-size: 10px; text-align: center; }

--- a/server/index.html
+++ b/server/index.html
@@ -264,7 +264,7 @@
   #historyinfo { margin-left: 5px; font-size: 10px; color: #818190; }
   #historypane { display: contents; }
   #historyrows { padding: 3px 0; }
-  #historynav { display: flex; align-items: center; justify-content: space-between; gap: 6px; padding: 8px 12px; border-top: 1px solid #26262c; }
+  #historynav { position: sticky; bottom: 0; z-index: 2; display: flex; align-items: center; justify-content: space-between; gap: 6px; padding: 8px 12px; border-top: 1px solid #26262c; background: #101014; }
   #historynav button { padding: 4px 7px; font-size: 10px; }
   #historypage { width: 3.5em; padding: 3px 4px; font: inherit; font-size: 10px; text-align: center; }
   #historypages { color: #818190; font-size: 10px; white-space: nowrap; }

--- a/server/index.html
+++ b/server/index.html
@@ -266,6 +266,8 @@
   #historyrows { padding: 3px 0; }
   #historynav { display: flex; align-items: center; justify-content: space-between; gap: 6px; padding: 8px 12px; border-top: 1px solid #26262c; }
   #historynav button { padding: 4px 7px; font-size: 10px; }
+  #historypage { width: 3.5em; padding: 3px 4px; font: inherit; font-size: 10px; text-align: center; }
+  #historypages { color: #818190; font-size: 10px; white-space: nowrap; }
   #historyrange { color: #818190; font-size: 10px; }
   .saved-row { padding: 8px 12px 10px; border-bottom: 1px solid #202028; }
   .saved-meta { display: flex; justify-content: space-between; gap: 5px; font-size: 10px; color: #707080; margin-bottom: 4px; }
@@ -386,7 +388,7 @@
   <div id="timeline" aria-label="活动时间线">
     <div id="historypane">
       <div id="historyrows"><div class="history-empty">正在读取截图…</div></div>
-      <div id="historynav"><button id="historyfirst" title="最早的截图" disabled>«</button><button id="historyprev" disabled>← 更早</button><span id="historyrange"></span><button id="historynext" disabled>更晚 →</button><button id="historylatest" title="最新 / 刷新" disabled>↻</button></div>
+      <div id="historynav"><button id="historyfirst" title="最早的截图" disabled>«</button><button id="historyprev" title="上一页" disabled>‹</button><input id="historypage" type="number" min="1" inputmode="numeric" aria-label="历史页码" disabled><span>/ <span id="historypages">—</span></span><button id="historynext" title="下一页" disabled>›</button><button id="historylatest" title="最新 / 刷新" disabled>»</button><span id="historyrange"></span></div>
     </div>
     <button id="image-jump" hidden>Show latest image</button>
     <div id="logrows"><div id="empty">nothing yet. keys you press here, and calls

--- a/server/index.html
+++ b/server/index.html
@@ -260,13 +260,11 @@
   #side h2 { flex: none; }
   #meter { color: #8b8b99; }
   #image-jump { margin: 0 12px 8px; align-self: flex-start; font: inherit; font-size: 11px; padding: 4px 8px; }
-  #activitytabs { display: flex; gap: 14px; padding: 0 12px; border-bottom: 1px solid #26262c; flex: none; }
-  #activitytabs button { padding: 9px 0; font-size: 11px; border: 0; border-radius: 0; background: none; color: #7e7e8e; }
-  #activitytabs button[aria-selected=true] { color: #a6d5ff; box-shadow: inset 0 -2px #7fc7ff; }
+  #timeline { flex: 1; min-height: 0; overflow-y: auto; }
   #historyinfo { margin-left: 5px; font-size: 10px; color: #818190; }
-  #historypane { display: flex; flex-direction: column; flex: 1; min-height: 0; }
-  #historyrows { overflow-y: auto; flex: 1; min-height: 0; padding: 3px 0; }
-  #historynav { display: flex; align-items: center; justify-content: space-between; gap: 6px; padding: 8px 12px; border-top: 1px solid #26262c; flex: none; }
+  #historypane { display: contents; }
+  #historyrows { padding: 3px 0; }
+  #historynav { display: flex; align-items: center; justify-content: space-between; gap: 6px; padding: 8px 12px; border-top: 1px solid #26262c; }
   #historynav button { padding: 4px 7px; font-size: 10px; }
   #historyrange { color: #818190; font-size: 10px; }
   .saved-row { padding: 8px 12px 10px; border-bottom: 1px solid #202028; }
@@ -385,17 +383,15 @@
     <span>web <b id="m-web">0</b></span>
   </div>
   <div id="bars"></div>
-  <div id="activitytabs" role="tablist" aria-label="活动记录">
-    <button id="historytab" role="tab" aria-selected="true" aria-controls="historypane">历史截图<span id="historyinfo"></span></button>
-    <button id="livetab" role="tab" aria-selected="false" aria-controls="logrows">实时活动</button>
-  </div>
-  <div id="historypane" role="tabpanel" aria-labelledby="historytab">
-    <div id="historyrows"><div class="history-empty">正在读取截图…</div></div>
-    <div id="historynav"><button id="historyfirst" title="最早的截图" disabled>«</button><button id="historyprev" disabled>← 更早</button><span id="historyrange"></span><button id="historynext" disabled>更晚 →</button><button id="historylatest" title="最新 / 刷新" disabled>↻</button></div>
-  </div>
-  <button id="image-jump" hidden>Show latest image</button>
-  <div id="logrows" role="tabpanel" aria-labelledby="livetab" hidden><div id="empty">nothing yet. keys you press here, and calls
+  <div id="timeline" aria-label="活动时间线">
+    <div id="historypane">
+      <div id="historyrows"><div class="history-empty">正在读取截图…</div></div>
+      <div id="historynav"><button id="historyfirst" title="最早的截图" disabled>«</button><button id="historyprev" disabled>← 更早</button><span id="historyrange"></span><button id="historynext" disabled>更晚 →</button><button id="historylatest" title="最新 / 刷新" disabled>↻</button></div>
+    </div>
+    <button id="image-jump" hidden>Show latest image</button>
+    <div id="logrows"><div id="empty">nothing yet. keys you press here, and calls
     to /api/*, both show up.</div></div>
+  </div>
 </aside>
 </div>
 
@@ -676,6 +672,7 @@ function connect() {
 }
 
 const rows = document.getElementById("logrows");
+const timeline = document.getElementById("timeline");
 const empty = document.getElementById("empty");
 const logcount = document.getElementById("logcount");
 const imageJump = document.getElementById("image-jump");
@@ -1061,12 +1058,12 @@ function addLog(e) {
       ? "Nearest recorded frame before this action" + (e.thumb_at ? " · " + new Date(e.thumb_at * 1000).toLocaleString() : "")
       : "what the API returned";
     img.onclick = () => window.open(e.thumb, "_blank");
-    img.onload = () => { rows.scrollTop = rows.scrollHeight; };
+    img.onload = () => { timeline.scrollTop = timeline.scrollHeight; };
     box.append(img);
     rows.appendChild(box);
   }
   while (rows.children.length > 400) rows.firstChild.remove();
-  rows.scrollTop = rows.scrollHeight;
+  timeline.scrollTop = timeline.scrollHeight;
   logcount.textContent = ++logged;
   updateImageJump();
 }

--- a/server/index.html
+++ b/server/index.html
@@ -266,11 +266,13 @@
   #historyinfo { margin-left: 5px; font-size: 10px; color: #818190; }
   #historypane { display: block; }
   #historyrows { flex: none; overflow: visible; padding: 3px 0; }
-  #historynav { position: relative; z-index: 2; display: flex; align-items: center; justify-content: space-between; gap: 6px; padding: 8px 12px; border-top: 1px solid #26262c; background: #101014; }
+  #historynav { position: relative; z-index: 2; display: flex; flex-wrap: wrap; align-items: center; justify-content: flex-start; gap: 6px; padding: 8px 12px; border-top: 1px solid #26262c; background: #101014; }
   #historynav button { padding: 4px 7px; font-size: 10px; }
   #historypage { width: 5em; padding: 3px 4px; font: inherit; font-size: 11px; text-align: center; }
+  #historysize { width: 4.2em; padding: 3px 2px; font: inherit; font-size: 11px; }
   #historypages { color: #818190; font-size: 10px; white-space: nowrap; }
-  #historyrange { color: #818190; font-size: 10px; }
+  #historyrange { color: #818190; font-size: 10px; white-space: nowrap; flex: 1 0 auto; }
+  #historynav label { white-space: nowrap; margin-left: auto; color: #818190; font-size: 10px; }
   .saved-row { padding: 8px 12px 10px; border-bottom: 1px solid #202028; }
   .saved-meta { display: flex; justify-content: space-between; gap: 5px; font-size: 10px; color: #707080; margin-bottom: 4px; }
   .saved-who { color: #8ecdf7; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 160px; }
@@ -284,7 +286,7 @@
   .history-empty { padding: 15px 12px; color: #9292a0; font-size: 11px; }
 
 </style>
-<script defer src="saved-history.js?v=timeline4" data-history-enabled="auto"></script>
+<script defer src="saved-history.js?v=timeline6" data-history-enabled="auto"></script>
 
 <div id="app">
 <div id="main">
@@ -388,7 +390,7 @@
   </div>
   <div id="bars"></div>
   <div id="activityheader" aria-label="活动时间线"><span>活动时间线</span><span id="historyinfo"></span></div>
-  <div id="historynav"><button id="historyfirst" title="最早的截图" disabled>«</button><button id="historyprev" title="上一页" disabled>‹</button><input id="historypage" type="text" inputmode="numeric" autocomplete="off" aria-label="历史页码" disabled><span>/ <span id="historypages">—</span></span><button id="historynext" title="下一页" disabled>›</button><button id="historylatest" title="最新 / 刷新" disabled>»</button><span id="historyrange"></span></div>
+  <div id="historynav"><button id="historyfirst" title="最早的截图" disabled>«</button><button id="historyprev" title="上一页" disabled>‹</button><input id="historypage" type="text" inputmode="numeric" autocomplete="off" aria-label="历史页码" disabled><span>/ <span id="historypages">—</span></span><button id="historynext" title="下一页" disabled>›</button><button id="historylatest" title="最新 / 刷新" disabled>»</button><span id="historyrange"></span><label>每页 <select id="historysize" aria-label="每页条数" disabled><option value="8">8</option><option value="16">16</option><option value="32">32</option><option value="64">64</option></select></label></div>
   <div id="timeline" aria-label="活动时间线">
     <div id="historypane">
       <div id="historyrows"><div class="history-empty">正在读取截图…</div></div>

--- a/server/index.html
+++ b/server/index.html
@@ -266,13 +266,15 @@
   #historyinfo { margin-left: 5px; font-size: 10px; color: #818190; }
   #historypane { display: block; }
   #historyrows { flex: none; overflow: visible; padding: 3px 0; }
-  #historynav { position: relative; z-index: 2; display: flex; flex-wrap: wrap; align-items: center; gap: 6px; padding: 8px 12px; border-top: 1px solid #26262c; background: #101014; }
-  #historycontrols { display: flex; align-items: center; gap: 6px; min-width: 0; }
+  #historynav { position: relative; z-index: 2; display: flex; flex-direction: column; align-items: stretch; gap: 4px; padding: 8px 12px; border-top: 1px solid #26262c; background: #101014; }
+  #historycontrols { display: flex; align-items: center; gap: 6px; width: 100%; }
   #historynav button { padding: 4px 7px; font-size: 10px; }
-  #historypage { width: 5em; padding: 3px 4px; font: inherit; font-size: 11px; text-align: center; }
+  #historypage { width: 8em; min-width: 8em; padding: 3px 4px; font: inherit; font-size: 11px; text-align: center; }
   #historysize { width: 4.2em; padding: 3px 2px; font: inherit; font-size: 11px; }
-  #historypages { color: #818190; font-size: 10px; white-space: nowrap; min-width: 2.8em; text-align: center; }
-  #historyrange { color: #818190; font-size: 10px; white-space: nowrap; flex: 1 0 100%; }
+  #historysummary { display: flex; align-items: center; gap: 8px; width: 100%; min-width: 0; }
+  #historytotal { color: #818190; font-size: 10px; white-space: nowrap; }
+  #historypages { min-width: 3.5em; text-align: center; }
+  #historyrange { color: #818190; font-size: 10px; white-space: nowrap; flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; text-align: right; }
   #historynav label { white-space: nowrap; color: #818190; font-size: 10px; margin-left: 2px; }
   .saved-row { padding: 8px 12px 10px; border-bottom: 1px solid #202028; }
   .saved-meta { display: flex; justify-content: space-between; gap: 5px; font-size: 10px; color: #707080; margin-bottom: 4px; }
@@ -287,7 +289,7 @@
   .history-empty { padding: 15px 12px; color: #9292a0; font-size: 11px; }
 
 </style>
-<script defer src="saved-history.js?v=timeline7" data-history-enabled="auto"></script>
+<script defer src="saved-history.js?v=timeline8" data-history-enabled="auto"></script>
 
 <div id="app">
 <div id="main">
@@ -391,7 +393,7 @@
   </div>
   <div id="bars"></div>
   <div id="activityheader" aria-label="活动时间线"><span>活动时间线</span><span id="historyinfo"></span></div>
-  <div id="historynav"><div id="historycontrols"><button id="historyfirst" title="最早的截图" disabled>«</button><button id="historyprev" title="上一页" disabled>‹</button><input id="historypage" type="text" inputmode="numeric" autocomplete="off" aria-label="历史页码" disabled><span>/ <span id="historypages">—</span></span><button id="historynext" title="下一页" disabled>›</button><button id="historylatest" title="最新 / 刷新" disabled>»</button><label>每页 <select id="historysize" aria-label="每页条数" disabled><option value="8">8</option><option value="16">16</option><option value="32">32</option><option value="64">64</option></select></label></div><span id="historyrange"></span></div>
+  <div id="historynav"><div id="historycontrols"><button id="historyfirst" title="最早的截图" disabled>«</button><button id="historyprev" title="上一页" disabled>‹</button><input id="historypage" type="text" inputmode="numeric" autocomplete="off" aria-label="历史页码" disabled><button id="historynext" title="下一页" disabled>›</button><button id="historylatest" title="最新 / 刷新" disabled>»</button><label>每页 <select id="historysize" aria-label="每页条数" disabled><option value="8">8</option><option value="16">16</option><option value="32">32</option><option value="64">64</option></select></label></div><div id="historysummary"><span id="historytotal">共 <span id="historypages">—</span> 页</span><span id="historyrange"></span></div></div>
   <div id="timeline" aria-label="活动时间线">
     <div id="historypane">
       <div id="historyrows"><div class="history-empty">正在读取截图…</div></div>

--- a/server/index.html
+++ b/server/index.html
@@ -284,7 +284,7 @@
   .history-empty { padding: 15px 12px; color: #9292a0; font-size: 11px; }
 
 </style>
-<script defer src="saved-history.js?v=timeline3" data-history-enabled="auto"></script>
+<script defer src="saved-history.js?v=timeline4" data-history-enabled="auto"></script>
 
 <div id="app">
 <div id="main">
@@ -394,7 +394,7 @@
       <div id="historyrows"><div class="history-empty">正在读取截图…</div></div>
     </div>
     <button id="image-jump" hidden>Show latest image</button>
-    <div id="logrows"><div id="empty">nothing yet. keys you press here, and calls
+    <div id="logrows" hidden><div id="empty">nothing yet. keys you press here, and calls
     to /api/*, both show up.</div></div>
   </div>
 </aside>

--- a/server/index.html
+++ b/server/index.html
@@ -386,7 +386,7 @@
     <span>web <b id="m-web">0</b></span>
   </div>
   <div id="bars"></div>
-  <div id="historynav"><button id="historyfirst" title="最早的截图" disabled>«</button><button id="historyprev" title="上一页" disabled>‹</button><input id="historypage" type="number" min="1" inputmode="numeric" aria-label="历史页码" disabled><span>/ <span id="historypages">—</span></span><button id="historynext" title="下一页" disabled>›</button><button id="historylatest" title="最新 / 刷新" disabled>»</button><span id="historyrange"></span></div>
+  <div id="historynav"><button id="historyfirst" title="最早的截图" disabled>«</button><button id="historyprev" title="上一页" disabled>‹</button><input id="historypage" type="text" inputmode="numeric" autocomplete="off" aria-label="历史页码" disabled><span>/ <span id="historypages">—</span></span><button id="historynext" title="下一页" disabled>›</button><button id="historylatest" title="最新 / 刷新" disabled>»</button><span id="historyrange"></span></div>
   <div id="timeline" aria-label="活动时间线">
     <div id="historypane">
       <div id="historyrows"><div class="history-empty">正在读取截图…</div></div>

--- a/server/index.html
+++ b/server/index.html
@@ -280,7 +280,7 @@
   .history-empty { padding: 15px 12px; color: #9292a0; font-size: 11px; }
 
 </style>
-<script defer src="saved-history.js" data-history-enabled="auto"></script>
+<script defer src="saved-history.js?v=timeline3" data-history-enabled="auto"></script>
 
 <div id="app">
 <div id="main">

--- a/server/recording.py
+++ b/server/recording.py
@@ -204,10 +204,14 @@ class RecordingAPI:
         response = web.StreamResponse(headers={'Content-Type': 'application/x-ndjson' if raw else 'application/json'})
         reader = None
         try:
-            if not raw:
+            if not raw or not include_trajectory:
                 reader = Snapshot(**pin)
             await response.prepare(request)
-            if raw:
+            if raw and not include_trajectory:
+                for _, line in reader.lines(0):
+                    if not json.loads(line).get('trajectory'):
+                        await response.write(line)
+            elif raw:
                 for start in range(0, pin['end'], 64 << 10):
                     await response.write(os.pread(pin['fd'], min(64 << 10, pin['end']-start), start))
             else:

--- a/server/recording.py
+++ b/server/recording.py
@@ -130,7 +130,7 @@ class RecordingAPI:
             app.add_routes([web.get('/api/recordings', self.list_files),
                             web.get('/api/recordings/{name}', self.download_file)])
 
-    async def handle(self, request):
+    async def handle(self, request, include_trajectory=True):
         from aiohttp import web
         import uuid
         name = request.query.get('recording', 'current')
@@ -185,10 +185,14 @@ class RecordingAPI:
                         location = index.locate(when)
                     except sqlite3.Error as exc:
                         return web.json_response({'error': 'seek index unreadable: ' + str(exc)}, status=503)
-                    return web.json_response(dict(reader.page(location['start']), token=token,
-                                                  seek=location, seek_supported=True))
-                return web.json_response(dict(reader.page(request.query.get('start')), token=token,
-                                              seek_supported=self.archives))
+                    page = reader.page(location['start'])
+                    if not include_trajectory:
+                        page['events'] = [event for event in page['events'] if not event.get('trajectory')]
+                    return web.json_response(dict(page, token=token, seek=location, seek_supported=True))
+                page = reader.page(request.query.get('start'))
+                if not include_trajectory:
+                    page['events'] = [event for event in page['events'] if not event.get('trajectory')]
+                return web.json_response(dict(page, token=token, seek_supported=self.archives))
             except ValueError as exc:
                 return web.json_response({'error': str(exc)}, status=400)
 
@@ -213,6 +217,8 @@ class RecordingAPI:
                 first = True
                 payload_bytes = 0
                 for event in reader:
+                    if not include_trajectory and event.get('trajectory'):
+                        continue
                     data = event.get("d", "")
                     payload_bytes += len(data) * 3 // 4 - (len(data) - len(data.rstrip("=")))
                     await response.write((('' if first else ',')+json.dumps(event, separators=(',', ':'))).encode())

--- a/server/saved-history.js
+++ b/server/saved-history.js
@@ -14,6 +14,11 @@
     if (typeof updateImageJump === 'function') updateImageJump();
   }
   function buttons() {
+    const pages = total ? Math.ceil(total / PAGE) : 0;
+    const page = total ? Math.floor(start / PAGE) + 1 : 0;
+    get('historypage').value = page || '';
+    get('historypages').textContent = pages || '—';
+    get('historypage').disabled = busy || !pages;
     get('historyfirst').disabled = get('historyprev').disabled = busy || start <= 0;
     get('historynext').disabled = busy || start + PAGE >= total;
     get('historylatest').disabled = busy;
@@ -134,6 +139,13 @@
   get('historyprev').onclick = () => load(Math.max(0,start-PAGE));
   get('historynext').onclick = () => load(start+PAGE);
   get('historylatest').onclick = () => load();
+  const jump = () => {
+    const pages = total ? Math.ceil(total / PAGE) : 0;
+    const page = Number.parseInt(get('historypage').value, 10);
+    if (pages && Number.isInteger(page)) load(Math.max(0, Math.min(pages, page) - 1) * PAGE);
+  };
+  get('historypage').onchange = jump;
+  get('historypage').onkeydown = event => { if (event.key === 'Enter') { event.preventDefault(); jump(); } };
   addEventListener('historyinvalidate', invalidate);
   addEventListener('pagehide', event => {
     if (!event.persisted) {

--- a/server/saved-history.js
+++ b/server/saved-history.js
@@ -8,15 +8,11 @@
   let start = 0, total = 0, origin = null, busy = false, urls = [];
   let generation = 0, active = null, reload = false, disposed = false;
   const box = get('historyrows'), info = get('historyinfo');
-  function selectHistory(selected) {
-    get('historypane').hidden = !selected;
-    get('logrows').hidden = selected;
-    get('historytab').setAttribute('aria-selected', String(selected));
-    get('livetab').setAttribute('aria-selected', String(!selected));
+  function selectHistory() {
+    get('historypane').hidden = false;
+    get('logrows').hidden = false;
     if (typeof updateImageJump === 'function') updateImageJump();
   }
-  get('historytab').onclick = () => { if (enabled) selectHistory(true); };
-  get('livetab').onclick = () => selectHistory(false);
   function buttons() {
     get('historyfirst').disabled = get('historyprev').disabled = busy || start <= 0;
     get('historynext').disabled = busy || start + PAGE >= total;
@@ -67,7 +63,9 @@
       info.textContent = ' · ' + total.toLocaleString();
       get('historyrange').textContent = total ? `${start+1}–${start+page.steps.length} / ${total} 张` : '0 张';
       const imageRows = [];
-      for (let offset = page.steps.length - 1; offset >= 0; offset--) {
+      // The page is already chronological. Keep older actions above newer ones
+      // so the timeline reads from top to bottom.
+      for (let offset = 0; offset < page.steps.length; offset++) {
         const step = page.steps[offset], index = start + offset;
         const row = document.createElement('article'); row.className = 'saved-row'; row.dataset.step = index;
         const details = document.createElement('div'); details.className = 'saved-meta';
@@ -142,10 +140,9 @@
       active?.controller.abort(); releaseImages();
     }
   });
-  get('historytab').hidden = !enabled;
   // Playback, export and the recordings menu read the same endpoints the
   // history pane does, so where the server has none they are hidden too.
   if (!enabled) for (const id of ['play', 'save', 'recordingfiles']) get(id).hidden = true;
-  selectHistory(enabled);
+  selectHistory();
   if (enabled) load();
 })();

--- a/server/saved-history.js
+++ b/server/saved-history.js
@@ -1,16 +1,22 @@
-// Complete disk-backed screenshot history. The realtime log's 40-image cache
-// is separate; each page owns only eight images and releases its snapshot.
+// Complete disk-backed activity history. When the server exposes saved
+// history, this is the one rendered feed: the websocket is only a change
+// signal and the page owns eight disk-backed records at a time.
 (() => {
   const PAGE = 8;
   const get = id => document.getElementById(id);
   const endpoint = path => new URL(path, location.href);
   const enabled = document.currentScript?.dataset.historyEnabled !== 'false';
+  globalThis.__savedHistoryEnabled = enabled;
   let start = 0, total = 0, origin = null, busy = false, urls = [];
   let generation = 0, active = null, reload = false, reloadStart = null, disposed = false;
+  let refreshTimer = null;
   const box = get('historyrows'), info = get('historyinfo');
   function selectHistory() {
     get('historypane').hidden = false;
-    get('logrows').hidden = false;
+    // The live websocket cache is a fallback for benchmark pages where saved
+    // history is disabled. Rendering it beside this feed would duplicate the
+    // same actions and make pagination look as if only half the timeline moved.
+    get('logrows').hidden = enabled;
     if (typeof updateImageJump === 'function') updateImageJump();
   }
   function buttons() {
@@ -59,7 +65,15 @@
       if (!Number.isSafeInteger(meta.steps) || meta.steps < 0) throw Error('历史记录数量无法识别。');
       if (origin !== null && origin !== meta.started) requested = null;
       origin = meta.started; total = meta.steps;
-      start = Math.max(0, Math.min(requested ?? Math.max(0, total - PAGE), Math.max(0, total - 1)));
+      const pages = total ? Math.ceil(total / PAGE) : 0;
+      const requestedPage = requested === null || requested === undefined
+        ? pages
+        : Math.floor(Math.max(0, requested) / PAGE) + 1;
+      const pageNumber = pages ? Math.max(1, Math.min(pages, requestedPage)) : 0;
+      // Every page is aligned to the same eight-record boundary. In
+      // particular, a 10,841-record history has page 1,356 starting at
+      // record 10,841, while page 1,355 starts at record 10,833.
+      start = pageNumber ? (pageNumber - 1) * PAGE : 0;
       const path = `api/replay/${encodeURIComponent(token)}/steps?start=${start}&count=${PAGE}`;
       const {data:page} = await request(path, signal);
       check();
@@ -114,7 +128,8 @@
         }));
       }
       check();
-      box.scrollTop = 0;
+      const timeline = get('timeline');
+      if (timeline) timeline.scrollTop = 0;
     } catch(error) {
       if (current()) { releaseImages(); info.textContent=''; box.textContent=''; const text=document.createElement('div'); text.className='history-empty'; text.textContent=error.message; box.append(text); }
     } finally {
@@ -135,6 +150,22 @@
     if (active) { reload = true; reloadStart = requested; }
     else load(requested);
   }
+  function scheduleRefresh() {
+    if (!enabled || disposed || refreshTimer !== null) return;
+    refreshTimer = setTimeout(() => {
+      refreshTimer = null;
+      // Keep an old page stable while it is being inspected. If the user was
+      // on the last page, follow the new last page so live activity becomes
+      // part of the same paginated feed immediately.
+      const requested = total && start + PAGE < total ? start : null;
+      if (active) {
+        reload = true;
+        reloadStart = requested;
+      } else {
+        load(requested);
+      }
+    }, 250);
+  }
   get('historyfirst').onclick = () => load(0);
   get('historyprev').onclick = () => load(Math.max(0,start-PAGE));
   get('historynext').onclick = () => load(start+PAGE);
@@ -147,9 +178,11 @@
   get('historypage').onchange = jump;
   get('historypage').onkeydown = event => { if (event.key === 'Enter') { event.preventDefault(); jump(); } };
   addEventListener('historyinvalidate', invalidate);
+  addEventListener('activityrecorded', scheduleRefresh);
   addEventListener('pagehide', event => {
     if (!event.persisted) {
       disposed = true; reload = false; generation++;
+      if (refreshTimer !== null) { clearTimeout(refreshTimer); refreshTimer = null; }
       active?.controller.abort(); releaseImages();
     }
   });

--- a/server/saved-history.js
+++ b/server/saved-history.js
@@ -2,15 +2,16 @@
 // history, this is the one rendered feed: the websocket is only a change
 // signal and the page owns eight disk-backed records at a time.
 (() => {
-  const PAGE = 8;
+  const PAGE_SIZES = [8, 16, 32, 64];
   const get = id => document.getElementById(id);
   const endpoint = path => new URL(path, location.href);
   const enabled = document.currentScript?.dataset.historyEnabled !== 'false';
   globalThis.__savedHistoryEnabled = enabled;
-  let start = 0, total = 0, origin = null, busy = false, urls = [];
+  let pageSize = 8, start = 0, total = 0, origin = null, busy = false, urls = [];
   let generation = 0, active = null, reload = false, reloadStart = null, disposed = false;
   let refreshTimer = null;
-  const box = get('historyrows'), info = get('historyinfo');
+  const box = get('historyrows'), info = get('historyinfo'), sizeControl = get('historysize');
+  sizeControl.value = String(pageSize);
   function selectHistory() {
     get('historypane').hidden = false;
     // The live websocket cache is a fallback for benchmark pages where saved
@@ -20,13 +21,14 @@
     if (typeof updateImageJump === 'function') updateImageJump();
   }
   function buttons() {
-    const pages = total ? Math.ceil(total / PAGE) : 0;
-    const page = total ? Math.floor(start / PAGE) + 1 : 0;
+    const pages = total ? Math.ceil(total / pageSize) : 0;
+    const page = total ? Math.floor(start / pageSize) + 1 : 0;
     get('historypage').value = page || '';
     get('historypages').textContent = pages || '—';
     get('historypage').disabled = busy || !pages;
+    sizeControl.disabled = busy || !pages;
     get('historyfirst').disabled = get('historyprev').disabled = busy || start <= 0;
-    get('historynext').disabled = busy || start + PAGE >= total;
+    get('historynext').disabled = busy || start + pageSize >= total;
     get('historylatest').disabled = busy;
   }
   function releaseImages() { urls.forEach(url => URL.revokeObjectURL(url)); urls = []; }
@@ -65,16 +67,15 @@
       if (!Number.isSafeInteger(meta.steps) || meta.steps < 0) throw Error('历史记录数量无法识别。');
       if (origin !== null && origin !== meta.started) requested = null;
       origin = meta.started; total = meta.steps;
-      const pages = total ? Math.ceil(total / PAGE) : 0;
+      const pages = total ? Math.ceil(total / pageSize) : 0;
       const requestedPage = requested === null || requested === undefined
         ? pages
-        : Math.floor(Math.max(0, requested) / PAGE) + 1;
+        : Math.floor(Math.max(0, requested) / pageSize) + 1;
       const pageNumber = pages ? Math.max(1, Math.min(pages, requestedPage)) : 0;
-      // Every page is aligned to the same eight-record boundary. In
-      // particular, a 10,841-record history has page 1,356 starting at
-      // record 10,841, while page 1,355 starts at record 10,833.
-      start = pageNumber ? (pageNumber - 1) * PAGE : 0;
-      const path = `api/replay/${encodeURIComponent(token)}/steps?start=${start}&count=${PAGE}`;
+      // Every page is aligned to the selected page-size boundary. The last
+      // page may be shorter when the total is not an exact multiple.
+      start = pageNumber ? (pageNumber - 1) * pageSize : 0;
+      const path = `api/replay/${encodeURIComponent(token)}/steps?start=${start}&count=${pageSize}`;
       const {data:page} = await request(path, signal);
       check();
       if (!Array.isArray(page.steps)) throw Error('历史截图列表无法读取。');
@@ -157,7 +158,7 @@
       // Keep an old page stable while it is being inspected. If the user was
       // on the last page, follow the new last page so live activity becomes
       // part of the same paginated feed immediately.
-      const requested = total && start + PAGE < total ? start : null;
+      const requested = total && start + pageSize < total ? start : null;
       if (active) {
         reload = true;
         reloadStart = requested;
@@ -167,16 +168,25 @@
     }, 250);
   }
   get('historyfirst').onclick = () => load(0);
-  get('historyprev').onclick = () => load(Math.max(0,start-PAGE));
-  get('historynext').onclick = () => load(start+PAGE);
+  get('historyprev').onclick = () => load(Math.max(0,start-pageSize));
+  get('historynext').onclick = () => load(start+pageSize);
   get('historylatest').onclick = () => load();
   const jump = () => {
-    const pages = total ? Math.ceil(total / PAGE) : 0;
+    const pages = total ? Math.ceil(total / pageSize) : 0;
     const page = Number.parseInt(get('historypage').value, 10);
-    if (pages && Number.isInteger(page)) load(Math.max(0, Math.min(pages, page) - 1) * PAGE);
+    if (pages && Number.isInteger(page)) load(Math.max(0, Math.min(pages, page) - 1) * pageSize);
   };
   get('historypage').onchange = jump;
   get('historypage').onkeydown = event => { if (event.key === 'Enter') { event.preventDefault(); jump(); } };
+  sizeControl.onchange = () => {
+    const next = Number.parseInt(sizeControl.value, 10);
+    if (!PAGE_SIZES.includes(next) || next === pageSize) {
+      sizeControl.value = String(pageSize);
+      return;
+    }
+    pageSize = next;
+    load(start);
+  };
   addEventListener('historyinvalidate', invalidate);
   addEventListener('activityrecorded', scheduleRefresh);
   addEventListener('pagehide', event => {

--- a/server/saved-history.js
+++ b/server/saved-history.js
@@ -6,7 +6,7 @@
   const endpoint = path => new URL(path, location.href);
   const enabled = document.currentScript?.dataset.historyEnabled !== 'false';
   let start = 0, total = 0, origin = null, busy = false, urls = [];
-  let generation = 0, active = null, reload = false, disposed = false;
+  let generation = 0, active = null, reload = false, reloadStart = null, disposed = false;
   const box = get('historyrows'), info = get('historyinfo');
   function selectHistory() {
     get('historypane').hidden = false;
@@ -115,19 +115,20 @@
     } finally {
       if (token) await fetch(endpoint(`api/replay/${encodeURIComponent(token)}`), {method:'DELETE',keepalive:true}).catch(()=>{});
       active = null; busy = false;
-      if (reload && !disposed) { reload = false; load(); }
+      if (reload && !disposed) { const requested = reloadStart; reload = false; reloadStart = null; load(requested); }
       else buttons();
     }
   }
   function invalidate() {
     if (!enabled || disposed) return;
+    const requested = origin !== null ? start : null;
     generation++;
     active?.controller.abort();
     releaseImages(); box.textContent = '';
-    start = total = 0; origin = null;
+    start = total = 0;
     info.textContent = ' · 读取中'; get('historyrange').textContent = '';
-    if (active) reload = true;
-    else load();
+    if (active) { reload = true; reloadStart = requested; }
+    else load(requested);
   }
   get('historyfirst').onclick = () => load(0);
   get('historyprev').onclick = () => load(Math.max(0,start-PAGE));

--- a/server/server.py
+++ b/server/server.py
@@ -2423,7 +2423,8 @@ async def calibrate():
 
 async def api_recording(request):
     if recording_api:
-        return await recording_api.handle(request)
+        return await recording_api.handle(
+            request, include_trajectory=not (warden.ON and not operator(request)))
     return web.json_response({"started": rec["started"], "duration": 0, "events": [], "bytes": 0})
 
 

--- a/server/server.py
+++ b/server/server.py
@@ -1051,7 +1051,7 @@ def rec_add(kind, payload=None, key=None, down=None, keyframe=False):
         rec["bytes"] = recording_store.committed_size
 
 
-def record_trajectory(sample, screen_changed):
+def record_trajectory(sample, screen_changed, action_at=None):
     """Persist the post-action observation beside the raw input marker.
 
     The action marker is written before input is sent. This second event is
@@ -1068,6 +1068,10 @@ def record_trajectory(sample, screen_changed):
              "scene": sample.get("scene", world["scenes"]),
              "frontier": sample.get("frontier"),
              "screen_changed": bool(screen_changed)}
+    if type(action_at) in (int, float) and math.isfinite(action_at):
+        # The per-worker action counter resets after a restart; this timestamp
+        # lets an offline reader join the observation to the older marker.
+        event["action_t"] = action_at
     if type(sample.get("x")) is int and type(sample.get("y")) is int:
         event["x"], event["y"] = sample["x"], sample["y"]
     try:
@@ -1686,9 +1690,9 @@ async def run_action(request, steps, note, verb="KEY"):
         rec["actor"] = actor(request)
         key_steps = [step for step in steps if len(step) > 2]
         input_frames = sum(int(step[1]) for step in key_steps)
-        log_action(rec["actor"], verb, note, detail=held_note(steps),
-                   key_events=len(key_steps), input_frames=input_frames,
-                   wait_call=not key_steps)
+        action_entry = log_action(rec["actor"], verb, note, detail=held_note(steps),
+                                  key_events=len(key_steps), input_frames=input_frames,
+                                  wait_call=not key_steps)
         if not disk_history_enabled():
             rec_add("a", key=session["actions"], down=f"{verb} {note}"[:32])
         if warden.ON:
@@ -1726,7 +1730,8 @@ async def run_action(request, steps, note, verb="KEY"):
         waited, changed = await settle(baseline, **settle_args)
         trajectory = note_move()
         screen_changed = note_screen()
-        record_trajectory(trajectory, screen_changed)
+        record_trajectory(trajectory, screen_changed,
+                          action_at=action_entry["at"] - rec["started"])
         # Inventory can increase and be consumed between sparse samples.  The
         # read is ~1.2 ms against hundreds of ms per action, so sample every
         # action and latch gains relative to the opening state.

--- a/server/server.py
+++ b/server/server.py
@@ -804,17 +804,26 @@ def note_move():
     new scene is still loading then and its coordinates have not landed. It is
     picked up on the next action instead, which costs one step of distance and
     is worth it for a number that is not nonsense."""
+    sample = {"scene": world["scenes"],
+              "frontier": (world["banked"] + world["far"])
+              if world["ok"] else None,
+              "x": None, "y": None}
     if world["dark"]:
         world["dark"] = False
         enter_scene()
-        return
+        sample["scene"] = world["scenes"]
+        sample["frontier"] = ((world["banked"] + world["far"])
+                               if world["ok"] else None)
+        return sample
     p = position()
     if p is None:
-        return
+        return sample
+    sample["x"], sample["y"] = p
     o = world["origin"]
     if o is None:
         world["origin"], world["far"] = p, 0
-        return
+        sample["frontier"] = world["banked"]
+        return sample
     # Chebyshev, not Manhattan: a step here is diagonal, moving both axes at
     # once, so Manhattan would call one step two tiles. This counts steps.
     d = max(abs(p[0] - o[0]), abs(p[1] - o[1]))
@@ -824,8 +833,12 @@ def note_move():
     if d > world["far"] + 8:
         enter_scene()
         world["origin"], world["far"] = p, 0
-        return
+        sample["scene"] = world["scenes"]
+        sample["frontier"] = world["banked"]
+        return sample
     world["far"] = max(world["far"], d)
+    sample["frontier"] = world["banked"] + world["far"]
+    return sample
 curve: list = []          # (action index, meaningful) sampled as the run goes
 agents: collections.Counter = collections.Counter()
 rec: dict = {"started": time.time(), "events": [], "bytes": 0, "last_key": 0.0,
@@ -1038,6 +1051,36 @@ def rec_add(kind, payload=None, key=None, down=None, keyframe=False):
         rec["bytes"] = recording_store.committed_size
 
 
+def record_trajectory(sample, screen_changed):
+    """Persist the post-action observation beside the raw input marker.
+
+    The action marker is written before input is sent. This second event is
+    written after settling, so an offline reader can join the two by
+    ``action`` and distinguish what was requested from what the game showed.
+    Coordinates are optional: resumed workers may not have calibrated offsets.
+    Missing coordinates stay null and are never interpreted as zero distance.
+    """
+    if not recording_store:
+        return
+    sample = sample or {}
+    event = {"t": round(time.time() - rec["started"], 3),
+             "trajectory": True, "action": session["actions"],
+             "scene": sample.get("scene", world["scenes"]),
+             "frontier": sample.get("frontier"),
+             "screen_changed": bool(screen_changed)}
+    if type(sample.get("x")) is int and type(sample.get("y")) is int:
+        event["x"], event["y"] = sample["x"], sample["y"]
+    try:
+        ok = recording_store.append(event)
+    except (OSError, BufferError) as exc:
+        recording_store.error = str(exc)
+        ok = False
+    if not ok:
+        block_recording()
+        raise RecordingUnavailable(recording_store.error)
+    rec["bytes"] = recording_store.committed_size
+
+
 def block_recording():
     global recording_blocked
     recording_blocked = True
@@ -1154,7 +1197,8 @@ def note_screen():
         return
     note_bigmap(fp)
     before = beh["last"]
-    if before is not None and fp != before:
+    changed = before is not None and fp != before
+    if changed:
         beh["meaningful"] += 1
     # A -> B -> A is the oscillation the literature calls out as the signature
     # of an agent that is busy without getting anywhere.
@@ -1164,6 +1208,7 @@ def note_screen():
     if not curve or session["actions"] - curve[-1][0] >= 5:
         curve.append((session["actions"], beh["meaningful"]))
         del curve[:-400]
+    return changed
 
 
 def session_summary():
@@ -1679,8 +1724,9 @@ async def run_action(request, steps, note, verb="KEY"):
                 await tap(kind, val, step[2] if len(step) > 2 else None)
         input_stage("settle")
         waited, changed = await settle(baseline, **settle_args)
-        note_move()
-        note_screen()
+        trajectory = note_move()
+        screen_changed = note_screen()
+        record_trajectory(trajectory, screen_changed)
         # Inventory can increase and be consumed between sparse samples.  The
         # read is ~1.2 ms against hundreds of ms per action, so sample every
         # action and latch gains relative to the opening state.

--- a/server/server.py
+++ b/server/server.py
@@ -1730,8 +1730,11 @@ async def run_action(request, steps, note, verb="KEY"):
         waited, changed = await settle(baseline, **settle_args)
         trajectory = note_move()
         screen_changed = note_screen()
-        record_trajectory(trajectory, screen_changed,
-                          action_at=action_entry["at"] - rec["started"])
+        action_at = (action_entry.get("at") - rec["started"]
+                     if isinstance(action_entry, dict)
+                     and type(action_entry.get("at")) in (int, float)
+                     else None)
+        record_trajectory(trajectory, screen_changed, action_at=action_at)
         # Inventory can increase and be consumed between sparse samples.  The
         # read is ~1.2 ms against hundreds of ms per action, so sample every
         # action and latch gains relative to the opening state.

--- a/server/server.py
+++ b/server/server.py
@@ -2424,7 +2424,7 @@ async def calibrate():
 async def api_recording(request):
     if recording_api:
         return await recording_api.handle(
-            request, include_trajectory=not (warden.ON and not operator(request)))
+            request, include_trajectory=include_trajectory(request))
     return web.json_response({"started": rec["started"], "duration": 0, "events": [], "bytes": 0})
 
 
@@ -2517,6 +2517,16 @@ def operator(request):
     got = request.query.get("token") or request.headers.get("X-Reset-Token")
     return bool(want) and hmac.compare_digest(
         (got or "").encode("utf-8"), want.encode("utf-8"))
+
+
+def include_trajectory(request):
+    """Only an explicitly authenticated operator may read recorded coordinates.
+
+    Trajectory markers are written for offline analysis. They must stay out of
+    every ordinary recording response, including interactive non-benchmark
+    sessions where the benchmark warden is disabled.
+    """
+    return operator(request)
 
 
 def withheld(request):

--- a/server/test_game_snapshot.py
+++ b/server/test_game_snapshot.py
@@ -114,6 +114,11 @@ class WithholdingTests(unittest.TestCase):
         game_server.warden.ON = False
         self.assertFalse(game_server.withheld(self.Request()))
 
+    def test_recorded_coordinates_are_operator_only_even_unscored(self):
+        game_server.warden.ON = False
+        self.assertFalse(game_server.include_trajectory(self.Request()))
+        self.assertTrue(game_server.include_trajectory(self.Request("secret")))
+
     def test_a_live_scored_run_hides_from_everyone_but_the_operator(self):
         game_server.warden.ON = True
         game_server.warden.run["done"] = None

--- a/server/test_recording.py
+++ b/server/test_recording.py
@@ -151,17 +151,26 @@ class RecordingApiTests(unittest.IsolatedAsyncioTestCase):
                 api.close();store.close()
 
     async def test_benchmark_view_can_hide_recorder_only_trajectory_events(self):
-        from types import SimpleNamespace
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
         with tempfile.TemporaryDirectory() as directory:
             store = RecordingStore(Path(directory) / 'run.jsonl', started=10)
-            api = RecordingAPI(store)
+            api = RecordingAPI(store, archives=False)
+            store.append({'t': 1, 'act': 'KEY', 'on': 'right'})
+            store.append({'t': 1.1, 'trajectory': True, 'x': 4, 'y': 5})
+            async def handle(request):
+                return await api.handle(request, include_trajectory=False)
+            app = web.Application()
+            app.router.add_get('/api/recording', handle)
             try:
-                store.append({'t': 1, 'act': 'KEY', 'on': 'right'})
-                store.append({'t': 1.1, 'trajectory': True, 'x': 4, 'y': 5})
-                request = SimpleNamespace(query={'view': 'paged'})
-                page = json.loads((await api.handle(request, include_trajectory=False)).body)
-                self.assertEqual([event.get('act') for event in page['events']], ['KEY'])
-                self.assertFalse(any(event.get('trajectory') for event in page['events']))
+                async with TestClient(TestServer(app)) as client:
+                    for query in ('?view=paged', '', '?format=jsonl'):
+                        async with client.get('/api/recording' + query) as response:
+                            self.assertEqual(response.status, 200)
+                            body = await response.text()
+                            events = ([json.loads(line) for line in body.splitlines()][1:]
+                                      if 'jsonl' in query else json.loads(body)['events'])
+                            self.assertEqual([event.get('act') for event in events], ['KEY'])
             finally:
                 api.close(); store.close()
 

--- a/server/test_recording.py
+++ b/server/test_recording.py
@@ -150,6 +150,21 @@ class RecordingApiTests(unittest.IsolatedAsyncioTestCase):
             finally:
                 api.close();store.close()
 
+    async def test_benchmark_view_can_hide_recorder_only_trajectory_events(self):
+        from types import SimpleNamespace
+        with tempfile.TemporaryDirectory() as directory:
+            store = RecordingStore(Path(directory) / 'run.jsonl', started=10)
+            api = RecordingAPI(store)
+            try:
+                store.append({'t': 1, 'act': 'KEY', 'on': 'right'})
+                store.append({'t': 1.1, 'trajectory': True, 'x': 4, 'y': 5})
+                request = SimpleNamespace(query={'view': 'paged'})
+                page = json.loads((await api.handle(request, include_trajectory=False)).body)
+                self.assertEqual([event.get('act') for event in page['events']], ['KEY'])
+                self.assertFalse(any(event.get('trajectory') for event in page['events']))
+            finally:
+                api.close(); store.close()
+
 
 class RecordingWorkerTests(unittest.TestCase):
     @classmethod

--- a/server/test_saved_history_ui.js
+++ b/server/test_saved_history_ui.js
@@ -70,7 +70,7 @@ function fixture({enabled = true, handle, decode} = {}) {
     click() { if (!this.disabled) return this.onclick?.({target: this}); }
   }
   const ids = ['historyrows', 'historyinfo', 'historypane', 'timeline',
-    'logrows', 'historyfirst', 'historyprev', 'historynext', 'historylatest', 'historypage', 'historypages', 'historyrange',
+    'logrows', 'historyfirst', 'historyprev', 'historynext', 'historylatest', 'historypage', 'historypages', 'historyrange', 'historysize',
     'play', 'save', 'recordingfiles'];
   const elements = Object.fromEntries(ids.map(id => [id, Object.assign(new Element(), {id})]));
   class TestURL extends URL {
@@ -250,6 +250,27 @@ test('a persisted activity refreshes the same feed and follows only the latest p
     'new persisted activity did not refresh the latest page', state);
   assert.equal(state.elements.logrows.hidden, true);
   assert.equal(state.elements.historyrange.textContent, '9–9 / 9 张');
+});
+
+test('page size can be changed without losing the current record range', async () => {
+  let opened = 0;
+  const state = fixture({handle: call => isOpen(call)
+    ? response({token: 'size-' + (++opened), started: 'same-recording', steps: 20})
+    : standard(call, tokenOf(call), 20)});
+  await until(() => deleted(state).length === 1 && !state.elements.historylatest.disabled,
+    'initial page did not finish', state);
+  state.elements.historysize.value = '16';
+  state.elements.historysize.onchange();
+  await until(() => deleted(state).length === 2 && !state.elements.historylatest.disabled,
+    'page-size change did not finish', state);
+  assert.deepEqual(indices(state), [16, 17, 18, 19]);
+  assert.equal(state.elements.historypages.textContent, '2');
+  assert.equal(state.elements.historyrange.textContent, '17–20 / 20 张');
+  assert.equal(state.requests.filter(isSteps).at(-1).url.searchParams.get('count'), '16');
+  state.elements.historyfirst.click();
+  await until(() => deleted(state).length === 3 && !state.elements.historylatest.disabled,
+    'first page after size change did not finish', state);
+  assert.deepEqual(indices(state), Array.from({length: 16}, (_, i) => i));
 });
 
 test('failed actions visibly retain their failure status and reason', async () => {

--- a/server/test_saved_history_ui.js
+++ b/server/test_saved_history_ui.js
@@ -69,7 +69,7 @@ function fixture({enabled = true, handle, decode} = {}) {
     addEventListener(name, handler) { this['on' + name] = handler; }
     click() { if (!this.disabled) return this.onclick?.({target: this}); }
   }
-  const ids = ['historyrows', 'historyinfo', 'historypane', 'historytab', 'livetab',
+  const ids = ['historyrows', 'historyinfo', 'historypane', 'timeline',
     'logrows', 'historyfirst', 'historyprev', 'historynext', 'historylatest', 'historyrange',
     'play', 'save', 'recordingfiles'];
   const elements = Object.fromEntries(ids.map(id => [id, Object.assign(new Element(), {id})]));
@@ -182,18 +182,14 @@ function standard(call, token = 'new', total = 20, customStep) {
   assert.fail('unexpected request ' + call.url);
 }
 
-test('explicitly disabled history selects realtime and makes no replay request', async () => {
+test('explicitly disabled history leaves the unified timeline without replay requests', async () => {
   const state = fixture({enabled: false, handle: () => assert.fail('disabled history requested the API')});
   await settle();
-  assert.equal(state.elements.historypane.hidden, true);
+  assert.equal(state.elements.historypane.hidden, false);
   assert.equal(state.elements.logrows.hidden, false);
-  assert.equal(state.elements.livetab.getAttribute('aria-selected'), 'true');
-  assert.ok(state.elements.historytab.disabled || state.elements.historytab.hidden,
-    'the unavailable history tab must not be interactive');
   for (const id of ['play', 'save', 'recordingfiles']) {
     assert.equal(state.elements[id].hidden, true, id + ' reads endpoints this server does not have');
   }
-  state.elements.historytab.click();
   state.emit('historyinvalidate');
   await settle();
   assert.equal(state.requests.length, 0);
@@ -203,8 +199,7 @@ test('an ordinary endpoint 404 remains a visible history error', async () => {
   const state = fixture({handle: () => response({}, 404)});
   await until(() => state.elements.historyrows.textContent.includes('历史'), 'history error did not appear', state);
   assert.equal(state.elements.historypane.hidden, false);
-  assert.equal(state.elements.logrows.hidden, true);
-  assert.equal(state.elements.historytab.getAttribute('aria-selected'), 'true');
+  assert.equal(state.elements.logrows.hidden, false);
   assert.match(state.elements.historyrows.textContent, /不可用|失败|重试/);
   assert.equal(state.elements.historylatest.disabled, false);
 });
@@ -219,17 +214,17 @@ test('latest, first, next, and previous pages own eight rows and preserve the us
       'page did not finish', state);
     assert.deepEqual(indices(state), expected);
   }
-  await completed(1, [19, 18, 17, 16, 15, 14, 13, 12]);
+  await completed(1, [12, 13, 14, 15, 16, 17, 18, 19]);
   assert.equal(state.elements.historyrange.textContent, '13–20 / 20 张');
   state.elements.historyfirst.click();
-  await completed(2, [7, 6, 5, 4, 3, 2, 1, 0]);
+  await completed(2, [0, 1, 2, 3, 4, 5, 6, 7]);
   assert.equal(state.elements.historyprev.disabled, true);
   state.elements.historynext.click();
-  await completed(3, [15, 14, 13, 12, 11, 10, 9, 8]);
+  await completed(3, [8, 9, 10, 11, 12, 13, 14, 15]);
   state.elements.historyprev.click();
-  await completed(4, [7, 6, 5, 4, 3, 2, 1, 0]);
+  await completed(4, [0, 1, 2, 3, 4, 5, 6, 7]);
   state.elements.historylatest.click();
-  await completed(5, [19, 18, 17, 16, 15, 14, 13, 12]);
+  await completed(5, [12, 13, 14, 15, 16, 17, 18, 19]);
   assert.equal(state.elements.historynext.disabled, true);
   assert.ok(state.requests.every(call => call.url.pathname.startsWith('/u/test-user/api/replay')));
   assert.ok(state.requests.filter(isOpen).every(call => call.url.searchParams.get('recording') === 'current'));
@@ -361,7 +356,7 @@ for (const stage of ['steps', 'frame', 'blob', 'decode']) {
     else pending.resolve();
     await until(() => deleted(state).includes('fresh') && !state.elements.historylatest.disabled,
       'fresh history did not finish', state);
-    assert.deepEqual(indices(state), [7, 6, 5, 4, 3, 2, 1, 0]);
+    assert.deepEqual(indices(state), [0, 1, 2, 3, 4, 5, 6, 7]);
     assert.ok(state.rows().every(row => row.textContent.includes('new-rec')));
     assert.equal(state.elements.historyrange.textContent, '1–8 / 8 张');
     const staleAppends = state.mutations.slice(invalidatedAt).filter(change =>

--- a/server/test_saved_history_ui.js
+++ b/server/test_saved_history_ui.js
@@ -199,7 +199,7 @@ test('an ordinary endpoint 404 remains a visible history error', async () => {
   const state = fixture({handle: () => response({}, 404)});
   await until(() => state.elements.historyrows.textContent.includes('历史'), 'history error did not appear', state);
   assert.equal(state.elements.historypane.hidden, false);
-  assert.equal(state.elements.logrows.hidden, false);
+  assert.equal(state.elements.logrows.hidden, true);
   assert.match(state.elements.historyrows.textContent, /不可用|失败|重试/);
   assert.equal(state.elements.historylatest.disabled, false);
 });
@@ -214,8 +214,8 @@ test('latest, first, next, and previous pages own eight rows and preserve the us
       'page did not finish', state);
     assert.deepEqual(indices(state), expected);
   }
-  await completed(1, [12, 13, 14, 15, 16, 17, 18, 19]);
-  assert.equal(state.elements.historyrange.textContent, '13–20 / 20 张');
+  await completed(1, [16, 17, 18, 19]);
+  assert.equal(state.elements.historyrange.textContent, '17–20 / 20 张');
   state.elements.historyfirst.click();
   await completed(2, [0, 1, 2, 3, 4, 5, 6, 7]);
   assert.equal(state.elements.historyprev.disabled, true);
@@ -224,16 +224,32 @@ test('latest, first, next, and previous pages own eight rows and preserve the us
   state.elements.historyprev.click();
   await completed(4, [0, 1, 2, 3, 4, 5, 6, 7]);
   state.elements.historylatest.click();
-  await completed(5, [12, 13, 14, 15, 16, 17, 18, 19]);
+  await completed(5, [16, 17, 18, 19]);
   assert.equal(state.elements.historynext.disabled, true);
   assert.ok(state.requests.every(call => call.url.pathname.startsWith('/u/test-user/api/replay')));
   assert.ok(state.requests.filter(isOpen).every(call => call.url.searchParams.get('recording') === 'current'));
   assert.ok(state.requests.filter(isSteps).every(call => call.url.searchParams.get('count') === '8'));
   assert.equal(new Set(deleted(state)).size, 5);
-  assert.equal(state.created.length - new Set(state.revoked).size, 8, 'only the current page retains image URLs');
+  assert.equal(state.created.length - new Set(state.revoked).size, 4, 'only the current page retains image URLs');
   state.emit('pagehide', {persisted: false});
   await settle();
   assert.ok(state.created.every(({url}) => state.revoked.includes(url)), 'pagehide releases all rendered image URLs');
+});
+
+test('a persisted activity refreshes the same feed and follows only the latest page', async () => {
+  let total = 8, opened = 0;
+  const state = fixture({handle: call => isOpen(call)
+    ? response({token: 'live-' + (++opened), started: 'same-recording', steps: total})
+    : standard(call, tokenOf(call), total)});
+  await until(() => deleted(state).length === 1 && !state.elements.historylatest.disabled,
+    'initial live page did not finish', state);
+  total = 9;
+  state.emit('activityrecorded');
+  await new Promise(resolve => setTimeout(resolve, 300));
+  await until(() => deleted(state).length === 2 && indices(state).join(',') === '8',
+    'new persisted activity did not refresh the latest page', state);
+  assert.equal(state.elements.logrows.hidden, true);
+  assert.equal(state.elements.historyrange.textContent, '9–9 / 9 张');
 });
 
 test('failed actions visibly retain their failure status and reason', async () => {

--- a/server/test_saved_history_ui.js
+++ b/server/test_saved_history_ui.js
@@ -70,7 +70,7 @@ function fixture({enabled = true, handle, decode} = {}) {
     click() { if (!this.disabled) return this.onclick?.({target: this}); }
   }
   const ids = ['historyrows', 'historyinfo', 'historypane', 'timeline',
-    'logrows', 'historyfirst', 'historyprev', 'historynext', 'historylatest', 'historyrange',
+    'logrows', 'historyfirst', 'historyprev', 'historynext', 'historylatest', 'historypage', 'historypages', 'historyrange',
     'play', 'save', 'recordingfiles'];
   const elements = Object.fromEntries(ids.map(id => [id, Object.assign(new Element(), {id})]));
   class TestURL extends URL {

--- a/server/test_trajectory.py
+++ b/server/test_trajectory.py
@@ -17,7 +17,7 @@ class TrajectoryTests(unittest.TestCase):
         ], 1):
             events.append({"t": when, "act": "KEY", "on": key})
             events.append({"t": when + .1, "trajectory": True, "action": number,
-                           "x": x, "y": 4, "frontier": frontier,
+                           "x": x, "y": 4, "scene": 1, "frontier": frontier,
                            "screen_changed": changed})
         result = summarize(events, window_size=2)
         self.assertEqual(result["status"], "measured")
@@ -27,6 +27,19 @@ class TrajectoryTests(unittest.TestCase):
         self.assertEqual(result["summary"]["reverse_steps"], 1)
         self.assertEqual(result["summary"]["long_pauses"], 1)
         self.assertEqual(len(result["windows"]), 2)
+
+    def test_reads_scene_transitions_and_missing_samples_do_not_inflate_movement(self):
+        events = [{"t": 0, "act": "GET", "on": "screen"}]
+        for number, (x, scene) in enumerate([(1, 1), (2, 1), (99, 2), (None, 2), (105, 2)], 1):
+            events.extend([
+                {"t": number, "act": "KEY", "on": "right" if number % 2 else "kp7"},
+                {"t": number + .1, "trajectory": True, "action": number,
+                 "x": x, "y": 1, "scene": scene},
+            ])
+        result = summarize(events)
+        self.assertEqual(result["summary"]["actions"], 5)
+        self.assertEqual(result["summary"]["distance"], 1)
+        self.assertEqual(result["summary"]["reverse_steps"], 4)
 
     def test_legacy_recording_reports_action_metrics_without_fake_coordinates(self):
         with tempfile.TemporaryDirectory() as raw:

--- a/server/test_trajectory.py
+++ b/server/test_trajectory.py
@@ -42,6 +42,18 @@ class TrajectoryTests(unittest.TestCase):
         self.assertEqual(result["summary"]["distance"], None)
         self.assertEqual(result["summary"]["reverse_steps"], 1)
 
+    def test_timestamp_join_survives_worker_action_counter_reset(self):
+        events = [
+            {"t": 10.0, "act": "KEY", "on": "right"},
+            # This worker restarted and emitted its local action number 1.
+            {"t": 10.1, "trajectory": True, "action": 1, "action_t": 10.0,
+             "x": 42, "y": 7, "frontier": 3, "screen_changed": True},
+        ]
+        result = summarize(events)
+        self.assertEqual(result["status"], "measured")
+        self.assertEqual(result["actions"][0]["x"], 42)
+        self.assertEqual(result["actions"][0]["y"], 7)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/server/test_trajectory.py
+++ b/server/test_trajectory.py
@@ -67,6 +67,16 @@ class TrajectoryTests(unittest.TestCase):
         self.assertEqual(result["actions"][0]["x"], 42)
         self.assertEqual(result["actions"][0]["y"], 7)
 
+    def test_direction_aliases_and_key_sequences_count_reversals(self):
+        events = [
+            {"t": 0.0, "act": "KEYS", "on": "ne enter"},
+            {"t": 0.1, "trajectory": True, "action": 1},
+            {"t": 1.0, "act": "KEY", "on": "sw"},
+            {"t": 1.1, "trajectory": True, "action": 2},
+        ]
+        result = summarize(events)
+        self.assertEqual(result["summary"]["reverse_steps"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/server/test_trajectory.py
+++ b/server/test_trajectory.py
@@ -1,0 +1,47 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from trajectory import analyze, summarize
+
+
+class TrajectoryTests(unittest.TestCase):
+    def test_action_observations_and_windows_measure_route_quality(self):
+        events = []
+        for number, (when, key, x, frontier, changed) in enumerate([
+            (0.0, "right", 0, 0, True),
+            (1.0, "right", 1, 1, True),
+            (7.0, "left", 2, 2, False),
+            (8.0, "left", 1, 1, True),
+        ], 1):
+            events.append({"t": when, "act": "KEY", "on": key})
+            events.append({"t": when + .1, "trajectory": True, "action": number,
+                           "x": x, "y": 4, "frontier": frontier,
+                           "screen_changed": changed})
+        result = summarize(events, window_size=2)
+        self.assertEqual(result["status"], "measured")
+        self.assertEqual(result["summary"]["distance"], 3)
+        self.assertEqual(result["summary"]["position_samples"], 4)
+        self.assertEqual(result["summary"]["frontier_regressions"], 1)
+        self.assertEqual(result["summary"]["reverse_steps"], 1)
+        self.assertEqual(result["summary"]["long_pauses"], 1)
+        self.assertEqual(len(result["windows"]), 2)
+
+    def test_legacy_recording_reports_action_metrics_without_fake_coordinates(self):
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw) / "recording.jsonl"
+            path.write_text("\n".join([
+                json.dumps({"version": 1, "started": 1}),
+                json.dumps({"t": 0.0, "act": "KEY", "on": "right"}),
+                json.dumps({"t": 2.0, "act": "KEY", "on": "left"}),
+            ]) + "\n")
+            result = analyze(path)
+        self.assertEqual(result["status"], "position-unmeasured")
+        self.assertEqual(result["summary"]["actions"], 2)
+        self.assertEqual(result["summary"]["distance"], None)
+        self.assertEqual(result["summary"]["reverse_steps"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/trajectory.py
+++ b/server/trajectory.py
@@ -19,6 +19,10 @@ _DIRECTION = {
     "up": (1, -1), "down": (-1, 1), "left": (-1, -1), "right": (1, 1),
     "kp1": (-1, 1), "kp2": (0, 1), "kp3": (1, 1), "kp4": (-1, 0),
     "kp6": (1, 0), "kp7": (-1, -1), "kp8": (0, -1), "kp9": (1, -1),
+    "upright": (1, -1), "ne": (1, -1),
+    "downright": (1, 1), "se": (1, 1),
+    "downleft": (-1, 1), "sw": (-1, 1),
+    "upleft": (-1, -1), "nw": (-1, -1),
 }
 
 
@@ -41,7 +45,11 @@ def _direction(event):
     if not isinstance(target, str):
         label = event.get("label")
         target = label.split(" ", 1)[-1] if isinstance(label, str) else ""
-    return _DIRECTION.get(target.lower())
+    # KEYS actions can carry a sequence such as ``kp9 enter``. Only the
+    # directional token contributes to route reversals; confirmation keys do
+    # not erase the movement direction.
+    return next((_DIRECTION[token] for token in target.lower().split()
+                 if token in _DIRECTION), None)
 
 
 def _window(rows):

--- a/server/trajectory.py
+++ b/server/trajectory.py
@@ -85,7 +85,7 @@ def _window(rows):
 def summarize(events, *, window_size=25):
     """Summarize parsed recording events without loading frame payloads."""
     actions = []
-    observations = {}
+    observations = []
     previous_direction = None
     for event in events:
         if not isinstance(event, dict):
@@ -96,14 +96,16 @@ def summarize(events, *, window_size=25):
         if event.get("trajectory") is True:
             action = event.get("action")
             if type(action) is int and action > 0:
-                observations[action] = {
+                observations.append({
+                    "action": action,
                     "t": timestamp,
+                    "action_t": _number(event.get("action_t")),
                     "x": event.get("x") if type(event.get("x")) is int else None,
                     "y": event.get("y") if type(event.get("y")) is int else None,
                     "frontier": _number(event.get("frontier")),
                     "screen_changed": (event.get("screen_changed")
                                        if type(event.get("screen_changed")) is bool else None),
-                }
+                })
             continue
         name = _action_name(event)
         if name is None:
@@ -120,7 +122,23 @@ def summarize(events, *, window_size=25):
     rows = []
     for action in actions:
         row = dict(action)
-        observation = observations.get(action["number"], {})
+        observation = {}
+        # Prefer the full recording timestamp because the worker-local action
+        # counter starts over after a restart. A small tolerance covers the
+        # marker's historical three-decimal timestamp rounding.
+        timed = [(abs(action["t"] - item["action_t"]), item)
+                 for item in observations if item["action_t"] is not None]
+        if timed:
+            distance, candidate = min(timed, key=lambda pair: pair[0])
+            if distance <= 0.02:
+                observation = candidate
+                observations.remove(candidate)
+        if not observation:
+            for candidate in list(observations):
+                if candidate["action"] == action["number"] and candidate["action_t"] is None:
+                    observation = candidate
+                    observations.remove(candidate)
+                    break
         row.update({"x": observation.get("x"), "y": observation.get("y"),
                     "frontier": observation.get("frontier"),
                     "screen_changed": observation.get("screen_changed")})
@@ -161,4 +179,3 @@ def read_events(path):
 
 def analyze(path, *, window_size=25):
     return summarize(read_events(path), window_size=window_size)
-

--- a/server/trajectory.py
+++ b/server/trajectory.py
@@ -1,4 +1,4 @@
-"""Bounded action and trajectory analysis for a JSONL recording.
+"""Action and trajectory analysis for a JSONL recording.
 
 The recording remains the source of truth.  This module only reads it and
 returns measurements that can be compared between windows of one run or
@@ -16,7 +16,7 @@ PAUSE_SECONDS = 5.0
 MAX_LINE = 4 << 20
 
 _DIRECTION = {
-    "up": (0, -1), "down": (0, 1), "left": (-1, 0), "right": (1, 0),
+    "up": (1, -1), "down": (-1, 1), "left": (-1, -1), "right": (1, 1),
     "kp1": (-1, 1), "kp2": (0, 1), "kp3": (1, 1), "kp4": (-1, 0),
     "kp6": (1, 0), "kp7": (-1, -1), "kp8": (0, -1), "kp9": (1, -1),
 }
@@ -58,10 +58,13 @@ def _window(rows):
                if row["screen_changed"] is not None]
     positions = [(row["x"], row["y"]) for row in rows
                  if row["x"] is not None and row["y"] is not None]
-    distance = None
-    if len(positions) >= 2:
-        distance = sum(max(abs(x2 - x1), abs(y2 - y1))
-                       for (x1, y1), (x2, y2) in zip(positions, positions[1:]))
+    # Missing samples and scene changes break the path; never count a scene
+    # transition or bridge an unobserved segment as walked distance.
+    segments = [max(abs(b["x"] - a["x"]), abs(b["y"] - a["y"]))
+                for a, b in zip(rows, rows[1:])
+                if all(row[axis] is not None for row in (a, b) for axis in ("x", "y"))
+                and a.get("scene") is not None and a["scene"] == b.get("scene")]
+    distance = sum(segments) if segments else None
     frontiers = [row["frontier"] for row in rows if row["frontier"] is not None]
     gain = regressions = None
     if len(frontiers) >= 2:
@@ -100,6 +103,7 @@ def summarize(events, *, window_size=25):
                     "action": action,
                     "t": timestamp,
                     "action_t": _number(event.get("action_t")),
+                    "scene": event.get("scene"),
                     "x": event.get("x") if type(event.get("x")) is int else None,
                     "y": event.get("y") if type(event.get("y")) is int else None,
                     "frontier": _number(event.get("frontier")),
@@ -108,7 +112,7 @@ def summarize(events, *, window_size=25):
                 })
             continue
         name = _action_name(event)
-        if name is None:
+        if name not in ("KEY", "KEYS", "WAIT", "TEXT"):
             continue
         direction = _direction(event)
         reverse = bool(direction and previous_direction
@@ -139,7 +143,7 @@ def summarize(events, *, window_size=25):
                     observation = candidate
                     observations.remove(candidate)
                     break
-        row.update({"x": observation.get("x"), "y": observation.get("y"),
+        row.update({"scene": observation.get("scene"), "x": observation.get("x"), "y": observation.get("y"),
                     "frontier": observation.get("frontier"),
                     "screen_changed": observation.get("screen_changed")})
         rows.append(row)
@@ -169,7 +173,7 @@ def summarize(events, *, window_size=25):
 def read_events(path):
     """Read a recording while rejecting oversized or incomplete lines."""
     with Path(path).open("rb") as stream:
-        for line in stream:
+        for line in iter(lambda: stream.readline(MAX_LINE + 1), b""):
             if len(line) > MAX_LINE:
                 raise ValueError("recording event is too large")
             if not line.endswith(b"\n"):

--- a/server/trajectory.py
+++ b/server/trajectory.py
@@ -1,0 +1,164 @@
+"""Bounded action and trajectory analysis for a JSONL recording.
+
+The recording remains the source of truth.  This module only reads it and
+returns measurements that can be compared between windows of one run or
+between runs.  A recording can be useful without calibrated coordinates:
+action timing, pauses, reversals, and screen response are still reported, but
+the position section is explicitly marked as unmeasured.
+"""
+from collections import defaultdict
+import json
+import math
+from pathlib import Path
+
+
+PAUSE_SECONDS = 5.0
+MAX_LINE = 4 << 20
+
+_DIRECTION = {
+    "up": (0, -1), "down": (0, 1), "left": (-1, 0), "right": (1, 0),
+    "kp1": (-1, 1), "kp2": (0, 1), "kp3": (1, 1), "kp4": (-1, 0),
+    "kp6": (1, 0), "kp7": (-1, -1), "kp8": (0, -1), "kp9": (1, -1),
+}
+
+
+def _number(value):
+    return value if type(value) in (int, float) and math.isfinite(value) else None
+
+
+def _action_name(event):
+    value = event.get("act")
+    if isinstance(value, str) and value:
+        return value
+    label = event.get("label")
+    if isinstance(label, str) and label:
+        return label.split(" ", 1)[0]
+    return None
+
+
+def _direction(event):
+    target = event.get("on") or event.get("key")
+    if not isinstance(target, str):
+        label = event.get("label")
+        target = label.split(" ", 1)[-1] if isinstance(label, str) else ""
+    return _DIRECTION.get(target.lower())
+
+
+def _window(rows):
+    if not rows:
+        return {"actions": 0, "elapsed_s": 0.0, "actions_per_min": 0.0,
+                "screen_change_ratio": None, "long_pauses": 0,
+                "reverse_steps": 0, "position_samples": 0,
+                "distance": None, "frontier_gain": None,
+                "frontier_regressions": None}
+    first, last = rows[0], rows[-1]
+    elapsed = max(0.0, last["t"] - first["t"])
+    gaps = [b["t"] - a["t"] for a, b in zip(rows, rows[1:])]
+    changes = [row["screen_changed"] for row in rows
+               if row["screen_changed"] is not None]
+    positions = [(row["x"], row["y"]) for row in rows
+                 if row["x"] is not None and row["y"] is not None]
+    distance = None
+    if len(positions) >= 2:
+        distance = sum(max(abs(x2 - x1), abs(y2 - y1))
+                       for (x1, y1), (x2, y2) in zip(positions, positions[1:]))
+    frontiers = [row["frontier"] for row in rows if row["frontier"] is not None]
+    gain = regressions = None
+    if len(frontiers) >= 2:
+        gain = max(0, frontiers[-1] - frontiers[0])
+        regressions = sum(b < a for a, b in zip(frontiers, frontiers[1:]))
+    return {
+        "actions": len(rows),
+        "elapsed_s": round(elapsed, 3),
+        "actions_per_min": round(len(rows) * 60 / elapsed, 3) if elapsed else 0.0,
+        "screen_change_ratio": (round(sum(changes) / len(changes), 3)
+                                 if changes else None),
+        "long_pauses": sum(gap >= PAUSE_SECONDS for gap in gaps),
+        "reverse_steps": sum(row["reverse"] for row in rows),
+        "position_samples": len(positions),
+        "distance": distance,
+        "frontier_gain": gain,
+        "frontier_regressions": regressions,
+    }
+
+
+def summarize(events, *, window_size=25):
+    """Summarize parsed recording events without loading frame payloads."""
+    actions = []
+    observations = {}
+    previous_direction = None
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        timestamp = _number(event.get("t"))
+        if timestamp is None or timestamp < 0:
+            continue
+        if event.get("trajectory") is True:
+            action = event.get("action")
+            if type(action) is int and action > 0:
+                observations[action] = {
+                    "t": timestamp,
+                    "x": event.get("x") if type(event.get("x")) is int else None,
+                    "y": event.get("y") if type(event.get("y")) is int else None,
+                    "frontier": _number(event.get("frontier")),
+                    "screen_changed": (event.get("screen_changed")
+                                       if type(event.get("screen_changed")) is bool else None),
+                }
+            continue
+        name = _action_name(event)
+        if name is None:
+            continue
+        direction = _direction(event)
+        reverse = bool(direction and previous_direction
+                       and direction[0] == -previous_direction[0]
+                       and direction[1] == -previous_direction[1])
+        if direction:
+            previous_direction = direction
+        actions.append({"number": len(actions) + 1, "t": timestamp,
+                        "name": name, "reverse": reverse})
+
+    rows = []
+    for action in actions:
+        row = dict(action)
+        observation = observations.get(action["number"], {})
+        row.update({"x": observation.get("x"), "y": observation.get("y"),
+                    "frontier": observation.get("frontier"),
+                    "screen_changed": observation.get("screen_changed")})
+        rows.append(row)
+    overall = _window(rows)
+    windows = [_window(rows[start:start + window_size])
+               for start in range(0, len(rows), window_size)]
+    coordinate_samples = sum(row["x"] is not None and row["y"] is not None
+                             for row in rows)
+    return {
+        "version": 1,
+        "status": "measured" if coordinate_samples else "position-unmeasured",
+        "actions": rows,
+        "summary": overall,
+        "windows": windows,
+        "window_size": window_size,
+        "position_samples": coordinate_samples,
+        "analysis": {
+            "smoothness_comparison": (
+                "Compare later windows with earlier windows using pause, reverse, "
+                "screen_change_ratio, and frontier/distance fields; missing "
+                "coordinates are not treated as zero."
+            )
+        },
+    }
+
+
+def read_events(path):
+    """Read a recording while rejecting oversized or incomplete lines."""
+    with Path(path).open("rb") as stream:
+        for line in stream:
+            if len(line) > MAX_LINE:
+                raise ValueError("recording event is too large")
+            if not line.endswith(b"\n"):
+                raise ValueError("recording has an incomplete trailing event")
+            yield json.loads(line)
+
+
+def analyze(path, *, window_size=25):
+    return summarize(read_events(path), window_size=window_size)
+


### PR DESCRIPTION
## 中文摘要
- 将磁盘录像中的截图、动作和轨迹观测作为唯一可见的活动时间线；WebSocket 只触发持久化历史刷新，不再渲染第二个未分页列表。
- 所有页面使用同一套分页边界；默认每页 8 条，也可切换为 16、32 或 64 条。非整页时，最后一页仍能正确跳转并显示剩余记录。
- 浏览旧页时保留当前页；停在最新页时，新活动归档后进入同一时间线并跟随最新页。
- 轨迹坐标默认只对 operator token 可见，普通 benchmark/交互调用者仍只能看到过滤后的录像；补齐方向别名和多键动作的反向统计。

## English summary
- Use the disk-backed recording, actions, and trajectory observations as the single visible activity timeline. WebSocket updates only refresh persisted history instead of rendering a second unpaginated list.
- Use one page model with selectable sizes of 8, 16, 32, or 64 records, including correctly aligned partial final pages.
- Preserve an older page while it is being inspected, while the latest page follows newly persisted activity after archival.
- Keep trajectory coordinates available only to an operator token, filter them from ordinary benchmark/interactive recording reads, and count direction aliases and multi-key actions in reversal metrics.

## 隐私边界 / Privacy boundary
Recording journals retain trajectory observations for offline analysis. `/api/recording` excludes those coordinates unless the request carries the operator token; this applies even when the benchmark warden is disabled.

## 验证 / Validation
- `cd server && python -m unittest test_saved_history test_history_markers test_replay_index test_recording test_trajectory -q`: 55 tests passed.
- `node --test server/test_saved_history_ui.js`: 17 tests passed.
- Chrome visual checks on 8084 covered page 1, page 1355, page 1356, direct page input, a new screenshot action, old-page stability, and switching to 32 records per page.
- `git diff --check` is clean; the history-index SQLite files are disposable per-recording caches and are not part of the public recording response.